### PR TITLE
feat(ottawa): add Hermes Agent deployment

### DIFF
--- a/clusters/talos-ottawa/apps/hermes/app/deployment.yaml
+++ b/clusters/talos-ottawa/apps/hermes/app/deployment.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-agent
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hermes-agent
+        app.kubernetes.io/component: agent
+        app.kubernetes.io/part-of: hermes
+    spec:
+      serviceAccountName: default
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      imagePullSecrets:
+        - name: zot-pull-secret
+      initContainers:
+        - name: init-data
+          image: alpine:3.21
+          command: [sh, -c]
+          args:
+            - |
+              set -e
+              mkdir -p /opt/data
+              chown -R 1000:1000 /opt/data
+              echo "[init-data] Done"
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+      containers:
+        - name: hermes-agent
+          image: nousresearch/hermes-agent:latest
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          args: ["gateway", "run"]
+          lifecycle:
+            preStop:
+              exec:
+                command: [sh, -c, "sleep 5"]
+          env:
+            - name: HERMES_DATA_DIR
+              value: /opt/data
+          envFrom:
+            - secretRef:
+                name: hermes-agent-secrets
+          startupProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            periodSeconds: 15
+            failureThreshold: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            periodSeconds: 30
+            failureThreshold: 5
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 4Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+        - name: tailscale
+          image: ghcr.io/tailscale/tailscale:v1.94.1
+          securityContext:
+            privileged: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: TS_KUBE_SECRET
+              value: ""
+            - name: TS_USERSPACE
+              value: "false"
+            - name: TS_STATE_DIR
+              value: /dev/shm
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ts-oauth
+                  key: TS_AUTHKEY
+            - name: TS_ACCEPT_DNS
+              value: "true"
+            - name: TS_EXTRA_ARGS
+              value: "--advertise-tags=tag:k8s,tag:ottawa --accept-routes"
+            - name: TS_HOSTNAME
+              value: $(POD_NAME)-hermes
+            - name: TS_DEBUG_FIREWALL_MODE
+              value: auto
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-agent-data

--- a/clusters/talos-ottawa/apps/hermes/app/httproute.yaml
+++ b/clusters/talos-ottawa/apps/hermes/app/httproute.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hermes-agent
+  namespace: hermes
+  annotations:
+    item.homer.rajsingh.info/name: "Hermes Agent"
+    item.homer.rajsingh.info/subtitle: "AI Agent Gateway"
+    item.homer.rajsingh.info/keywords: "ai, agent, llm, chat"
+
+    service.homer.rajsingh.info/name: "AI"
+    service.homer.rajsingh.info/icon: "fas fa-robot"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "hermes.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: hermes-agent
+          port: 3000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/clusters/talos-ottawa/apps/hermes/app/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/hermes/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hermes
+resources:
+  - ./namespace.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./httproute.yaml
+  - ./pvc.yaml
+  - ./secret.sops.yaml

--- a/clusters/talos-ottawa/apps/hermes/app/namespace.yaml
+++ b/clusters/talos-ottawa/apps/hermes/app/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/talos-ottawa/apps/hermes/app/pvc.yaml
+++ b/clusters/talos-ottawa/apps/hermes/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-agent-data
+  namespace: hermes
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ceph-block-replicated

--- a/clusters/talos-ottawa/apps/hermes/app/secret.sops.yaml
+++ b/clusters/talos-ottawa/apps/hermes/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-agent-secrets
+  namespace: hermes
+type: Opaque
+stringData:
+  # Hermes Agent API keys and credentials
+  # Add your API keys and chat system credentials here
+  # This file is SOPS-encrypted
+  HERMES_DISCORD_BOT_TOKEN: "${HERMES_DISCORD_BOT_TOKEN}"
+  HERMES_TELEGRAM_BOT_TOKEN: "${HERMES_TELEGRAM_BOT_TOKEN}"
+  # Add other providers as needed
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-ts-oauth
+  namespace: hermes
+type: Opaque
+stringData:
+  TS_AUTHKEY: "${TS_OAUTH_KEY}"

--- a/clusters/talos-ottawa/apps/hermes/app/service.yaml
+++ b/clusters/talos-ottawa/apps/hermes/app/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-agent
+  namespace: hermes
+spec:
+  selector:
+    app.kubernetes.io/name: hermes-agent
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP
+  type: ClusterIP

--- a/clusters/talos-ottawa/apps/hermes/ks.yaml
+++ b/clusters/talos-ottawa/apps/hermes/ks.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes-agent
+  namespace: flux-system
+spec:
+  targetNamespace: hermes
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./clusters/talos-ottawa/apps/hermes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/clusters/talos-ottawa/apps/hermes/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/hermes/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hermes
+resources:
+  - ./app


### PR DESCRIPTION
## Summary

Add Hermes Agent deployment to Ottawa cluster, similar to OpenClaw structure.

### What's included

- **Namespace**: `hermes`
- **Deployment**: `hermes-agent` with Tailscale sidecar for networking
- **PVC**: 1Gi ceph-block-replicated for `/opt/data`
- **HTTPRoute**: `hermes.${CLUSTER_DOMAIN}`
- **Secrets**: SOPS-encrypted for API keys

### Environment variables (need values)

Add to cluster-secrets.sops.yaml:
- `HERMES_DISCORD_BOT_TOKEN`
- `HERMES_TELEGRAM_BOT_TOKEN`
- `TS_OAUTH_KEY`

### Notes

- Image: `nousresearch/hermes-agent:latest`
- Runs in gateway mode (`gateway run`)
- Similar structure to OpenClaw deployment