### PR TITLE
feat(tailscale-examples): deploy tsk9s with HTTPRoute

### DIFF
--- a/clusters/common/apps/tailscale-examples/ks.yaml
+++ b/clusters/common/apps/tailscale-examples/ks.yaml
@@ -17,4 +17,16 @@ spec:
   wait: false
   interval: 30m
   retryInterval: 1m
-  timeout: 5m 
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/clusters/common/apps/tailscale-examples/sandbox/kustomization.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   # - ./golink
   # - ./egress
   # - ./vector
+  - ./tsk9s

--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tsk9s
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tsk9s
+  template:
+    metadata:
+      labels:
+        app: tsk9s
+    spec:
+      containers:
+      - name: tsk9s
+        image: ghcr.io/rajsinghtech/tsk9s:v0.1.2
+        args:
+          - --state-dir=/data/tsk9s-state
+          - --endpoints=ottawa-k8s.keiretsu.ts.net,robbinsdale-k8s.keiretsu.ts.net,stpetersburg-k8s.keiretsu.ts.net
+          - --local-addr=0.0.0.0:8080
+        env:
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY
+              optional: true
+        ports:
+        - containerPort: 8080
+          name: http
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/httproute.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/httproute.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tsk9s
+  annotations:
+    item.homer.rajsingh.info/name: "tsk9s"
+    item.homer.rajsingh.info/subtitle: "Multi-cluster K8s terminal"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/kubernetes.svg"
+    item.homer.rajsingh.info/keywords: "k8s, terminal, tailscale"
+
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "tsk9s.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: tsk9s
+          port: 8080
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/kustomization.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/service.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tsk9s
+spec:
+  selector:
+    app: tsk9s
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http


### PR DESCRIPTION
Deploy tsk9s (https://github.com/rajsinghtech/tsk9s) into the `tailscale-examples` namespace.

## Changes

- **tsk9s deployment** — connects to Tailscale via tsnet, proxies the three k8s API server ProxyGroups (`ottawa-k8s`, `robbinsdale-k8s`, `stpetersburg-k8s`), and serves the web UI on `:8080` via `--local-addr`
- **HTTPRoute** — routes `tsk9s.${CLUSTER_DOMAIN}` → service:8080 via the `ts` gateway
- **ks.yaml postBuild** — adds `substituteFrom` to the tailscale-examples sandbox Kustomization (was missing from git, already live on clusters)