### PR TITLE
fix(tsk9s): bump to v0.1.3 with --tags for OAuth

### DIFF
--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
@@ -17,11 +17,12 @@ spec:
     spec:
       containers:
       - name: tsk9s
-        image: ghcr.io/rajsinghtech/tsk9s:v0.1.2
+        image: ghcr.io/rajsinghtech/tsk9s:v0.1.3
         args:
           - --state-dir=/data/tsk9s-state
           - --endpoints=ottawa-k8s.keiretsu.ts.net,robbinsdale-k8s.keiretsu.ts.net,stpetersburg-k8s.keiretsu.ts.net
           - --local-addr=0.0.0.0:8080
+          - --tags=tag:k8s,tag:${LOCATION}
         env:
         - name: TS_AUTHKEY
           valueFrom:


### PR DESCRIPTION
OAuth auth keys require `--advertise-tags`. Adds `--tags=tag:k8s,tag:${LOCATION}` to the tsk9s deployment args and bumps image to v0.1.3 which adds the `--tags` flag.