### PR TITLE
fix(tsk9s): serve on k9s.CLUSTER_DOMAIN

### DIFF
--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/httproute.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/httproute.yaml
@@ -18,7 +18,7 @@ spec:
       name: ts
       namespace: home
   hostnames:
-    - "tsk9s.${CLUSTER_DOMAIN}"
+    - "k9s.${CLUSTER_DOMAIN}"
   rules:
     - backendRefs:
         - group: ""


### PR DESCRIPTION
Route hostname should be `k9s.${CLUSTER_DOMAIN}` (i.e. k9s.killinit.cc), not tsk9s.