### PR TITLE
feat(tsk9s): LoadBalancer service with tailscale hostname k9s

### DIFF
--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/service.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/service.yaml
@@ -3,10 +3,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tsk9s
+  annotations:
+    tailscale.com/hostname: k9s
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
 spec:
   selector:
     app: tsk9s
   ports:
   - name: http
-    port: 8080
+    port: 80
     targetPort: http
+  type: LoadBalancer
+  loadBalancerClass: tailscale


### PR DESCRIPTION
Exposes tsk9s via Tailscale operator LoadBalancer (`tailscale.com/hostname: k9s`, `common-ingress` ProxyGroup) in addition to the HTTPRoute. Port changed to 80 on the service to match the LB convention.