### PR TITLE
bump tsk9s to v0.1.4

### DIFF
--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: tsk9s
-        image: ghcr.io/rajsinghtech/tsk9s:v0.1.3
+        image: ghcr.io/rajsinghtech/tsk9s:v0.1.4
         args:
           - --state-dir=/data/tsk9s-state
           - --endpoints=ottawa-k8s.keiretsu.ts.net,robbinsdale-k8s.keiretsu.ts.net,stpetersburg-k8s.keiretsu.ts.net


### PR DESCRIPTION
- Cluster picker sidebar (left panel with cluster buttons, auto-connects to first)
- `/ws?cluster=<name>` passes `--context` to k9s so each session targets the right cluster
- `COLORTERM=truecolor` so k9s renders full color instead of muted 256-color