### PR TITLE
tsk9s v0.1.5: ephemeral auth, location hostname

### DIFF
--- a/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
+++ b/clusters/common/apps/tailscale-examples/sandbox/tsk9s/deployment.yaml
@@ -17,9 +17,10 @@ spec:
     spec:
       containers:
       - name: tsk9s
-        image: ghcr.io/rajsinghtech/tsk9s:v0.1.4
+        image: ghcr.io/rajsinghtech/tsk9s:v0.1.5
         args:
           - --state-dir=/data/tsk9s-state
+          - --hostname=${LOCATION}-tsk9s
           - --endpoints=ottawa-k8s.keiretsu.ts.net,robbinsdale-k8s.keiretsu.ts.net,stpetersburg-k8s.keiretsu.ts.net
           - --local-addr=0.0.0.0:8080
           - --tags=tag:k8s,tag:${LOCATION}
@@ -28,7 +29,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: ts-oauth
-              key: TS_AUTHKEY
+              key: TS_AUTHKEY_EPHEMERAL
               optional: true
         ports:
         - containerPort: 8080


### PR DESCRIPTION
- Image bumped to v0.1.5 (no cluster selector, COLORTERM=truecolor, term.focus())
- `--hostname=${LOCATION}-tsk9s` so the tailnet node is named e.g. `ottawa-tsk9s`
- `TS_AUTHKEY_EPHEMERAL` so the node is ephemeral and removed on pod restart