### PR TITLE
media: re-enable sonarr and radarr deployments on robbinsdale

### DIFF
--- a/clusters/talos-robbinsdale/apps/media/app/radarr/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/media/app/radarr/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
 resources:
-# - app.yaml
+- app.yaml
 - httproute.yaml
 - storagestack.yaml

--- a/clusters/talos-robbinsdale/apps/media/app/sonarr/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/media/app/sonarr/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
 resources:
-# - app.yaml
+- app.yaml
 - httproute.yaml
 - storagestack.yaml


### PR DESCRIPTION
Re-enable sonarr and radarr deployments by uncommenting app.yaml in their kustomization files. Raj commented these out during a restore operation.