### PR TITLE
Switch QBittorrent Gatus probes to TCP check

### DIFF
--- a/clusters/talos-ottawa/apps/gatus/app/helmrelease.yaml
+++ b/clusters/talos-ottawa/apps/gatus/app/helmrelease.yaml
@@ -395,21 +395,15 @@ spec:
         # === Download Clients ===
         - name: QBittorrent
           group: Media
-          url: http://qbittorrent.media:80/login
+          url: tcp://qbittorrent.media:80
           interval: 60s
-          conditions:
-            - "[STATUS] == 200"
-            - "[RESPONSE_TIME] < 3000"
           alerts:
             - type: discord
               send-on-resolved: true
         - name: QBittorrent PVT
           group: Media
-          url: http://qbittorrent-pvt.media:80/login
+          url: tcp://qbittorrent-pvt.media:80
           interval: 60s
-          conditions:
-            - "[STATUS] == 200"
-            - "[RESPONSE_TIME] < 3000"
           alerts:
             - type: discord
               send-on-resolved: true


### PR DESCRIPTION
QBittorrent web UI returns 404 on root path, making HTTP-based Gatus probes unreliable.

Changes:
- Switch both QBittorrent probes (public and PVT) from HTTP to TCP
- TCP check verifies port 80 is reachable without caring about HTTP response code
- Removes status/response_time conditions (unnecessary for port connectivity checks)

This aligns with how other infrastructure probes work (e.g., Garage, kubeconfigs).