### PR TITLE
feat(comfyui): deploy aeon-movie-maker stack on stpetersburg

### DIFF
--- a/clusters/talos-stpetersburg/apps/comfyui/app/deployment.yaml
+++ b/clusters/talos-stpetersburg/apps/comfyui/app/deployment.yaml
@@ -1,0 +1,208 @@
+---
+# ComfyUI (comfyui-aeon-spark) + Ollama + aeon-movie-maker on DGX Spark
+# ComfyUI serves on :8188; movie-maker scripts live at /opt/movie-maker (exec in)
+# Scale down ai/vllm before running — both compete for Blackwell GPU memory
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: comfyui
+  namespace: comfyui
+  labels:
+    app: comfyui
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: comfyui
+  template:
+    metadata:
+      labels:
+        app: comfyui
+    spec:
+      enableServiceLinks: false
+      runtimeClassName: nvidia
+      initContainers:
+      - name: clone-movie-maker
+        image: alpine/git:latest
+        command:
+          - sh
+          - -c
+          - |
+            if [ ! -f /movie-maker/scripts/movie_maker_fast.py ]; then
+              git clone --depth 1 https://github.com/AEON-7/aeon-movie-maker.git /movie-maker
+            else
+              cd /movie-maker && git pull --ff-only || true
+            fi
+        volumeMounts:
+        - name: movie-maker
+          mountPath: /movie-maker
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+      containers:
+      - name: comfyui
+        image: ghcr.io/aeon-7/comfyui-aeon-spark:latest
+        ports:
+        - containerPort: 8188
+          name: http
+          protocol: TCP
+        env:
+        - name: COMFYUI_PORT
+          value: "8188"
+        - name: COMFYUI_FLAGS
+          value: >-
+            --listen 0.0.0.0
+            --port 8188
+            --use-sage-attention
+            --fp8_e4m3fn-unet --bf16-vae --bf16-text-enc
+            --disable-pinned-memory
+            --reserve-vram 2.0
+            --preview-method auto
+            --enable-cors-header
+        - name: TORCH_COMPILE_DISABLE
+          value: "1"
+        - name: TORCHDYNAMO_DISABLE
+          value: "1"
+        - name: CUDA_DEVICE_MAX_CONNECTIONS
+          value: "1"
+        - name: CUDA_DEVICE_MAX_COPY_CONNECTIONS
+          value: "4"
+        - name: CUDA_MODULE_LOADING
+          value: "EAGER"
+        - name: CUDA_MANAGED_FORCE_DEVICE_ALLOC
+          value: "1"
+        - name: CUBLAS_WORKSPACE_CONFIG
+          value: ":0:0"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: OMP_NUM_THREADS
+          value: "20"
+        - name: MKL_NUM_THREADS
+          value: "20"
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "all"
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: "compute,utility,video"
+        - name: HF_HUB_ENABLE_HF_TRANSFER
+          value: "1"
+        - name: HF_HUB_DOWNLOAD_TIMEOUT
+          value: "180"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: HF_TOKEN
+        - name: HF_HOME
+          value: /workspace/ComfyUI/.cache/huggingface
+        - name: SKIP_MODEL_DOWNLOAD
+          value: "0"
+        - name: SKIP_ABLITERATED
+          value: "1"
+        - name: COMFYUI_URL
+          value: http://localhost:8188
+        - name: COMFYUI_ROOT
+          value: /workspace/ComfyUI
+        - name: OUTPUT_DIR
+          value: /workspace/ComfyUI/output
+        resources:
+          requests:
+            memory: "32Gi"
+            cpu: "4000m"
+            nvidia.com/gpu: "4"
+          limits:
+            memory: "128Gi"
+            nvidia.com/gpu: "4"
+        volumeMounts:
+        - name: workspace
+          mountPath: /workspace/ComfyUI
+        - name: movie-maker
+          mountPath: /opt/movie-maker
+        - name: shm
+          mountPath: /dev/shm
+        livenessProbe:
+          httpGet:
+            path: /system_stats
+            port: http
+          initialDelaySeconds: 600
+          periodSeconds: 60
+          timeoutSeconds: 10
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /system_stats
+            port: http
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 10
+        startupProbe:
+          httpGet:
+            path: /system_stats
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 30
+      - name: ollama
+        image: ollama/ollama:latest
+        env:
+        - name: OLLAMA_HOST
+          value: "0.0.0.0:11434"
+        - name: OLLAMA_KEEP_ALIVE
+          value: "24h"
+        - name: OLLAMA_NUM_PARALLEL
+          value: "1"
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "all"
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: "compute,utility"
+        ports:
+        - containerPort: 11434
+          name: ollama
+          protocol: TCP
+        command:
+          - /bin/sh
+          - -c
+          - |
+            /bin/ollama serve &
+            sleep 10
+            /bin/ollama pull gemma3:4b || true
+            wait
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "2000m"
+          limits:
+            memory: "16Gi"
+        volumeMounts:
+        - name: ollama-data
+          mountPath: /root/.ollama
+      volumes:
+      - name: workspace
+        persistentVolumeClaim:
+          claimName: comfyui-workspace
+      - name: ollama-data
+        persistentVolumeClaim:
+          claimName: comfyui-ollama
+      - name: movie-maker
+        emptyDir: {}
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 32Gi
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      terminationGracePeriodSeconds: 120
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-secret
+  namespace: comfyui
+stringData:
+  HF_TOKEN: ${HF_TOKEN}

--- a/clusters/talos-stpetersburg/apps/comfyui/app/kustomization.yaml
+++ b/clusters/talos-stpetersburg/apps/comfyui/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: comfyui
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/clusters/talos-stpetersburg/apps/comfyui/app/pvc.yaml
+++ b/clusters/talos-stpetersburg/apps/comfyui/app/pvc.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-workspace
+  namespace: comfyui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 500Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-ollama
+  namespace: comfyui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 30Gi

--- a/clusters/talos-stpetersburg/apps/comfyui/app/service.yaml
+++ b/clusters/talos-stpetersburg/apps/comfyui/app/service.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comfyui
+  namespace: comfyui
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8188
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: comfyui
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comfyui-ts
+  namespace: comfyui
+  annotations:
+    tailscale.com/hostname: "${LOCATION}-comfyui"
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:singh360,tag:k8s,tag:${LOCATION}"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8188
+  selector:
+    app: comfyui

--- a/clusters/talos-stpetersburg/apps/comfyui/ks.yaml
+++ b/clusters/talos-stpetersburg/apps/comfyui/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app comfyui
+  namespace: flux-system
+spec:
+  targetNamespace: comfyui
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/${CLUSTER_NAME}/apps/comfyui/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+    namespace: flux-system
+  wait: false
+  interval: 1m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-stpetersburg/apps/comfyui/kustomization.yaml
+++ b/clusters/talos-stpetersburg/apps/comfyui/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ks.yaml

--- a/clusters/talos-stpetersburg/apps/comfyui/namespace.yaml
+++ b/clusters/talos-stpetersburg/apps/comfyui/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: comfyui
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary

- Deploys [AEON-7/aeon-movie-maker](https://github.com/AEON-7/aeon-movie-maker) on the stpetersburg DGX Spark cluster
- Single pod with three containers: **ComfyUI** (`comfyui-aeon-spark:latest`), **Ollama** (gemma3:4b for prompt expansion), and an init container that clones the movie-maker repo to `/opt/movie-maker`
- Two PVCs: `comfyui-workspace` (500Gi for models/workspace) and `comfyui-ollama` (30Gi)
- Exposed on Tailscale as `stpetersburg-comfyui` via the `common-ingress` ProxyGroup

## Usage

```bash
# Run a clip
kubectl --context stpetersburg-k8s-operator.keiretsu.ts.net \
  exec -it -n comfyui deployment/comfyui -c comfyui -- \
  python /opt/movie-maker/scripts/movie_maker_fast.py clip \
    --prompt "drone shot over a misty pine forest" \
    --duration 5 --output /workspace/ComfyUI/output/test.mp4
```

> **Note:** Scale down vLLM first — it competes for the same Blackwell GPU slices:
> `kubectl scale -n ai deployment/vllm --replicas=0`