### PR TITLE
fix(stpetersburg): add spark-1 and orin-0 BGP peers to FRR config

### DIFF
--- a/clusters/talos-stpetersburg/unifi/frr.conf
+++ b/clusters/talos-stpetersburg/unifi/frr.conf
@@ -15,8 +15,9 @@ router bgp 64515
  neighbor cilium remote-as 64514
  neighbor cilium activate
  neighbor cilium soft-reconfiguration inbound
- neighbor 192.168.73.206 peer-group cilium
- neighbor 192.168.73.161 peer-group cilium
+ neighbor 192.168.73.206 peer-group cilium  # spark-0
+ neighbor 192.168.73.211 peer-group cilium  # spark-1
+ neighbor 192.168.73.248 peer-group cilium  # orin-0
  address-family ipv4 unicast
   redistribute connected
   neighbor cilium activate
@@ -24,7 +25,7 @@ router bgp 64515
   neighbor cilium route-map ALLOW-ALL out
   neighbor cilium next-hop-self
  exit-address-family
- !
+!
 route-map ALLOW-ALL permit 10
 !
 line vty


### PR DESCRIPTION
The stpetersburg cluster was scaled to 3 control plane nodes (spark-0, spark-1, orin-0) but the FRR BGP configuration only had spark-0 (.206) and a stale .161 entry.

**Changes:**
- Removed stale neighbor 192.168.73.161
- Added spark-1: 192.168.73.211
- Added orin-0: 192.168.73.248
- Added inline comments mapping IPs to hostnames