### PR TITLE
fix: uncomment ClickHouse operator Kustomization

### DIFF
--- a/clusters/common/apps/clickhouse-operator-system/ks.yaml
+++ b/clusters/common/apps/clickhouse-operator-system/ks.yaml
@@ -1,21 +1,20 @@
-# ---
-# apiVersion: kustomize.toolkit.fluxcd.io/v1
-# kind: Kustomization
-# metadata:
-#   name: &app clickhouse-operator-system
-#   namespace: flux-system
-# spec:
-#   targetNamespace: clickhouse-operator-system
-#   commonMetadata:
-#     labels:
-#       app.kubernetes.io/name: *app
-#   path: ./clusters/common/apps/clickhouse-operator-system/app
-#   prune: true
-#   sourceRef:
-#     kind: GitRepository
-#     name: kubernetes-manifests
-#   wait: false
-#   interval: 30m
-#   retryInterval: 1m
-#   timeout: 5m
 ---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-operator-system
+  namespace: flux-system
+spec:
+  targetNamespace: clickhouse-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/common/apps/clickhouse-operator-system/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Problem

The ClickHouse operator Kustomization () is entirely commented out. This means:

1. The operator HelmRelease never gets created
2. The  CRD is never installed
3. The  Kustomization fails: 
4. This blocks the entire  Kustomization — everything downstream is stuck

## Fix

Uncomment the operator Kustomization. This is the simplest fix — just remove the  comments so Flux can deploy the operator.

## Root Cause

Someone commented out the operator Kustomization (likely during debugging) and never uncommented it. The ClickHouse app Kustomization () was active and depends on the operator, but the operator was commented out — so nothing could deploy.

## Impact

Enabling the operator allows the existing  config to be applied (note: that config has its own issues but the CRD at least needs to exist for it to fail gracefully).