### PR TITLE
fix: wait for operator CRDs before dependent kustomizations

### DIFF
--- a/clusters/common/apps/clickhouse-operator-system/ks.yaml
+++ b/clusters/common/apps/clickhouse-operator-system/ks.yaml
@@ -14,7 +14,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: kubernetes-manifests
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/clusters/common/apps/garage-operator-system/ks.yaml
+++ b/clusters/common/apps/garage-operator-system/ks.yaml
@@ -14,7 +14,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: kubernetes-manifests
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/clusters/common/apps/garage/ks.yaml
+++ b/clusters/common/apps/garage/ks.yaml
@@ -14,7 +14,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: kubernetes-manifests
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m
@@ -29,12 +29,14 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
   path: ./clusters/common/apps/garage/bucket
   prune: true
   sourceRef:
     kind: GitRepository
     name: kubernetes-manifests
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/clusters/common/apps/k8gb/ks.yaml
+++ b/clusters/common/apps/k8gb/ks.yaml
@@ -29,13 +29,14 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: garage
     - name: k8gb-app
   path: ./clusters/common/apps/k8gb/config
   prune: true
   sourceRef:
     kind: GitRepository
     name: kubernetes-manifests
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/clusters/talos-ottawa/apps/immich/ks.yaml
+++ b/clusters/talos-ottawa/apps/immich/ks.yaml
@@ -13,12 +13,13 @@ spec:
     - name: cnpg-system
     - name: dragonfly-operator-system
     - name: volsync
+    - name: garage
   path: ./clusters/${CLUSTER_NAME}/apps/immich/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: kubernetes-manifests
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m


### PR DESCRIPTION
Both failures are caused by `wait: false` on operator systems that provide CRDs — dependents start reconciling before the CRDs are fully registered.

**Changes:**

1. **clickhouse-operator-system** — `wait: false` → `wait: true`
   - Fixes: `clickhouse` failing with 'no matches for kind ClickHouseInstallation'

2. **garage-operator-system** — `wait: false` → `wait: true`
   - Fixes: GarageKey/GarageBucket schema errors (CRD not yet registered)

3. **garage** — `wait: false` → `wait: true` + added `dependsOn: garage` on garage-bucket
   - Ensures Garage CRDs are ready before bucket/key resources

4. **k8gb-config** — added `dependsOn: garage` + `wait: true`
   - Fixes: 'GarageKey secretTemplate.namespace field not declared in schema'

5. **immich** — added `dependsOn: garage` + `wait: true`
   - Fixes: same GarageKey error on Ottawa cluster