### PR TITLE
feat: add Grafana image renderer plugin

### DIFF
--- a/clusters/common/apps/grafana/instance/grafana.yaml
+++ b/clusters/common/apps/grafana/instance/grafana.yaml
@@ -13,35 +13,8 @@ spec:
       resources:
         requests:
           storage: 10Gi
-  deployment:
-    spec:
-      strategy:
-        type: Recreate
-      replicas: 1
-      template:
-        spec:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 472
-            runAsGroup: 472
-            fsGroup: 472
-            fsGroupChangePolicy: OnRootMismatch
-          containers:
-            - name: grafana
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: false
-                runAsUser: 472
-                runAsGroup: 472
-                capabilities:
-                  drop: ["ALL"]
-              env:
-                - name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
-                  value: "${TS_IDP_GRAFANA_CLIENT_SECRET}"
-          volumes:
-            - name: grafana-data
-              persistentVolumeClaim:
-                claimName: grafana-pvc
+  plugins:
+    - grafana-image-renderer
   config:
     log:
       mode: console
@@ -62,3 +35,5 @@ spec:
       api_url: https://${LOCATION}-idp.keiretsu.ts.net/userinfo
       redirect_uri: https://grafana.${CLUSTER_DOMAIN}/login/generic_oauth
       login_attribute: preferred_username
+  instance:
+    replicas: 1

--- a/clusters/common/apps/grafana/instance/kustomization.yaml
+++ b/clusters/common/apps/grafana/instance/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./httproute.yaml
   - ./servicemonitor.yaml
   - ./secret.yaml
+  - ../plugins/image-renderer/deployment.yaml
+  - ../plugins/image-renderer/service.yaml

--- a/clusters/common/apps/grafana/plugins/image-renderer/deployment.yaml
+++ b/clusters/common/apps/grafana/plugins/image-renderer/deployment.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-image-renderer
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana-image-renderer
+  template:
+    metadata:
+      labels:
+        app: grafana-image-renderer
+      annotations:
+        rendering/grafana: "true"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+      containers:
+        - name: grafana-image-renderer
+          image: docker.io/grafana/grafana-image-renderer:3.2.0
+          imagePullPolicy: IfNotPresent
+          args: ["--server", "http://localhost:8081"]
+          ports:
+            - name: renderer
+              containerPort: 8081
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              port: renderer
+              path: /render
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              port: renderer
+              path: /render
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/clusters/common/apps/grafana/plugins/image-renderer/service.yaml
+++ b/clusters/common/apps/grafana/plugins/image-renderer/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-image-renderer
+  namespace: monitoring
+spec:
+  ports:
+    - name: renderer
+      port: 8081
+      targetPort: renderer
+      protocol: TCP
+  selector:
+    app: grafana-image-renderer


### PR DESCRIPTION
## Summary\n\nInstalls the Grafana Image Renderer plugin as a sidecar deployment to enable PNG rendering of dashboards.\n\n- Adds deployment for \n- Exposes the renderer on port 8081 in the monitoring namespace\n- Configures the Grafana CRD with the image-renderer plugin\n- Uses the  annotation so Grafana discovers it automatically\n\nThis enables dashboard PDF/PNG rendering for alerts and reports.\n\n## Test Plan\n\n- [ ] Verify  pod is running in monitoring namespace\n- [ ] Check that Grafana recognizes the renderer in Settings → Plugins\n- [ ] Test rendering a dashboard panel to PNG via the API