### PR TITLE
AirConnect: add -x config path for -I auto-save

### DIFF
--- a/clusters/talos-stpetersburg/apps/home-assistant/app/airconnect-deployment.yaml
+++ b/clusters/talos-stpetersburg/apps/home-assistant/app/airconnect-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           image: 1activegeek/airconnect:1.9.3
           env:
             - name: AIRUPNP_OPTS
-              value: "-l 500:1000 -r 44100 -Z -I"
+              value: "-l 500:1000 -r 44100 -Z -x /config/airupnp.xml -I"
             - name: AIRCAST_OPTS
               value: ""
           resources:


### PR DESCRIPTION
The -I flag needs -x to know where to save the config file. Without -x, no config.xml was written.