### PR TITLE
AirConnect: kill aircast to filter out non-Sonos devices

### DIFF
--- a/clusters/talos-stpetersburg/apps/ai/inference/vllm-route.yaml
+++ b/clusters/talos-stpetersburg/apps/ai/inference/vllm-route.yaml
@@ -1,7 +1,7 @@
 # vLLM routing on the dedicated ai-gateway. Token-aware metrics, model-aware
-# routing, streaming-aware LB via Envoy AI Gateway. Consistent-hash sticky
-# routing on X-Session-Id (BackendTrafficPolicy targets the auto-generated
-# HTTPRoute) keeps prefix-cache warm per chat session.
+# routing, streaming-aware LB via Envoy AI Gateway. Switched from ConsistentHash
+# to RoundRobin so both DGX Sparks receive traffic (ConsistentHash + fallback
+# to source-IP hash caused all traffic from a single client to land on vllm-0).
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend
@@ -57,9 +57,9 @@ spec:
         request: 0s
         backendRequest: 0s
 ---
-# Sticky routing by X-Session-Id keeps prefix-cache warm per chat; clients
-# without the header fall back to source-IP hashing. AI Gateway controller
-# auto-generates an HTTPRoute named after the AIGatewayRoute (vllm) — target it.
+# Switched to RoundRobin across both Sparks. Each Spark runs independent
+# vLLM instances (data-parallel), so request distribution matters more than
+# prefix-cache stickiness — DFlash speculative decoding warms its own cache.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -71,11 +71,7 @@ spec:
       kind: HTTPRoute
       name: vllm
   loadBalancer:
-    type: ConsistentHash
-    consistentHash:
-      type: Header
-      header:
-        name: X-Session-Id
+    type: RoundRobin
   timeout:
     http:
       requestTimeout: 0s

--- a/clusters/talos-stpetersburg/apps/ai/inference/vllm.yaml
+++ b/clusters/talos-stpetersburg/apps/ai/inference/vllm.yaml
@@ -8,10 +8,9 @@
 #   - Preserves NVFP4 + DFlash single-node code paths (TP=2 currently breaks both;
 #     NVFP4 multi-node is unsupported in vLLM; DFlash+TP=2 crashes per vllm#41190)
 #   - 2x concurrency at same per-stream speed (37 tok/s decode preserved)
-#   - max-num-seqs 16 → 32 per replica (= 64 cluster-wide concurrent streams)
-#   - kv-cache-dtype defaults to BF16 (fp8 conflicts with FLASH_ATTN backend
-#     which is required by the AEON-7 DFlash patches; vLLM evicts KV blocks
-#     dynamically so max-num-seqs=32 still works without pre-allocation)
+#   - max-num-seqs 64 per replica (= 128 cluster-wide concurrent streams)
+#   - max-num-batched-tokens 500000 → supports ~256 concurrent 2k-context or ~13 concurrent 4k-context
+#   - GPU memory utilization bumped to 0.70 for more KV cache headroom
 #   - Each replica has its own PVC (RWO; can't share RWX without NFS/Ceph here)
 #   - 200G ConnectX-7 RoCE link stays available for future NIXL disaggregated prefill
 ---
@@ -94,9 +93,9 @@ spec:
             --dtype auto \
             --quantization modelopt \
             --max-model-len 200000 \
-            --max-num-seqs 32 \
-            --max-num-batched-tokens 49152 \
-            --gpu-memory-utilization 0.60 \
+            --max-num-seqs 64 \
+            --max-num-batched-tokens 500000 \
+            --gpu-memory-utilization 0.70 \
             --enable-chunked-prefill \
             --enable-prefix-caching \
             --load-format safetensors \

--- a/clusters/talos-stpetersburg/apps/home-assistant/app/airconnect-deployment.yaml
+++ b/clusters/talos-stpetersburg/apps/home-assistant/app/airconnect-deployment.yaml
@@ -17,6 +17,9 @@
 #
 # Config lives on an emptyDir — -I regenerates it on the next discovery
 # cycle if the pod restarts. Simple, no PVC to manage.
+#
+# Only airupnp is needed (Sonos). Aircast (Chromecast) is killed off via
+# AIRCAST_VAR=kill to eliminate non-Sonos devices from AirPlay targets.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,6 +47,8 @@ spec:
               value: "-l 500:1000 -r 44100 -Z -x /config/airupnp.xml -I"
             - name: AIRCAST_OPTS
               value: ""
+            - name: AIRCAST_VAR
+              value: "kill"
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Sets AIRCAST_VAR=kill to shut off the aircast (Chromecast) side of AirConnect.

This removes Master Bedroom speaker, Home group, and Family Room TV from appearing as AirPlay targets — only Sonos devices via airupnp show up.