### PR TITLE
AirConnect: kill aircast to filter out non-Sonos Chromecast devices

### DIFF
--- a/clusters/talos-stpetersburg/apps/home-assistant/app/airconnect-deployment.yaml
+++ b/clusters/talos-stpetersburg/apps/home-assistant/app/airconnect-deployment.yaml
@@ -44,6 +44,8 @@ spec:
               value: "-l 500:1000 -r 44100 -Z -x /config/airupnp.xml -I"
             - name: AIRCAST_OPTS
               value: ""
+            - name: AIRCAST_VAR
+              value: "kill"
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Sets AIRCAST_VAR=kill to shut off the aircast (Chromecast) side of AirConnect.

This removes Master Bedroom speaker, Home group, and Family Room TV from appearing as AirPlay targets — only Sonos devices via airupnp show up.