### PR TITLE
garage-operator: bump chart to 0.6.0

### DIFF
--- a/clusters/common/apps/garage-operator-system/install/helmrelease.yaml
+++ b/clusters/common/apps/garage-operator-system/install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.5.11"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: garage-operator


### PR DESCRIPTION
Bumps the garage-operator HelmRelease from 0.5.11 → 0.6.0.

## Upstream change (rajsinghtech/garage-operator#192)

Auto mode now reconciles per-node \`GarageNode\` CRs (one per replica) instead
of a single cluster-level StatefulSet. On first reconcile by the new operator,
each cluster auto-migrates by:

1. Detecting the legacy STS \`garage\`.
2. Creating per-node \`GarageNode\` CRs (\`garage-storage-0\`, \`garage-storage-1\`)
   with \`spec.storage.{metadata,data}.existingClaim\` pointing at the existing
   PVCs (\`metadata-garage-0\`, \`data-garage-0\`, etc.).
3. Orphan-deleting the legacy STS and explicitly deleting its pods so the
   kubelet releases the RWO PVCs for the new per-node STSes.

Brief per-pod downtime; metadata PVC preserves node identity. Cluster-wide
replication factor 3 + zone redundancy keeps the data available globally.

## Canary plan (executed before this PR landed)

- Flux \`garage-operator-system-install\` is **suspended** on robbinsdale + ottawa.
- After merge, stpetersburg picks up 0.6.0 first.
- Once stpetersburg's per-node GarageNodes (\`garage-storage-0\`, \`garage-storage-1\`)
  are \`status.connected=true\` and \`status.inLayout=true\`, resume Flux on
  robbinsdale → ottawa in sequence.

## Per-cluster pre-state
- stpetersburg: 2 storage replicas, 2 gateway replicas
- robbinsdale: 1 storage replica, 2 gateway replicas
- ottawa: 1 storage replica, 2 gateway replicas

All three are currently Running.