### PR TITLE
fix(garage): update garage-ts selector for v0.6.0+ storage pod labels

### DIFF
--- a/clusters/common/apps/garage/app/service-ts.yaml
+++ b/clusters/common/apps/garage/app/service-ts.yaml
@@ -31,10 +31,11 @@ spec:
       protocol: TCP
       targetPort: 3903
   selector:
-    app.kubernetes.io/name: garage
-    app.kubernetes.io/instance: garage
-    # Tier filter required since v1beta2: both storage and gateway pods carry
-    # instance=garage on the unified CR. This LB serves the storage tier only.
+    # Match by operator-stamped cluster + tier labels (v0.6.0+).
+    # Pre-v0.6.0 selectors of {name=garage, instance=garage, tier=storage}
+    # silently lost endpoints when the #190 refactor relabeled storage pods to
+    # {name=garagenode, instance=<garagenode-name>}.
+    garage.rajsingh.info/cluster: garage
     garage.rajsingh.info/tier: storage
   type: LoadBalancer
   loadBalancerClass: tailscale


### PR DESCRIPTION
## Summary

- Update `garage-ts` (Tailscale LB) Service selector from `{name=garage, instance=garage, tier=storage}` to `{garage.rajsingh.info/cluster=garage, tier=storage}`.
- Storage pods after garage-operator #190 carry `app.kubernetes.io/name=garagenode, instance=<garagenode-name>` instead of the legacy values, so the previous selector matched 0 endpoints and the `\${LOCATION}-garage.keiretsu.ts.net:3901` hostname stopped routing to any backing pod.
- The new selector uses the operator-stamped per-cluster label that all storage pods carry (pre- and post-#190), so the LB picks up endpoints again immediately and cross-cluster Garage RPC resumes.

## Test plan

- [x] Hot-patched on all 3 clusters earlier today; endpoints populated within seconds, health went to `healthy`, `connectedNodes=10/10`, `storageNodesOk=4/4`.
- [ ] Flux reconciles this PR → verify all three `garage-ts` Services show endpoints again.