### PR TITLE
garage-operator: bump to 0.6.1

### DIFF
--- a/clusters/common/apps/garage-operator-system/install/helmrelease.yaml
+++ b/clusters/common/apps/garage-operator-system/install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.6.0"
+      version: "0.6.1"
       sourceRef:
         kind: HelmRepository
         name: garage-operator

--- a/clusters/common/apps/garage/app/service-ts.yaml
+++ b/clusters/common/apps/garage/app/service-ts.yaml
@@ -31,10 +31,11 @@ spec:
       protocol: TCP
       targetPort: 3903
   selector:
-    app.kubernetes.io/name: garage
-    app.kubernetes.io/instance: garage
-    # Tier filter required since v1beta2: both storage and gateway pods carry
-    # instance=garage on the unified CR. This LB serves the storage tier only.
+    # Match by operator-stamped cluster + tier labels (v0.6.0+).
+    # Pre-v0.6.0 selectors of {name=garage, instance=garage, tier=storage}
+    # silently lost endpoints when the #190 refactor relabeled storage pods to
+    # {name=garagenode, instance=<garagenode-name>}.
+    garage.rajsingh.info/cluster: garage
     garage.rajsingh.info/tier: storage
   type: LoadBalancer
   loadBalancerClass: tailscale


### PR DESCRIPTION
Picks up the fix from rajsinghtech/garage-operator#193: restores cluster-shared {name=garage, instance=<cluster>} labels on per-node storage pods so the garage-ts Tailscale LB endpoints keep working after the #190 refactor. Also tightens the legacy-STS migration's orphan-pod cleanup.