### PR TITLE
feat(robbinsdale): canary the tailgate egress operator

### DIFF
--- a/clusters/common/flux/repositories/oci/kustomization.yaml
+++ b/clusters/common/flux/repositories/oci/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./controlplaneio.yaml
   - ./home-operations.yaml
   - ./garage-operator.yaml
+  - ./tailgate-operator.yaml

--- a/clusters/common/flux/repositories/oci/tailgate-operator.yaml
+++ b/clusters/common/flux/repositories/oci/tailgate-operator.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: tailgate-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  type: oci
+  url: oci://ghcr.io/rajsinghtech/charts

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/helmrelease.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/helmrelease.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailgate-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: tailgate-operator
+      version: "0.0.2"
+      sourceRef:
+        kind: HelmRepository
+        name: tailgate-operator
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  values:
+    fullnameOverride: tailgate-operator
+    crds:
+      install: true
+      keep: true
+    tailnet:
+      # Reference secret.yaml (creds substituted from common-secrets) instead of templating one.
+      create: false
+      secretName: tailgate-tailnet-creds
+    agent:
+      enabled: true
+      # robbinsdale pod CIDR,service CIDR — kept on the primary CNI for exit-node
+      # members so kube-dns / the API server never blackhole through the tunnel.
+      clusterCIDRs: "10.1.0.0/16,10.0.0.0/16"
+      image:
+        tag: v0.0.2
+    operator:
+      image:
+        tag: v0.0.2
+    gateway:
+      image:
+        tag: v0.0.2

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - helmrelease.yaml

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/secret.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/secret.yaml
@@ -1,0 +1,15 @@
+---
+# Reuses the same Tailscale OAuth client the tailscale operator uses: TS_OAUTH_CLIENT_ID /
+# TS_OAUTH_CLIENT_SECRET come from common-secrets, substituted by Flux (the cluster-apps
+# patch injects postBuild.substituteFrom into every child Kustomization). No new client,
+# no per-app SOPS. tag:k8s-operator owns tag:k8s + tag:robbinsdale, so this client can mint
+# the gateway authkey. TS_TAILNET "-" = the client's default tailnet.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailgate-tailnet-creds
+type: Opaque
+stringData:
+  TS_TAILNET: "-"
+  TS_OAUTH_CLIENT_ID: ${TS_OAUTH_CLIENT_ID}
+  TS_OAUTH_CLIENT_SECRET: ${TS_OAUTH_CLIENT_SECRET}

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/egressgroup.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/egressgroup.yaml
@@ -1,0 +1,24 @@
+---
+# Canary group (cluster-scoped). The operator stands up one shared gateway tagged
+# tag:k8s + tag:robbinsdale (both owned by tag:k8s-operator in tailscale/policy.hujson).
+# Cross-site test: members reach the ottawa LAN (192.168.169.0/24) through the gateway —
+# policy grants tag:robbinsdale -> ipset:ottawa via tag:ottawa, and the ottawa subnet
+# router advertises 192.168.169.0/24 (autoApprover). Ping 192.168.169.1 (ottawa router)
+# from a selected pod to confirm the full path.
+apiVersion: tailscale.rajsingh.info/v1alpha1
+kind: EgressGroup
+metadata:
+  name: robbinsdale-egress
+spec:
+  selector:
+    podSelector:
+      matchLabels:
+        tailgate.rajsingh.info/egress: robbinsdale
+  tags:
+    - "tag:k8s"
+    - "tag:robbinsdale"
+  mode: subnet
+  routes:
+    - 192.168.169.0/24    # ottawa LAN (advertised by tag:ottawa subnet router)
+  acceptRoutes: true      # gateway accepts the ottawa advertised route (default)
+  replicas: 1

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - egressgroup.yaml
+  - probe.yaml

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/probe.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/probe.yaml
@@ -1,0 +1,34 @@
+---
+# Connectivity probe for the canary: a busybox the EgressGroup selects (label
+# tailgate.rajsingh.info/egress=robbinsdale). Lives in default (NOT the gateway namespace —
+# the agent skips its own namespace). Verify the cross-site path with:
+#   kubectl exec deploy/tailgate-canary-probe -- ping -c3 192.168.169.1
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailgate-canary-probe
+  namespace: default
+  labels:
+    app.kubernetes.io/name: tailgate-canary-probe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailgate-canary-probe
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailgate-canary-probe
+        tailgate.rajsingh.info/egress: robbinsdale
+    spec:
+      containers:
+        - name: probe
+          image: busybox:1.37
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/ks.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/ks.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailgate-operator
+  namespace: flux-system
+spec:
+  targetNamespace: tailgate-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/talos-robbinsdale/apps/tailgate-operator-system/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  # decryption + postBuild.substituteFrom (common-secrets etc.) are injected into every
+  # child Kustomization by the cluster-apps patch, so ${TS_OAUTH_CLIENT_*} resolve here.
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# The EgressGroup is cluster-scoped, so it gets its own Kustomization (no
+# targetNamespace, which would otherwise stamp a namespace onto a cluster-scoped
+# CR). dependsOn + the install's wait:true means it only applies once the operator
+# HelmRelease is Ready and its CRD is installed.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tailgate-operator-egress
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: tailgate-operator
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: tailgate-operator-egress
+  path: ./clusters/talos-robbinsdale/apps/tailgate-operator-system/egress
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ks.yaml

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/namespace.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailgate-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    # agent DaemonSet runs privileged + hostNetwork + hostPID
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
Robbinsdale-only canary of the **tailgate** egress operator (v0.0.2), to validate cross-site egress before promoting to `clusters/common`.

## How it's wired
- New app dir `clusters/talos-robbinsdale/apps/tailgate-operator-system/` — creating it *is* the registration (the `cluster-apps` Kustomization auto-recurses `talos-robbinsdale/apps`, so this never reaches ottawa/stpetersburg).
- New OCI `HelmRepository` for `oci://ghcr.io/rajsinghtech/charts` (the only edit to a shared file: one line in `repositories/oci/kustomization.yaml`).
- HelmRelease: chart `tailgate-operator:0.0.2`, `tailnet.create=false`, `agent.clusterCIDRs=10.1.0.0/16,10.0.0.0/16`, `fullnameOverride: tailgate-operator`, images `v0.0.2`.

## Credentials — reuses the Tailscale operator's OAuth client
`secret.yaml` is a plain manifest with `${TS_OAUTH_CLIENT_ID}` / `${TS_OAUTH_CLIENT_SECRET}`, substituted by Flux from `common-secrets` (the `cluster-apps` patch injects `postBuild.substituteFrom` into every child Kustomization). **No new OAuth client, no new SOPS secret.** `tag:k8s-operator` owns both `tag:k8s` and `tag:robbinsdale`, so this client can mint the gateway authkey. `TS_TAILNET: "-"` = the client's default tailnet.

## Cross-site test
`EgressGroup robbinsdale-egress` (`tag:k8s`,`tag:robbinsdale`) steers `192.168.169.0/24` onto selected pods. Policy already allows it: grant `tag:robbinsdale -> ipset:ottawa via tag:ottawa`, and `tag:ottawa` advertises `192.168.169.0/24` (autoApprover). A `busybox` probe in `default` (the agent skips the gateway namespace) is selected by the group.

```
kubectl -n default exec deploy/tailgate-canary-probe -- ping -c3 192.168.169.1
```

> ⚠️ **Target IP corrected:** the ask was `192.168.168.1`, but there is no `192.168.168.0/24` anywhere in `policy.hujson`. The advertised ottawa LAN is **`192.168.169.0/24`** (`ipset:ottawa`), so the reachable router is **`192.168.169.1`**. If `.168.1` is a real target, it needs adding to `ipset:ottawa` + an autoApprover first.

## Cluster-scoped CR handling
The `EgressGroup` is cluster-scoped, so it + the probe get their own Flux Kustomization (`tailgate-operator-egress`, no `targetNamespace`, `dependsOn` the install) — avoids kustomize stamping a namespace onto a cluster-scoped resource, and ensures the CRD is installed first.

Merging deploys to robbinsdale (Flux tracks `main`). The `tailgate-canary-probe` Deployment is a test artifact — safe to delete after validating.