### PR TITLE
tailgate: bump robbinsdale canary to v0.0.4

### DIFF
--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/helmrelease.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: tailgate-operator
-      version: "0.0.3"
+      version: "0.0.4"
       sourceRef:
         kind: HelmRepository
         name: tailgate-operator
@@ -37,10 +37,10 @@ spec:
       # members so kube-dns / the API server never blackhole through the tunnel.
       clusterCIDRs: "10.1.0.0/16,10.0.0.0/16"
       image:
-        tag: v0.0.3
+        tag: v0.0.4
     operator:
       image:
-        tag: v0.0.3
+        tag: v0.0.4
     gateway:
       image:
-        tag: v0.0.3
+        tag: v0.0.4

--- a/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/egressgroup.yaml
+++ b/clusters/talos-robbinsdale/apps/tailgate-operator-system/egress/egressgroup.yaml
@@ -17,8 +17,6 @@ spec:
   tags:
     - "tag:k8s"
     - "tag:robbinsdale"
-  mode: subnet
   routes:
     - 192.168.169.0/24    # ottawa LAN (advertised by tag:ottawa subnet router)
   acceptRoutes: true      # gateway accepts the ottawa advertised route (default)
-  replicas: 1


### PR DESCRIPTION
Bumps the robbinsdale tailgate canary to **v0.0.4** (chart 0.0.4 + images v0.0.4).

What's in v0.0.4: native L3 egress positioning, `tag:k8s` default gateway tag, mirror accepted routes onto members by default (members reach the whole tailnet without `spec.routes`), and the native `exitNode.name` surface.

Manifest changes:
- `helmrelease.yaml`: chart `0.0.3`→`0.0.4`, image tags `v0.0.3`→`v0.0.4` (operator/agent/gateway).
- `egressgroup.yaml`: drop `mode`/`replicas` — both removed from the CRD in the redesign, pruned under v0.0.4.

Flux deploys on merge; validated by the canary probe (`ping 192.168.169.1` from the egress probe pod).