### PR TITLE
searxng: move from stpetersburg into common (run on all clusters)

### DIFF
--- a/clusters/common/apps/searxng/app/kustomization.yaml
+++ b/clusters/common/apps/searxng/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: searxng
+
+resources:
+  - namespace.yaml
+  - valkey.yaml
+  - searxng.yaml
+  - probes.yaml

--- a/clusters/common/apps/searxng/app/namespace.yaml
+++ b/clusters/common/apps/searxng/app/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: searxng
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/common/apps/searxng/app/probes.yaml
+++ b/clusters/common/apps/searxng/app/probes.yaml
@@ -1,0 +1,38 @@
+---
+# SearXNG meta-search backend used by AI agents.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-searxng
+  namespace: searxng
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://searxng.searxng:8080/healthz
+      labels:
+        service: searxng
+        target: searxng
+---
+# Valkey (Redis-compat) backing store for SearXNG.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-valkey
+  namespace: searxng
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - valkey.searxng:6379
+      labels:
+        service: searxng
+        target: valkey

--- a/clusters/common/apps/searxng/app/searxng.yaml
+++ b/clusters/common/apps/searxng/app/searxng.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: searxng-config
-  namespace: ai
+  namespace: searxng
 data:
   settings.yml: |
     use_default_settings: true
@@ -60,7 +60,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: searxng
-  namespace: ai
+  namespace: searxng
   labels:
     app: searxng
 spec:
@@ -132,7 +132,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: searxng
-  namespace: ai
+  namespace: searxng
   labels:
     app: searxng
 spec:
@@ -149,7 +149,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: searxng-ts
-  namespace: ai
+  namespace: searxng
   annotations:
     tailscale.com/hostname: "${LOCATION}-searxng"
     tailscale.com/proxy-group: common-ingress

--- a/clusters/common/apps/searxng/app/valkey.yaml
+++ b/clusters/common/apps/searxng/app/valkey.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: valkey
-  namespace: ai
+  namespace: searxng
 spec:
   interval: 30m
   chart:

--- a/clusters/common/apps/searxng/ks.yaml
+++ b/clusters/common/apps/searxng/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app searxng
+  namespace: flux-system
+spec:
+  targetNamespace: searxng
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/common/apps/searxng/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/common/apps/searxng/kustomization.yaml
+++ b/clusters/common/apps/searxng/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ks.yaml

--- a/clusters/talos-stpetersburg/apps/ai/inference/kustomization.yaml
+++ b/clusters/talos-stpetersburg/apps/ai/inference/kustomization.yaml
@@ -9,8 +9,6 @@ resources:
   - ai-gateway.yaml
   - vllm-route.yaml
   - vllm-dnsrecord.yaml
-  - valkey.yaml
-  - searxng.yaml
   - dashboards.yaml
   - scrapeconfig.yaml
   - secret.yaml

--- a/clusters/talos-stpetersburg/apps/ai/inference/probes.yaml
+++ b/clusters/talos-stpetersburg/apps/ai/inference/probes.yaml
@@ -17,39 +17,3 @@ spec:
       labels:
         service: ai-inference
         target: vllm
----
-# SearXNG meta-search backend used by AI agents.
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: app-searxng
-spec:
-  jobName: blackbox
-  module: http_2xx
-  prober:
-    url: blackbox-exporter.monitoring.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-        - http://searxng.ai:8080/healthz
-      labels:
-        service: ai-inference
-        target: searxng
----
-# Valkey (Redis-compat) backing store for the AI stack.
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: app-valkey
-spec:
-  jobName: blackbox
-  module: tcp_connect
-  prober:
-    url: blackbox-exporter.monitoring.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-        - valkey.ai:6379
-      labels:
-        service: ai-inference
-        target: valkey


### PR DESCRIPTION
## Why
St. Petersburg is currently **down**, which takes SearXNG offline — and with it the AI agents' web search (Hermes `web.search_backend: searxng` → `SEARXNG_URL`). SearXNG lived only in `clusters/talos-stpetersburg/apps/ai/inference`, so a single-site outage kills search everywhere.

## What
Move SearXNG **and its valkey backing store** out of stpetersburg's `ai` namespace into a new **`clusters/common/apps/searxng`** app so it deploys on **all three clusters** (ottawa / robbinsdale / stpetersburg) and survives any single-site outage. Each cluster gets a local instance + its own Tailscale ingress.

## Changes
- **New** `clusters/common/apps/searxng/` — standard Flux app layout (`kustomization.yaml` → `ks.yaml` → `app/`):
  - dedicated `searxng` namespace
  - `valkey.yaml` (HelmRelease; repo already registered in `common/flux/repositories/helm/valkey.yaml`)
  - `searxng.yaml` (ConfigMap + Deployment + ClusterIP Service + Tailscale LoadBalancer)
  - `probes.yaml` (blackbox probes for searxng + valkey)
- TS ingress hostname unchanged: `${LOCATION}-searxng` → renders `ottawa-searxng`, `robbinsdale-searxng`, `stpetersburg-searxng` per cluster, so existing egress wiring keeps working once reconciled.
- **Removed** `searxng.yaml` + `valkey.yaml` from `clusters/talos-stpetersburg/apps/ai/inference`, trimmed their entries from that kustomization, and dropped the searxng/valkey blackbox probes there (vllm probe retained).

## Validation (no-downtime gate)
```
kustomize build --enable-helm clusters/common/apps/searxng/app      # OK
kustomize build              clusters/common/apps/searxng            # OK
kustomize build --enable-helm clusters/talos-stpetersburg/apps/ai/inference  # OK (after removal)
```

## Notes
- `clusters/common` blast radius = all 3 clusters; this is intentional here (we want SearXNG everywhere for HA).
- valkey uses `auth.enabled: false` + `dataStorage.enabled: false` (ephemeral cache, same as the original stpetersburg config).
- After merge + reconcile, the Ottawa instance lets the in-cluster agents reach search locally even while stpetersburg is down.