### PR TITLE
agents: enable CSI-Addons RBD network fencing on ottawa (prod follow-up to #1464)

### DIFF
--- a/clusters/talos-ottawa/apps/csi-addons/app/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/csi-addons/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./networkfenceclass.yaml

--- a/clusters/talos-ottawa/apps/csi-addons/app/networkfenceclass.yaml
+++ b/clusters/talos-ottawa/apps/csi-addons/app/networkfenceclass.yaml
@@ -1,0 +1,18 @@
+---
+# NetworkFenceClass tells CephCSI how to fence a failed node's RBD client.
+# When a node is tainted node.kubernetes.io/out-of-service=...:NoExecute, the
+# CephCSI driver auto-creates a NetworkFence referencing this class, which
+# blocklists the dead node in Ceph (breaking its exclusive-lock) so RWO volumes
+# can immediately reattach on a healthy node instead of waiting out the kubelet
+# force-detach timeout + a stale Ceph lock.
+# Secret + clusterID match the rook-csi-rbd-provisioner used by the StorageClass.
+apiVersion: csiaddons.openshift.io/v1alpha1
+kind: NetworkFenceClass
+metadata:
+  name: ceph-rbd-network-fence
+spec:
+  provisioner: rook-ceph.rbd.csi.ceph.com
+  parameters:
+    clusterID: rook-ceph
+    csiaddons.openshift.io/networkfence-secret-name: rook-csi-rbd-provisioner
+    csiaddons.openshift.io/networkfence-secret-namespace: rook-ceph

--- a/clusters/talos-ottawa/apps/csi-addons/ks.yaml
+++ b/clusters/talos-ottawa/apps/csi-addons/ks.yaml
@@ -1,0 +1,48 @@
+---
+# CSI-Addons controller + CRDs, pulled straight from the upstream repo at a
+# pinned tag (see clusters/common/flux/repositories/git/csi-addons.yaml).
+# No kustomization.yaml exists at ./deploy/controller upstream, so Flux
+# auto-generates one and builds all manifests in that dir
+# (crds.yaml, rbac.yaml, setup-controller.yaml, csi-addons-config.yaml).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-addons
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # Rook operator owns the RBD CSI driver the csi-addons sidecar attaches to.
+    - name: rook-ceph-operator
+  path: ./deploy/controller
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: csi-addons
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# NetworkFenceClass (+ any other cluster-local fencing config) lives in-repo and
+# depends on the CRDs installed by the csi-addons controller above.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-addons-config
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: csi-addons
+  path: ./clusters/${CLUSTER_NAME}/apps/csi-addons/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-ottawa/apps/csi-addons/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/csi-addons/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ks.yaml

--- a/clusters/talos-ottawa/apps/rook-ceph/app/helmrelease.yaml
+++ b/clusters/talos-ottawa/apps/rook-ceph/app/helmrelease.yaml
@@ -25,4 +25,15 @@ spec:
       enabled: true
       createPrometheusRules: true
     toolbox:
-      enabled: true 
+      enabled: true
+    csi:
+      # Deploy the csi-addons sidecar into the RBD provisioner + nodeplugin pods.
+      # Required for automatic RBD network fencing on hard node loss: when a node
+      # is tainted node.kubernetes.io/out-of-service, CephCSI uses the sidecar +
+      # NetworkFenceClass (clusters/talos-ottawa/apps/csi-addons) to blocklist the
+      # dead node in Ceph, breaking its RBD exclusive-lock so RWO volumes reattach
+      # on a healthy node immediately instead of waiting out the force-detach timeout.
+      # The csi-addons CONTROLLER + CRDs are installed by the csi-addons app.
+      # Proven on robbinsdale (PR #1464) before this prod rollout.
+      csiAddons:
+        enabled: true 


### PR DESCRIPTION
## Prod follow-up to #1464

Brings CSI-Addons RBD network fencing to **ottawa (prod)** after the robbinsdale canary in #1464 was verified healthy:
- csi-addons controller 1/1 Running
- all 7 CRDs registered (networkfenceclasses, networkfences, csiaddonsnodes, reclaimspace*, encryptionkeyrotation*)
- `ceph-rbd-network-fence` NetworkFenceClass live
- `CSI_ENABLE_CSIADDONS: true`, sidecar injected into the RBD ctrlplugin + a `nodeplugin-csi-addons` DaemonSet (3/3)

## Changes (ottawa only — shared source already merged)
- New app `clusters/talos-ottawa/apps/csi-addons` (NetworkFenceClass + ks.yaml). The ks points the controller at the shared `csi-addons` GitRepository source (tag `v0.14.0`) already merged in `common/`. `${CLUSTER_NAME}` substitution makes the ks identical to robbinsdale's.
- `csi.csiAddons.enabled: true` on the ottawa rook HelmRelease.

ottawa's RBD setup matches robbinsdale (clusterID `rook-ceph`, secret `rook-csi-rbd-provisioner/rook-ceph`, provisioner `rook-ceph.rbd.csi.ceph.com` — verified live), so the NetworkFenceClass is unchanged.

## Safety
- **No data-path impact on merge.** The sidecar is idle until a NetworkFence is created; activation is the manual `node.kubernetes.io/out-of-service` taint on a confirmed-dead node.
- On reconcile the operator does a **rolling update of the CSI driver pods** to add the sidecar (observed clean on robbinsdale, no workload disruption). **Ottawa is prod — merge during off-hours** as planned.

## Validation
`kustomize build` csi-addons app + ks wrapper + `--enable-helm` rook-ceph app all pass; net diff +88/-1.
