### PR TITLE
assistant-raj: enable browser toolset (--no-sandbox) + resource bump

### DIFF
--- a/clusters/talos-ottawa/apps/agents/app/assistant-raj/configmap.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/assistant-raj/configmap.yaml
@@ -13,6 +13,15 @@ data:
   DISCORD_AUTO_THREAD: "true"
   DISCORD_REACTIONS: "true"
 
+  # ---- Browser toolset (web_extract / browser_* tools) ----
+  # The image already bundles Chromium (Chrome for Testing) + the agent-browser
+  # CLI. Hermes auto-injects --no-sandbox only when running as root or on
+  # AppArmor-restricted hosts. This pod runs as uid 10000 (non-root, via
+  # s6-setuidgid) on Talos with no AppArmor userns flag, so neither trigger
+  # fires and Chromium dies with "No usable sandbox". Setting the flag
+  # explicitly is the documented fix (browser_tool.py honours AGENT_BROWSER_ARGS).
+  AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+
   # LLM endpoint lives in /opt/data/config.yaml inside the PVC (set once via
   # kubectl exec; reachable through the `stpetersburg-vllm` ExternalName).
   # OPENAI_BASE_URL is kept so Hermes auxiliary clients (summarization /

--- a/clusters/talos-ottawa/apps/agents/app/assistant-raj/deployment.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/assistant-raj/deployment.yaml
@@ -87,10 +87,10 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 1000m
+              memory: 2Gi
             limits:
-              memory: 4Gi
+              memory: 6Gi
           volumeMounts:
             - name: data
               mountPath: /opt/data
@@ -103,5 +103,5 @@ spec:
         - name: shm
           emptyDir:
             medium: Memory
-            sizeLimit: 1Gi
+            sizeLimit: 2Gi
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## What
Enables the browser toolset (`web_extract`, `browser_*`) for the assistant-raj pod, plus a modest resource bump for browser headroom. **Ottawa-only.**

## Root cause
The image already bundles Chromium (Chrome for Testing 148) and the `agent-browser` CLI — env vars (`AGENT_BROWSER_EXECUTABLE_PATH`, `PLAYWRIGHT_BROWSERS_PATH`) are already wired. The only blocker was the Chrome sandbox:

- Hermes (`tools/browser_tool.py`) auto-injects `--no-sandbox` **only** when running as root **or** on AppArmor-restricted hosts.
- This pod runs as **uid 10000** (non-root, via `s6-setuidgid`) on **Talos** with no `apparmor_restrict_unprivileged_userns` flag → neither trigger fires → Chromium exits with `No usable sandbox`.

## Fix
Set `AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage` explicitly in the ConfigMap. **Verified in-pod**: `agent-browser open/snapshot/close` against example.com succeeds with the flag set. No image rebuild or Chromium download required.

## Changes
| File | Change |
|---|---|
| configmap.yaml | + `AGENT_BROWSER_ARGS` |
| deployment.yaml | requests cpu 500m→1000m, mem 1Gi→2Gi; limit mem 4Gi→6Gi; shm 1Gi→2Gi |

## Resource / blast-radius notes
- Node `kaji` has ample headroom (62Gi mem available, requests ~35% committed). Mem **limits** are at ~106% overcommit, so the limit bump is kept modest (4→6Gi).
- assistant-raj has **no canary equivalent** (no agents dir in robbinsdale/stpetersburg), and the only blast radius is this single pod — not shared media/infra.
- Recreate strategy ⇒ merging restarts the pod (~30–60s WhatsApp reconnect). Merge when convenient.

## Validation
- `kubectl kustomize` renders cleanly with all four values.
- Browser flow verified working in-pod with the flag.