### PR TITLE
agents: add abtar persona (second Hermes assistant)

### DIFF
--- a/clusters/talos-ottawa/apps/agents/README.md
+++ b/clusters/talos-ottawa/apps/agents/README.md
@@ -10,6 +10,7 @@ reach it.
 | Persona       | Tailscale hostname | Purpose                              |
 | ------------- | ------------------ | ------------------------------------ |
 | assistant-raj | `assistant-raj`    | Calendar / email / notes / reminders |
+| abtar         | `abtar`            | Calendar / email / notes / reminders |
 
 Reach it from your tailnet:
 

--- a/clusters/talos-ottawa/apps/agents/app/abtar/configmap.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/configmap.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: abtar-config
+data:
+  GATEWAY_ALLOW_ALL_USERS: "true"
+  API_SERVER_ENABLED: "true"
+  API_SERVER_HOST: "0.0.0.0"
+  API_SERVER_PORT: "8642"
+  API_SERVER_KEY: "${DEFAULT_PASSWORD}"
+  DISCORD_REQUIRE_MENTION: "false"
+  DISCORD_AUTO_THREAD: "true"
+  DISCORD_REACTIONS: "true"
+
+  # ---- Browser toolset (web_extract / browser_* tools) ----
+  # The image already bundles Chromium (Chrome for Testing) + the agent-browser
+  # CLI. Hermes auto-injects --no-sandbox only when running as root or on
+  # AppArmor-restricted hosts. This pod runs as uid 10000 (non-root, via
+  # s6-setuidgid) on Talos with no AppArmor userns flag, so neither trigger
+  # fires and Chromium dies with "No usable sandbox". Setting the flag
+  # explicitly is the documented fix (browser_tool.py honours AGENT_BROWSER_ARGS).
+  AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+
+  # ---- Camofox browser backend (watchable browser) ----
+  # Routes the browser_* tools through the camofox deployment instead of the
+  # bundled headless shell. Camofox runs headed with a noVNC viewer, so raj can
+  # watch live and take over (logins) at https://camofox.keiretsu.ts.net.
+  # Cluster-internal API; no auth header is sent by Hermes, so the API service
+  # is ClusterIP-only.
+  CAMOFOX_URL: "http://camofox.agents.svc.cluster.local:9377"
+
+  # LLM endpoint lives in /opt/data/config.yaml inside the PVC (set once via
+  # kubectl exec; reachable through the `stpetersburg-vllm` ExternalName).
+  # OPENAI_BASE_URL is kept so Hermes auxiliary clients (summarization /
+  # compression) route to the same vLLM endpoint when they're invoked.
+  OPENAI_BASE_URL: "http://stpetersburg-vllm/v1"
+  OPENAI_API_KEY: "unused"
+
+  # ---- WhatsApp bridge (Baileys, self-chat mode) ----
+  # Pair once: kubectl exec -it deploy/abtar -c gateway --
+  #   /opt/hermes/.venv/bin/hermes whatsapp
+  # Session persists at /opt/data/whatsapp/session/ in the PVC.
+  WHATSAPP_ENABLED: "true"
+  WHATSAPP_MODE: "self-chat"
+  WHATSAPP_ALLOWED_USERS: "16516051093"
+
+  # ---- Persona ----
+  AGENT_NAME: "abtar"
+  AGENT_PERSONA: "assistant"
+  AGENT_SYSTEM_PROMPT: |
+    You are Abtar, a personal assistant.
+    You manage calendar, email, notes, reminders, and life logistics.
+    Default tone: warm, proactive, terse. Remember context across days.
+    When uncertain, prefer to ask one clarifying question over guessing.

--- a/clusters/talos-ottawa/apps/agents/app/abtar/deployment.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: abtar
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: abtar
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: abtar
+        agents.keiretsu.ts.net/persona: assistant
+        agents.keiretsu.ts.net/owner: raj
+    spec:
+      initContainers:
+        - name: seed-aws-credentials
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /opt/data/.aws
+              umask 077
+              cat >/opt/data/.aws/credentials <<EOF
+              [default]
+              aws_access_key_id = $${AWS_ACCESS_KEY_ID}
+              aws_secret_access_key = $${AWS_SECRET_ACCESS_KEY}
+              EOF
+              cat >/opt/data/.aws/config <<EOF
+              [default]
+              region = $${AWS_REGION}
+              endpoint_url = $${AWS_ENDPOINT_URL}
+              s3 =
+                  endpoint_url = $${AWS_ENDPOINT_URL_S3}
+                  addressing_style = path
+              EOF
+          envFrom:
+            - secretRef:
+                name: abtar-s3
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      containers:
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.5.29
+          args: ["gateway", "run"]
+          envFrom:
+            - configMapRef:
+                name: abtar-config
+            - secretRef:
+                name: abtar-secrets
+            - secretRef:
+                name: abtar-s3
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/data/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /opt/data/.aws/config
+            # v2026.5.29 introduced s6 supervision — dashboard runs in the same
+            # container as the gateway. HERMES_DASHBOARD=1 spawns it; TUI=1
+            # enables the embedded chat tab; HOST=0.0.0.0 exposes it.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            # Skip the dashboard's OAuth gate. Safe here because access is
+            # already gated at the network layer by Tailscale `tag:raj` ACL.
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: gateway
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              memory: 6Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: abtar-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      terminationGracePeriodSeconds: 30

--- a/clusters/talos-ottawa/apps/agents/app/abtar/garagekey.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/garagekey.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: abtar-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "abtar S3 Reader Key"
+  allBuckets:
+    read: true
+  secretTemplate:
+    name: abtar-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://garage.garage.svc.cluster.local:3900"
+      AWS_ENDPOINT_URL_S3: "http://garage.garage.svc.cluster.local:3900"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/clusters/talos-ottawa/apps/agents/app/abtar/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - deployment.yaml
+  - service.yaml
+  - service-tailscale.yaml
+  - storagestack.yaml
+  - garagekey.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/clusters/talos-ottawa/apps/agents/app/abtar/secret.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/secret.yaml
@@ -1,0 +1,14 @@
+---
+# Fill in real values then re-apply. Encrypt before committing real tokens:
+#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: abtar-secrets
+type: Opaque
+stringData:
+  # Discord disabled until a real token is provided.
+  # DISCORD_BOT_TOKEN: ""
+  GOOGLE_OAUTH_CLIENT_ID: ""
+  GOOGLE_OAUTH_CLIENT_SECRET: ""
+  NOTION_TOKEN: ""

--- a/clusters/talos-ottawa/apps/agents/app/abtar/service-tailscale.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/service-tailscale.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: abtar-ts
+  annotations:
+    tailscale.com/hostname: abtar
+    tailscale.com/tags: "tag:raj"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: abtar
+  ports:
+    - name: dashboard
+      port: 80
+      targetPort: 9119
+      protocol: TCP
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP

--- a/clusters/talos-ottawa/apps/agents/app/abtar/service.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: abtar
+spec:
+  selector:
+    app.kubernetes.io/name: abtar
+  ports:
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: 9119
+      protocol: TCP

--- a/clusters/talos-ottawa/apps/agents/app/abtar/storagestack.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/abtar/storagestack.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: abtar-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: abtar-data
+  size: 20Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/abtar/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot

--- a/clusters/talos-ottawa/apps/agents/app/bucket.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/bucket.yaml
@@ -17,3 +17,8 @@ spec:
       read: true
       write: true
       owner: true
+    - keyRef:
+        name: abtar-s3-key
+      read: true
+      write: true
+      owner: true

--- a/clusters/talos-ottawa/apps/agents/app/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/kustomization.yaml
@@ -5,4 +5,5 @@ namespace: agents
 resources:
   - bucket.yaml
   - assistant-raj
+  - abtar
   - camofox


### PR DESCRIPTION
## What

Adds a second Hermes assistant persona, **abtar**, to `clusters/talos-ottawa/apps/agents`, mirroring `assistant-raj`.

## Objects (ns `agents`)
- Deployment `abtar` (hermes-agent v2026.5.29, gateway + dashboard)
- ClusterIP Service + Tailscale LoadBalancer (`tag:raj`, hostname `abtar`)
- StorageStack `abtar-data` (20Gi ceph-block-replicated, nightly Garage backup to `agents/abtar/data`)
- GarageKey `abtar-s3-key` added to the shared `agents` bucket keyPermissions
- ConfigMap + placeholder Secret

## Identity / config
- Reuses `tag:raj` ACL (same owner — only rajsinghtech@github can reach it)
- WhatsApp self-chat allowed user `16516051093`
- API key `${DEFAULT_PASSWORD}` (same as assistant-raj)
- Shares the single `stpetersburg-vllm` egress ExternalName (no per-agent `egress.yaml` to avoid the duplicate-resource collision)

## Still to do before merge (Raj supplies)
- Fill `app/abtar/secret.yaml` with real integration tokens, then SOPS-encrypt (`secret.yaml` -> `secret.sops.yaml`) — currently a placeholder with empty values
- After merge + reconcile: pair WhatsApp once (`kubectl exec -it deploy/abtar -c gateway -- /opt/hermes/.venv/bin/hermes whatsapp`)
- Tweak `AGENT_SYSTEM_PROMPT` persona text if desired

## Validation
`kustomize build --enable-helm clusters/talos-ottawa/apps/agents/app` passes; all abtar objects render.

Draft so you can follow along before it's reconciled.