### PR TITLE
agents: add karthik assistant persona (Karthik's Hermes agent)

### DIFF
--- a/clusters/talos-ottawa/apps/agents/app/bucket.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/bucket.yaml
@@ -22,3 +22,8 @@ spec:
       read: true
       write: true
       owner: true
+    - keyRef:
+        name: karthik-s3-key
+      read: true
+      write: true
+      owner: true

--- a/clusters/talos-ottawa/apps/agents/app/karthik/configmap.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/configmap.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karthik-config
+data:
+  GATEWAY_ALLOW_ALL_USERS: "true"
+  API_SERVER_ENABLED: "true"
+  API_SERVER_HOST: "0.0.0.0"
+  API_SERVER_PORT: "8642"
+  API_SERVER_KEY: "${DEFAULT_PASSWORD}"
+  DISCORD_REQUIRE_MENTION: "false"
+  DISCORD_AUTO_THREAD: "true"
+  DISCORD_REACTIONS: "true"
+
+  # ---- Browser toolset (web_extract / browser_* tools) ----
+  # The image already bundles Chromium (Chrome for Testing) + the agent-browser
+  # CLI. Hermes auto-injects --no-sandbox only when running as root or on
+  # AppArmor-restricted hosts. This pod runs as uid 10000 (non-root, via
+  # s6-setuidgid) on Talos with no AppArmor userns flag, so neither trigger
+  # fires and Chromium dies with "No usable sandbox". Setting the flag
+  # explicitly is the documented fix (browser_tool.py honours AGENT_BROWSER_ARGS).
+  AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+
+  # ---- Camofox browser backend (watchable browser) ----
+  # Routes the browser_* tools through the camofox deployment instead of the
+  # bundled headless shell. Camofox runs headed with a noVNC viewer, so raj can
+  # watch live and take over (logins) at https://camofox.keiretsu.ts.net.
+  # Cluster-internal API; no auth header is sent by Hermes, so the API service
+  # is ClusterIP-only.
+  CAMOFOX_URL: "http://camofox.agents.svc.cluster.local:9377"
+
+  # LLM endpoint lives in /opt/data/config.yaml inside the PVC (set once via
+  # kubectl exec; reachable through the `stpetersburg-vllm` ExternalName).
+  # OPENAI_BASE_URL is kept so Hermes auxiliary clients (summarization /
+  # compression) route to the same vLLM endpoint when they're invoked.
+  OPENAI_BASE_URL: "http://stpetersburg-vllm/v1"
+  OPENAI_API_KEY: "unused"
+
+  # ---- WhatsApp bridge (Baileys, self-chat mode) ----
+  # Pair once: kubectl exec -it deploy/karthik -c gateway --
+  #   /opt/hermes/.venv/bin/hermes whatsapp
+  # Session persists at /opt/data/whatsapp/session/ in the PVC.
+  WHATSAPP_ENABLED: "true"
+  WHATSAPP_MODE: "self-chat"
+  # Karthik's WhatsApp number (E.164 without +). PLACEHOLDER — Raj/Karthik to set.
+  WHATSAPP_ALLOWED_USERS: "REPLACE_WITH_KARTHIK_PHONE"
+
+  # ---- Persona ----
+  AGENT_NAME: "karthik"
+  AGENT_PERSONA: "assistant"
+  AGENT_SYSTEM_PROMPT: |
+    You are Karthik's personal assistant.
+    You manage calendar, email, notes, reminders, and life logistics.
+    Default tone: warm, proactive, terse. Remember context across days.
+    When uncertain, prefer to ask one clarifying question over guessing.

--- a/clusters/talos-ottawa/apps/agents/app/karthik/deployment.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karthik
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karthik
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karthik
+        agents.keiretsu.ts.net/persona: assistant
+        agents.keiretsu.ts.net/owner: karthik
+    spec:
+      initContainers:
+        - name: seed-aws-credentials
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /opt/data/.aws
+              umask 077
+              cat >/opt/data/.aws/credentials <<EOF
+              [default]
+              aws_access_key_id = $${AWS_ACCESS_KEY_ID}
+              aws_secret_access_key = $${AWS_SECRET_ACCESS_KEY}
+              EOF
+              cat >/opt/data/.aws/config <<EOF
+              [default]
+              region = $${AWS_REGION}
+              endpoint_url = $${AWS_ENDPOINT_URL}
+              s3 =
+                  endpoint_url = $${AWS_ENDPOINT_URL_S3}
+                  addressing_style = path
+              EOF
+          envFrom:
+            - secretRef:
+                name: karthik-s3
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      containers:
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.5.29
+          args: ["gateway", "run"]
+          envFrom:
+            - configMapRef:
+                name: karthik-config
+            - secretRef:
+                name: karthik-secrets
+            - secretRef:
+                name: karthik-s3
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/data/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /opt/data/.aws/config
+            # v2026.5.29 introduced s6 supervision — dashboard runs in the same
+            # container as the gateway. HERMES_DASHBOARD=1 spawns it; TUI=1
+            # enables the embedded chat tab; HOST=0.0.0.0 exposes it.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            # Skip the dashboard's OAuth gate. Safe here because access is
+            # already gated at the network layer by Tailscale `tag:raj` ACL.
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: gateway
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              memory: 6Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: karthik-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      terminationGracePeriodSeconds: 30

--- a/clusters/talos-ottawa/apps/agents/app/karthik/garagekey.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/garagekey.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: karthik-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "karthik S3 Reader Key"
+  allBuckets:
+    read: true
+  secretTemplate:
+    name: karthik-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://garage.garage.svc.cluster.local:3900"
+      AWS_ENDPOINT_URL_S3: "http://garage.garage.svc.cluster.local:3900"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/clusters/talos-ottawa/apps/agents/app/karthik/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - deployment.yaml
+  - service.yaml
+  - service-tailscale.yaml
+  - storagestack.yaml
+  - garagekey.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/clusters/talos-ottawa/apps/agents/app/karthik/secret.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/secret.yaml
@@ -1,0 +1,14 @@
+---
+# Fill in real values then re-apply. Encrypt before committing real tokens:
+#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: karthik-secrets
+type: Opaque
+stringData:
+  # Discord disabled until a real token is provided.
+  # DISCORD_BOT_TOKEN: ""
+  GOOGLE_OAUTH_CLIENT_ID: ""
+  GOOGLE_OAUTH_CLIENT_SECRET: ""
+  NOTION_TOKEN: ""

--- a/clusters/talos-ottawa/apps/agents/app/karthik/service-tailscale.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/service-tailscale.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: karthik-ts
+  annotations:
+    tailscale.com/hostname: karthik
+    # Using tag:raj for now so the LB provisions immediately (tag:karthik does
+    # not exist in tailscale/policy.hujson yet). If Karthik should own/reach this
+    # independently of Raj, add `tag:karthik` to policy.hujson (tagOwners + an
+    # ACL grant for karthik's tailnet identity) and switch this to "tag:karthik".
+    tailscale.com/tags: "tag:raj"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: karthik
+  ports:
+    - name: dashboard
+      port: 80
+      targetPort: 9119
+      protocol: TCP
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP

--- a/clusters/talos-ottawa/apps/agents/app/karthik/service.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: karthik
+spec:
+  selector:
+    app.kubernetes.io/name: karthik
+  ports:
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: 9119
+      protocol: TCP

--- a/clusters/talos-ottawa/apps/agents/app/karthik/storagestack.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/karthik/storagestack.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: karthik-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: karthik-data
+  size: 20Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/karthik/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot

--- a/clusters/talos-ottawa/apps/agents/app/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/agents/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - bucket.yaml
   - assistant-raj
   - abtar
+  - karthik
   - camofox


### PR DESCRIPTION
## What
Adds a new per-user Hermes agent **karthik** to `clusters/talos-ottawa/apps/agents/app/`, cloned from the existing **abtar** persona. This is Karthik's own assistant — same shape as Abtar/assistant-raj.

## Objects (all render in `kustomize build --enable-helm`)
- Deployment `karthik` (image `nousresearch/hermes-agent:v2026.5.29`, gateway + dashboard + API)
- Service `karthik` (ClusterIP) + `karthik-ts` (Tailscale LoadBalancer)
- StorageStack `karthik-data` (20Gi ceph-block-replicated, nightly Garage backup, s3Path `agents/karthik/data`)
- GarageKey `karthik-s3-key` (+ added to `bucket.yaml` keyPermissions on the shared `agents` bucket)
- ConfigMap `karthik-config` + placeholder Secret `karthik-secrets`
- Registered `karthik` in `app/kustomization.yaml`

## ⚠️ Placeholders for Raj/Karthik to fill before it's fully live
1. **WhatsApp number** — `configmap.yaml` `WHATSAPP_ALLOWED_USERS: REPLACE_WITH_KARTHIK_PHONE` (E.164, digits only, no +).
2. **Secrets** — `secret.yaml` ships empty (Google OAuth / Notion). Fill real tokens then `sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml`.
3. **Tailscale tag/ownership** — kept as `tag:raj` so the LB provisions immediately. `tag:karthik` does **not** exist in `tailscale/policy.hujson` yet. If Karthik should own/reach this independently, add `tag:karthik` to policy.hujson (tagOwners + ACL grant for his tailnet identity) and switch the annotation in `service-tailscale.yaml`.
4. **LLM provider** — boots on the per-PVC config.yaml default. Set via `kubectl exec` into the pod after first reconcile (uses the shared `stpetersburg-vllm` ExternalName).
5. **WhatsApp pairing** — one-time post-reconcile: `kubectl exec -it deploy/karthik -c gateway -- /opt/hermes/.venv/bin/hermes whatsapp`.

## Validation
`KUBERNETES_VERSION=1.29.0 kustomize build --enable-helm clusters/talos-ottawa/apps/agents/app` → OK; all 7 karthik objects render (ConfigMap, Secret, 2x Service, Deployment, GarageKey, StorageStack).

Draft so you can follow along / supply the node-level + secret pieces. Not a cross-cluster infra change (normal ottawa app addition), so no robbinsdale canary needed.