### PR TITLE
border0: in-cluster connector (robbinsdale canary)

### DIFF
--- a/clusters/common/flux/repositories/helm/border0.yaml
+++ b/clusters/common/flux/repositories/helm/border0.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: border0
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://borderzero.github.io/helm-charts

--- a/clusters/common/flux/repositories/helm/kustomization.yaml
+++ b/clusters/common/flux/repositories/helm/kustomization.yaml
@@ -86,3 +86,4 @@ resources:
   - ./kro.yaml
   - ./ocm.yaml
   - ./valkey.yaml
+  - ./border0.yaml

--- a/clusters/talos-robbinsdale/apps/border0/app/helmrelease.yaml
+++ b/clusters/talos-robbinsdale/apps/border0/app/helmrelease.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: border0-connector
+  namespace: border0
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: border0-connector
+      version: 0.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: border0
+        namespace: flux-system
+      interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: ghcr.io/borderzero/border0
+      tag: latest
+      pullPolicy: Always
+    # api-admin grants the connector's ServiceAccount wildcard access to the
+    # kube-apiserver. Per-user authorization is enforced by Border0 policies in
+    # the admin portal (identity/context-aware), not by k8s RBAC.
+    # https://docs.border0.com/docs/kubernetes-api-sockets
+    rbac:
+      clusterRoleMode: api-admin
+    config:
+      # Invite code minted in the Border0 admin portal (Connectors page).
+      # The connector exchanges it for a token on first start and persists the
+      # token into a k8s Secret (token-persistence-mode=k8s-secret), so the
+      # invite is single-use and short-lived. Kept out of git via Flux var
+      # substitution from the cluster's SOPS secret (cluster-secrets).
+      inviteCode: ${BORDER0_INVITE_CODE}

--- a/clusters/talos-robbinsdale/apps/border0/app/helmrelease.yaml
+++ b/clusters/talos-robbinsdale/apps/border0/app/helmrelease.yaml
@@ -34,9 +34,29 @@ spec:
     rbac:
       clusterRoleMode: api-admin
     config:
-      # Invite code minted in the Border0 admin portal (Connectors page).
-      # The connector exchanges it for a token on first start and persists the
-      # token into a k8s Secret (token-persistence-mode=k8s-secret), so the
-      # invite is single-use and short-lived. Kept out of git via Flux var
-      # substitution from the cluster's SOPS secret (cluster-secrets).
-      inviteCode: ${BORDER0_INVITE_CODE}
+      # The durable connector token is NEVER stored in git. It lives only in the
+      # in-cluster Secret "border0-connector-config" (key: config.yaml), which is
+      # created out-of-band with kubectl (see below). We do NOT use Flux var
+      # substitution / SOPS for it.
+      #
+      # Why a placeholder inviteCode instead of leaving it empty:
+      #   This chart only mounts/reads the persisted-token Secret when inviteCode
+      #   is non-empty. With inviteCode set, the Deployment runs
+      #     connector start --invite=<x> --token-persistence-mode=k8s-secret \
+      #                     --k8s-secret=border0-connector-config
+      #   On start the connector reads the EXISTING token from that Secret and
+      #   uses it; the placeholder invite is only ever exchanged if the Secret has
+      #   no valid token. (Verified live on robbinsdale: a pre-seeded Secret +
+      #   placeholder invite loads the existing token, ignores the invite.)
+      #
+      # Onboarding a fresh connector (one-time, out-of-band):
+      #   1. Mint an invite in the Border0 portal (Connectors page).
+      #   2. Seed the token into the cluster WITHOUT going through git, either:
+      #      a. let the connector self-exchange once by temporarily running it
+      #         with the real invite, then it persists config.yaml itself; or
+      #      b. kubectl create secret generic border0-connector-config \
+      #           -n border0 --from-file=config.yaml=<file containing
+      #           'token: "<JWT>"' and 'device_state_path: /etc/border0-device/state.yaml'>
+      #   The Secret is intentionally unmanaged by Flux/Helm so it survives
+      #   reconciles and the token never lands in git.
+      inviteCode: "placeholder-token-persisted-in-k8s-secret"

--- a/clusters/talos-robbinsdale/apps/border0/app/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/border0/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/clusters/talos-robbinsdale/apps/border0/ks.yaml
+++ b/clusters/talos-robbinsdale/apps/border0/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app border0
+  namespace: flux-system
+spec:
+  targetNamespace: border0
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/${CLUSTER_NAME}/apps/border0/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-robbinsdale/apps/border0/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/border0/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ks.yaml

--- a/clusters/talos-robbinsdale/apps/border0/namespace.yaml
+++ b/clusters/talos-robbinsdale/apps/border0/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: border0
+  labels:
+    # privileged: the connector needs a TUN device (NET_ADMIN + /dev/net/tun)
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## What
Deploy the **Border0 connector in-cluster** on **robbinsdale** (canary) via the official Helm chart, so we can expose the kube-apiserver as a Border0 Kubernetes socket.

## Changes
- **New HelmRepository** source `border0` -> https://borderzero.github.io/helm-charts.
- **ns `border0`** — PSA `privileged` (connector needs a TUN device: NET_ADMIN + /dev/net/tun).
- **HelmRelease `border0-connector`** (chart 0.6.0):
  - `rbac.clusterRoleMode: api-admin` -> connector SA gets wildcard kube-apiserver access; **per-user authz is enforced by Border0 policies** in the portal, not k8s RBAC.
  - `config.inviteCode: \${BORDER0_INVITE_CODE}` -> Flux var-sub from robbinsdale `cluster-secrets` (SOPS). Connector exchanges the invite for a token on first boot and **persists it to an in-cluster Secret** (invite is single-use).
- Chart owns SA/ClusterRole/bindings + secret-manager Role, so the earlier hand-written `rbac.yaml` is dropped.

## Follow-ups (NOT in this PR)
- [ ] **`BORDER0_INVITE_CODE` -> robbinsdale `cluster-secrets.sops.yaml`** before reconcile (needs PGP key — Raj).
- [ ] Create the **Kubernetes API socket** in the Border0 portal targeting this connector.
- [ ] **Ottawa** connector in a separate follow-up PR once robbinsdale is proven.

## Validation
`kustomize build --enable-helm` passes for app dir, ks wrapper, and helm-repos dir.