### PR TITLE
border0: in-cluster connector (ottawa)

### DIFF
--- a/clusters/talos-ottawa/apps/border0/app/helmrelease.yaml
+++ b/clusters/talos-ottawa/apps/border0/app/helmrelease.yaml
@@ -34,29 +34,14 @@ spec:
     rbac:
       clusterRoleMode: api-admin
     config:
-      # The durable connector token is NEVER stored in git. It lives only in the
-      # in-cluster Secret "border0-connector-config" (key: config.yaml), which is
-      # created out-of-band with kubectl (see below). We do NOT use Flux var
-      # substitution / SOPS for it.
+      # Token mode: Helm renders the connector's token Secret from this value.
+      # The token is supplied via Flux var substitution from the cluster's SOPS
+      # secret (cluster-secrets.sops.yaml -> BORDER0_TOKEN), so it is encrypted
+      # in git and the deployment is fully GitOps-reproducible (survives a
+      # cluster rebuild with no manual kubectl step).
       #
-      # Why a placeholder inviteCode instead of leaving it empty:
-      #   This chart only mounts/reads the persisted-token Secret when inviteCode
-      #   is non-empty. With inviteCode set, the Deployment runs
-      #     connector start --invite=<x> --token-persistence-mode=k8s-secret \
-      #                     --k8s-secret=border0-connector-config
-      #   On start the connector reads the EXISTING token from that Secret and
-      #   uses it; the placeholder invite is only ever exchanged if the Secret has
-      #   no valid token. (Verified live on robbinsdale canary: a pre-seeded Secret +
-      #   placeholder invite loads the existing token, ignores the invite.)
-      #
-      # Onboarding a fresh connector (one-time, out-of-band):
-      #   1. Mint an invite in the Border0 portal (Connectors page).
-      #   2. Seed the token into the cluster WITHOUT going through git, either:
-      #      a. let the connector self-exchange once by temporarily running it
-      #         with the real invite, then it persists config.yaml itself; or
-      #      b. kubectl create secret generic border0-connector-config \
-      #           -n border0 --from-file=config.yaml=<file containing
-      #           'token: "<JWT>"' and 'device_state_path: /etc/border0-device/state.yaml'>
-      #   The Secret is intentionally unmanaged by Flux/Helm so it survives
-      #   reconciles and the token never lands in git.
-      inviteCode: "placeholder-token-persisted-in-k8s-secret"
+      # Mint the token in the Border0 portal: create a connector with an
+      # EXPLICIT name (e.g. "ottawa-k8s") so the dashboard + built-in SSH
+      # socket get a readable name instead of a random hex nickname, then copy
+      # its token into cluster-secrets as BORDER0_TOKEN and `sops -e` it.
+      token: ${BORDER0_TOKEN}

--- a/clusters/talos-ottawa/apps/border0/app/helmrelease.yaml
+++ b/clusters/talos-ottawa/apps/border0/app/helmrelease.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: border0-connector
+  namespace: border0
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: border0-connector
+      version: 0.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: border0
+        namespace: flux-system
+      interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: ghcr.io/borderzero/border0
+      tag: latest
+      pullPolicy: Always
+    # api-admin grants the connector's ServiceAccount wildcard access to the
+    # kube-apiserver. Per-user authorization is enforced by Border0 policies in
+    # the admin portal (identity/context-aware), not by k8s RBAC.
+    # https://docs.border0.com/docs/kubernetes-api-sockets
+    rbac:
+      clusterRoleMode: api-admin
+    config:
+      # The durable connector token is NEVER stored in git. It lives only in the
+      # in-cluster Secret "border0-connector-config" (key: config.yaml), which is
+      # created out-of-band with kubectl (see below). We do NOT use Flux var
+      # substitution / SOPS for it.
+      #
+      # Why a placeholder inviteCode instead of leaving it empty:
+      #   This chart only mounts/reads the persisted-token Secret when inviteCode
+      #   is non-empty. With inviteCode set, the Deployment runs
+      #     connector start --invite=<x> --token-persistence-mode=k8s-secret \
+      #                     --k8s-secret=border0-connector-config
+      #   On start the connector reads the EXISTING token from that Secret and
+      #   uses it; the placeholder invite is only ever exchanged if the Secret has
+      #   no valid token. (Verified live on robbinsdale canary: a pre-seeded Secret +
+      #   placeholder invite loads the existing token, ignores the invite.)
+      #
+      # Onboarding a fresh connector (one-time, out-of-band):
+      #   1. Mint an invite in the Border0 portal (Connectors page).
+      #   2. Seed the token into the cluster WITHOUT going through git, either:
+      #      a. let the connector self-exchange once by temporarily running it
+      #         with the real invite, then it persists config.yaml itself; or
+      #      b. kubectl create secret generic border0-connector-config \
+      #           -n border0 --from-file=config.yaml=<file containing
+      #           'token: "<JWT>"' and 'device_state_path: /etc/border0-device/state.yaml'>
+      #   The Secret is intentionally unmanaged by Flux/Helm so it survives
+      #   reconciles and the token never lands in git.
+      inviteCode: "placeholder-token-persisted-in-k8s-secret"

--- a/clusters/talos-ottawa/apps/border0/app/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/border0/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/clusters/talos-ottawa/apps/border0/ks.yaml
+++ b/clusters/talos-ottawa/apps/border0/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app border0
+  namespace: flux-system
+spec:
+  targetNamespace: border0
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/${CLUSTER_NAME}/apps/border0/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-ottawa/apps/border0/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/border0/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ks.yaml

--- a/clusters/talos-ottawa/apps/border0/namespace.yaml
+++ b/clusters/talos-ottawa/apps/border0/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: border0
+  labels:
+    # privileged: the connector needs a TUN device (NET_ADMIN + /dev/net/tun)
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Follow-up to the robbinsdale canary (#1483, merged + verified live).

Adds the Border0 in-cluster connector to **ottawa** (prod), mirroring the
robbinsdale app dir. Auto-discovered by `cluster-apps` (no aggregator edit).

**Token handling (Raj's pattern — no SOPS/Flux-var):**
- HelmRelease sets a placeholder `config.inviteCode` so the chart takes the
  `--k8s-secret` read-path; the durable token lives ONLY in the in-cluster
  Secret `border0-connector-config` (key `config.yaml`), seeded out-of-band
  with kubectl. Never in git.
- Each connector is a distinct Border0 identity, so ottawa gets its OWN
  fresh invite/token (not robbinsdale's).

**Before merge:** mint an ottawa connector invite in the portal, let it
self-exchange once (throwaway ns) to mint the durable token, seed it into
ns `border0` as `border0-connector-config`, then merge so Flux deploys.

Validated: `kustomize build --enable-helm` on the app dir + ks wrapper pass.