### PR TITLE
agents: Firecrawl self-hosted canary (Ottawa)

### DIFF
--- a/clusters/common/flux/repositories/git/firecrawl.yaml
+++ b/clusters/common/flux/repositories/git/firecrawl.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: firecrawl
+  namespace: flux-system
+spec:
+  interval: 30m
+  url: https://github.com/firecrawl/firecrawl
+  ref:
+    # Pin to a release tag for reproducible manifests. NOTE: upstream only
+    # publishes `latest` (+ arch buildcache) container tags -- no semver image
+    # tags exist -- so the running image floats at :latest regardless of this
+    # pin. This pins the manifest *shape* (deploys/services/config), not the
+    # image. Bump deliberately and re-verify health when moving this tag.
+    tag: v3.0.0
+  ignore: |
+    # only need the simple cluster-install example manifests
+    /*
+    !/examples/kubernetes/cluster-install

--- a/clusters/common/flux/repositories/git/kustomization.yaml
+++ b/clusters/common/flux/repositories/git/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - bitbucket-ssh-secret.sops.yaml
   - garage.yaml
   - csi-addons.yaml
+  - firecrawl.yaml

--- a/clusters/talos-ottawa/apps/firecrawl/ks.yaml
+++ b/clusters/talos-ottawa/apps/firecrawl/ks.yaml
@@ -1,0 +1,45 @@
+---
+# Firecrawl (self-hosted web scrape/extract) -- CANARY.
+# Upstream "simple" cluster-install manifests pulled straight from the firecrawl
+# repo at a pinned tag (see clusters/common/flux/repositories/git/firecrawl.yaml).
+# No kustomization.yaml exists in that upstream dir, so Flux auto-generates one
+# and builds every manifest there: api, worker, nuq-worker, nuq-postgres, redis,
+# playwright-service, configmap, secret.
+#
+# Notes:
+#  - nuq-postgres uses an emptyDir (ephemeral queue state) -- fine for a canary.
+#  - upstream secret.yaml ships empty values (no LLM key etc). Scrape->markdown
+#    works without them; only schema/LLM-extract features need OPENAI_API_KEY.
+#  - imagePullSecret `docker-registry-secret` is referenced but unneeded: the
+#    ghcr.io/firecrawl images are public and pull anonymously.
+#  - same-cluster: Hermes (agents ns) reaches this over the ClusterIP `api`
+#    svc, exactly like it reaches searxng. No tailscale LB needed.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firecrawl
+  namespace: flux-system
+spec:
+  targetNamespace: firecrawl
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./examples/kubernetes/cluster-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: firecrawl
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  patches:
+    # Upstream ships nuq-worker at replicas: 5 (~15G mem requests). Way too heavy
+    # for a canary -- trim to 1. Bump later if throughput needs it.
+    - target:
+        kind: Deployment
+        name: nuq-worker
+      patch: |-
+        - op: replace
+          path: /spec/replicas
+          value: 1

--- a/clusters/talos-ottawa/apps/firecrawl/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/firecrawl/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ks.yaml

--- a/clusters/talos-ottawa/apps/firecrawl/namespace.yaml
+++ b/clusters/talos-ottawa/apps/firecrawl/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: firecrawl
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## What
Self-host **Firecrawl** in the Ottawa cluster as a web **extract** backend for the Hermes agents. SearXNG (our current web backend) is search-only and cannot extract URL content. Firecrawl is already a native Hermes extract_backend, so wiring is just a base-URL flip once it's healthy.

## How (no vendoring)
- GitRepository source pinned to upstream tag v3.0.0, ignore rules pull ONLY examples/kubernetes/cluster-install -- no vendored lines.
- Flux Kustomization in talos-ottawa builds the upstream simple stack: api, worker, nuq-worker, nuq-postgres, redis, playwright-service.
- Flux auto-generates the kustomization over the upstream dir (same trick as the existing csi-addons source).

## Canary trims
- nuq-worker 5 -> 1 replica via Flux patch (upstream 5x3G ~= 15G mem is too heavy for canary).
- Same-cluster: agents reach it over ClusterIP api svc (port 3002), like SearXNG. No tailscale LB.

## Why Ottawa (not robbinsdale)
Per your steer -- agent pods live in Ottawa, so co-locating avoids a cross-cluster hop. Brand-new isolated namespace, additive, touches no existing workloads.

## Caveats
- Images float at :latest (upstream publishes no semver image tags); git tag pins manifest shape, not image.
- nuq-postgres uses emptyDir (ephemeral) -- fine for canary.
- Self-host has no Fire-engine (anti-bot/proxy); normal sites scrape fine.

## Follow-up (separate change)
Once api pods are healthy + a test scrape returns markdown, flip Hermes web.extract_backend=firecrawl + base URL http://api.firecrawl.svc.cluster.local:3002 and restart gateway.

## Validation
- kubectl kustomize builds app dir + git-repos dir clean.
- Simulated Flux auto-kustomization of upstream path -> all 8 manifests render; patch target (Deployment/nuq-worker) confirmed vs upstream replicas:5.