### PR TITLE
garage(stpetersburg): decouple storage to per-spark GarageNode CRs (Manual)

### DIFF
--- a/clusters/common/apps/garage/app/garagecluster.yaml
+++ b/clusters/common/apps/garage/app/garagecluster.yaml
@@ -89,6 +89,14 @@ spec:
   # Storage tier — persistent identity in metadata PVC; data PVC holds blocks.
   storage:
     replicas: ${GARAGE_REPLICAS:=1}
+    # Per-tier layout ownership (operator v0.6.11+). Default Auto: the operator
+    # generates and owns one storage GarageNode per replica. A region can set
+    # GARAGE_STORAGE_LAYOUT_POLICY=Manual in its cluster-settings to hand-manage
+    # storage GarageNode CRs in gitops (e.g. stpetersburg's per-spark storage
+    # arrays under clusters/talos-stpetersburg/apps/garage) while the GATEWAY
+    # tier stays operator-managed. Auto->Manual is one-way (operator ejects its
+    # storage nodes; Manual->Auto is rejected by the webhook).
+    layoutPolicy: "${GARAGE_STORAGE_LAYOUT_POLICY:=Auto}"
     metadata:
       size: 3Gi
       storageClassName: "${STORAGECLASS_METADATA}"

--- a/clusters/talos-stpetersburg/apps/garage/ks.yaml
+++ b/clusters/talos-stpetersburg/apps/garage/ks.yaml
@@ -1,0 +1,29 @@
+---
+# Per-location (decoupled) storage layout for stpetersburg. The GarageCluster CR
+# still comes from clusters/common (federation, gateway tier, replication), but
+# its storage layout is Manual here (GARAGE_LAYOUT_POLICY=Manual in
+# cluster-settings) and the storage GarageNodes are hand-authored per Spark node
+# below, so each Spark can carry its own heterogeneous storage array.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-nodes
+  namespace: flux-system
+spec:
+  # The GarageCluster CR + operator must exist (and be Manual) before the
+  # per-node GarageNodes are applied.
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/talos-stpetersburg/apps/garage/nodes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-stpetersburg/apps/garage/nodes/garage-storage-0.yaml
+++ b/clusters/talos-stpetersburg/apps/garage/nodes/garage-storage-0.yaml
@@ -1,0 +1,29 @@
+---
+# Spark-0 storage node. Binds the existing metadata + data PVCs via existingClaim
+# so the node_key (and thus the Garage node identity 5b58bb8e…) and all data are
+# preserved across the Auto->Manual migration. local-path PV node-affinity pins
+# this to spark-0; the storage-tier PodTemplate (dgx-spark nodeSelector +
+# topology spread) is inherited from the GarageCluster CR.
+#
+# This is the per-Spark "storage array" hook: add spec.storage.dataPaths[] here to
+# describe a multi-disk array on spark-0 without touching the other Spark or the
+# common cluster config.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: garage-storage-0
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: 5b58bb8e679ba9689288b12814e788b5ec8f5217a9bb556d175e33de35762e66
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-0-0
+  storage:
+    metadata:
+      existingClaim: metadata-garage-0
+    data:
+      existingClaim: data-garage-0

--- a/clusters/talos-stpetersburg/apps/garage/nodes/garage-storage-1.yaml
+++ b/clusters/talos-stpetersburg/apps/garage/nodes/garage-storage-1.yaml
@@ -1,0 +1,26 @@
+---
+# Spark-1 storage node. Binds the existing metadata + data PVCs via existingClaim
+# so the node_key (Garage node identity f863543b…) and all data survive the
+# Auto->Manual migration. local-path PV node-affinity pins this to spark-1.
+#
+# Add spec.storage.dataPaths[] here to describe a multi-disk array on spark-1
+# independently of spark-0.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: garage-storage-1
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: f863543b50d70a7b516c3092520908f90162720a82fd6a5ccfe06069ef0c82b7
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-1-0
+  storage:
+    metadata:
+      existingClaim: metadata-garage-1
+    data:
+      existingClaim: data-garage-1

--- a/clusters/talos-stpetersburg/apps/garage/nodes/kustomization.yaml
+++ b/clusters/talos-stpetersburg/apps/garage/nodes/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - garage-storage-0.yaml
+  - garage-storage-1.yaml

--- a/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
@@ -40,7 +40,14 @@ data:
   # one value to repoint every app — all S3 clients use ${COMMON_S3_ENDPOINT}.
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
 
-  # Garage: run one storage replica per Spark (excludes orin-0).
+  # Garage: STORAGE layout is hand-managed per Spark node via GarageNode CRs in
+  # clusters/talos-stpetersburg/apps/garage (decoupled from clusters/common so
+  # each Spark can carry its own heterogeneous storage array). Per-tier Manual
+  # stops the operator from generating/owning storage GarageNodes here; the
+  # GATEWAY tier stays operator-managed (Auto). The cluster CR (federation,
+  # gateway tier, replication) still comes from common. Requires operator
+  # v0.6.11+ (spec.storage.layoutPolicy).
+  GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
   GARAGE_REPLICAS: "2"
   GARAGE_NODE_SELECTOR: '{"node.kubernetes.io/instance-type":"dgx-spark"}'
   GARAGE_TOPOLOGY_SPREAD: '[{"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"DoNotSchedule","labelSelector":{"matchLabels":{"app.kubernetes.io/name":"garage"}}}]'


### PR DESCRIPTION
Decouples stpetersburg's Garage **storage** layout from `clusters/common` into per-location, hand-managed GarageNode CRs — one per Spark node — so each Spark can carry its own heterogeneous storage array. The gateway tier stays operator-managed (Auto).

## Changes
- `clusters/common/apps/garage/app/garagecluster.yaml`: `spec.storage.layoutPolicy` is now substitutable via `GARAGE_STORAGE_LAYOUT_POLICY` (default `Auto`). Per-tier — only storage is affected; the gateway tier follows the cluster policy.
- `clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml`: `GARAGE_STORAGE_LAYOUT_POLICY: Manual`.
- `clusters/talos-stpetersburg/apps/garage/`: `garage-storage-0` (spark-0) + `garage-storage-1` (spark-1) GarageNode CRs binding the existing PVCs via `existingClaim` (preserves `node_key` identity + data — **zero diff** against the live operator-generated nodes, verified with `kubectl diff`), plus a `garage-nodes` Flux Kustomization.

## ⚠️ MERGE ORDER (required)
The operator must understand `spec.storage.layoutPolicy` first:
1. Release **garage-operator** with rajsinghtech/garage-operator#229 (adds per-tier `spec.storage.layoutPolicy`).
2. Bump the `garage-operator` HelmRelease (`clusters/common/apps/garage-operator-system`) to that version.
3. **Then** merge this PR.

Merging before the operator/CRD upgrade would prune `spec.storage.layoutPolicy` (old CRD) and leave storage in Auto, conflicting with these GarageNode CRs. On a correctly-ordered merge the transition is non-disruptive: the operator ejects its storage GarageNodes (controllerRef/label dropped, pods keep running) and Flux adopts the identical hand-written CRs.