### PR TITLE
garage(ottawa,robbinsdale): per-tier Manual storage + descriptive GarageNode CRs

### DIFF
--- a/clusters/common/apps/garage-operator-system/install/helmrelease.yaml
+++ b/clusters/common/apps/garage-operator-system/install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.6.11"
+      version: "0.6.12"
       sourceRef:
         kind: HelmRepository
         name: garage-operator

--- a/clusters/talos-ottawa/apps/garage/ks.yaml
+++ b/clusters/talos-ottawa/apps/garage/ks.yaml
@@ -40,3 +40,29 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+# Per-location hand-managed storage GarageNode CRs (Manual). The cluster CR
+# (from clusters/common) is per-tier Manual for storage via
+# GARAGE_STORAGE_LAYOUT_POLICY, so the operator ejects its Auto storage node and
+# these take over. Gateway tier stays Auto.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-nodes
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/${CLUSTER_NAME}/apps/garage/nodes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-ottawa/apps/garage/nodes/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ottawa-garage-smb.yaml

--- a/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-smb.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-smb.yaml
@@ -1,0 +1,30 @@
+---
+# Ottawa storage node, hand-managed (Manual). Data lives on SMB (schedulable,
+# node-fault-tolerant) and metadata on ceph-block-replicated — so the pod is
+# free to reschedule; no node pin. Named by the data backend (smb). Binds the
+# existing PVCs via existingClaim so node_key identity (Garage NodeID
+# 9107ef0e…) and all data are preserved across the Auto->Manual rename.
+#
+# spec.tags keep the EXACT existing layout-role tags (including the legacy
+# pod-name tag) so the rejoin is a zero-churn no-op (no layout version bump).
+# To move this array off SMB later, add a new node (e.g. ottawa-garage-cephrbd),
+# let it sync, then drain+remove this one.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: ottawa-garage-smb
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: 9107ef0ef2600c5d9968998c62f9954e8de419ab943d9476f142c86aef72390f
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-0-0
+  storage:
+    metadata:
+      existingClaim: metadata-garage-0
+    data:
+      existingClaim: data-garage-0

--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -40,5 +40,10 @@ data:
   # one value to repoint every app — all S3 clients use ${COMMON_S3_ENDPOINT}.
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
 
+  # Garage: storage layout hand-managed per-node in clusters/talos-ottawa/apps/garage
+  # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
+  # tier stays operator-managed (Auto). Requires operator v0.6.11+.
+  GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
+
   # Garage: exclude asuka from gateway scheduling (SIGILL on that node)
   GARAGE_GATEWAY_AFFINITY: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"NotIn","values":["asuka"]}]}]}}}'

--- a/clusters/talos-robbinsdale/apps/garage/ks.yaml
+++ b/clusters/talos-robbinsdale/apps/garage/ks.yaml
@@ -18,3 +18,29 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+# Per-location hand-managed storage GarageNode CRs (Manual). The cluster CR
+# (from clusters/common) is per-tier Manual for storage via
+# GARAGE_STORAGE_LAYOUT_POLICY, so the operator ejects its Auto storage node and
+# these take over. Gateway tier stays Auto.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-nodes
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/${CLUSTER_NAME}/apps/garage/nodes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/clusters/talos-robbinsdale/apps/garage/nodes/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/garage/nodes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - robbinsdale-garage-smb.yaml

--- a/clusters/talos-robbinsdale/apps/garage/nodes/robbinsdale-garage-smb.yaml
+++ b/clusters/talos-robbinsdale/apps/garage/nodes/robbinsdale-garage-smb.yaml
@@ -8,6 +8,16 @@
 # spec.tags keep the EXACT existing layout-role tags (including the legacy
 # pod-name tag) so the rejoin is a zero-churn no-op. To move this array off SMB
 # later, add a new node (e.g. robbinsdale-garage-cephrbd), sync, then drain.
+#
+# STAGED CUTOVER (created suspended): metadata is on local-path (RWO is NOT
+# kernel-enforced for two pods on the same node), so spawning this node's STS
+# while the old garage-storage-0 still mounts metadata-garage-0 on node `stone`
+# would risk two Garage processes opening the same node_key concurrently. So
+# this CR ships suspended (no STS/pod). Runbook: (1) delete the ejected
+# garage-storage-0, (2) wait for its pod + volumes to release, (3) remove the
+# maintenance block below so the operator brings this node up on the freed PVCs.
+# (ottawa's metadata is on ceph CSI, which Multi-Attach-blocks the handoff, so
+# ottawa-garage-smb needs no staging.)
 apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageNode
 metadata:
@@ -15,6 +25,8 @@ metadata:
 spec:
   clusterRef:
     name: garage
+  maintenance:
+    suspended: true
   zone: "${LOCATION}"
   capacity: 2Ti
   nodeId: 62b5e2ddcba5261e9b6ce201039d93bc4411d53810869bcc55ab1f267e505bb4

--- a/clusters/talos-robbinsdale/apps/garage/nodes/robbinsdale-garage-smb.yaml
+++ b/clusters/talos-robbinsdale/apps/garage/nodes/robbinsdale-garage-smb.yaml
@@ -1,0 +1,29 @@
+---
+# Robbinsdale storage node, hand-managed (Manual). Data lives on SMB; metadata
+# on local-path (node-pinned to its current node until metadata moves to ceph),
+# so the pod is effectively pinned for now. Named by the data backend (smb).
+# Binds the existing PVCs via existingClaim so node_key identity (Garage NodeID
+# 62b5e2dd…) and all data are preserved across the Auto->Manual rename.
+#
+# spec.tags keep the EXACT existing layout-role tags (including the legacy
+# pod-name tag) so the rejoin is a zero-churn no-op. To move this array off SMB
+# later, add a new node (e.g. robbinsdale-garage-cephrbd), sync, then drain.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: robbinsdale-garage-smb
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: 62b5e2ddcba5261e9b6ce201039d93bc4411d53810869bcc55ab1f267e505bb4
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-0-0
+  storage:
+    metadata:
+      existingClaim: metadata-garage-0
+    data:
+      existingClaim: data-garage-0

--- a/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
@@ -40,4 +40,9 @@ data:
   # one value to repoint every app — all S3 clients use ${COMMON_S3_ENDPOINT}.
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
 
+  # Garage: storage layout hand-managed per-node in clusters/talos-robbinsdale/apps/garage
+  # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
+  # tier stays operator-managed (Auto). Requires operator v0.6.11+.
+  GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
+
   GARAGE_GATEWAY_AFFINITY: '{}'


### PR DESCRIPTION
Migrates ottawa + robbinsdale storage to the per-node **Manual** model (matching stpetersburg) so each region's storage array can move off SMB to **ceph/local-path per node**. Gateway tier stays operator-managed (Auto), via per-tier `spec.storage.layoutPolicy` (operator v0.6.11+, already deployed).

## Changes
- `cluster-settings`: `GARAGE_STORAGE_LAYOUT_POLICY=Manual` (storage tier only).
- `apps/garage/ks.yaml`: add a `garage-nodes` Flux Kustomization (`dependsOn: garage`, `targetNamespace: garage`).
- `apps/garage/nodes/`: `ottawa-garage-smb` / `robbinsdale-garage-smb` GarageNode CRs (named by data backend — SMB is schedulable/node-fault-tolerant, so no node suffix). Bind existing PVCs via `existingClaim` (preserves `node_key` identity + data) with the **exact existing layout-role tags** for a zero-churn rejoin.

## Live cutover (manual, one region at a time — NOT automated by merge)
Merging sets Manual (operator ejects its Auto `garage-storage-0`, keeps it running) and creates the descriptive node `Pending` (RWO PVC still held). To complete:
1. Confirm `spec.storage.pvcRetentionPolicy` is Retain (default) — the only data-loss guard.
2. `kubectl patch garagenode garage-storage-0 --type=merge -p '{"metadata":{"finalizers":[]}}'` (skip the finalizer's layout-role removal), then `kubectl delete garagenode garage-storage-0`.
3. Old pod releases the RWO PVCs → descriptive node binds, reads the same `node_key`, rejoins its existing layout role. **No data movement** (partition assignment is zone+capacity only; verified vs upstream Garage). Brief write-availability dip on that single-storage-node region during the swap — covered by factor-2 replicas in the other zones; **no data loss**.

Verify health before the next region.