### PR TITLE
plex: fix transcode OOM — move scratch from RAM tmpfs to node disk

### DIFF
--- a/clusters/talos-robbinsdale/apps/media/app/plex/app.yaml
+++ b/clusters/talos-robbinsdale/apps/media/app/plex/app.yaml
@@ -65,8 +65,7 @@ spec:
             claimName: media-share
         - name: transcode
           emptyDir:
-            medium: Memory
-            sizeLimit: 6Gi
+            sizeLimit: 32Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The /transcode emptyDir used `medium: Memory` (tmpfs), so transcode scratch counted against the container's 8Gi memory cgroup. During a transcode the readahead buffer + EasyAudioEncoder WAV temp filled tmpfs, pushed the cgroup past 8Gi, and the kernel OOM-killed the transcoder subprocess (exit signal -9). PID 1 survived so the pod looked healthy, but clients got "Transcode runner appears to have died" → 404 on the next segment → s1001 (Network) playback errors. Direct-play files were unaffected, which is why only some videos failed.

Switch to a node-local disk-backed emptyDir (no medium) so scratch no longer competes with process RAM. Plex floats across stone/tank/titan (no node pinning), and titan only has 29Gi RAM, so a disk-backed dir is the only option that's uniformly safe wherever it schedules. sizeLimit raised 6Gi -> 32Gi; node ephemeral disk is ~897Gi on all nodes so this is ~3.5% and never network-replicated.