### PR TITLE
network: all four domains on every gateway at every location

### DIFF
--- a/clusters/common/apps/home/local-gateway/external-dns-unifi.yaml
+++ b/clusters/common/apps/home/local-gateway/external-dns-unifi.yaml
@@ -83,7 +83,10 @@ spec:
       - gateway-udproute
       - service
     domainFilters:
-      - ${CLUSTER_DOMAIN}
+      - killinit.cc
+      - lukehouge.com
+      - rajsingh.info
+      - keiretsu.top
       - killinit.internal
       - stpetersburg.internal
       - robbinsdale.internal

--- a/clusters/common/apps/home/local-gateway/gateway-private.yaml
+++ b/clusters/common/apps/home/local-gateway/gateway-private.yaml
@@ -15,10 +15,10 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - name: wildcard-${CLUSTER_DOMAIN//./-}-https
+    - name: wildcard-killinit-cc-https
       protocol: HTTPS
       port: 443
-      hostname: "*.${CLUSTER_DOMAIN}"
+      hostname: "*.killinit.cc"
       allowedRoutes:
         namespaces:
           from: All
@@ -27,11 +27,11 @@ spec:
         certificateRefs:
         - group: ''
           kind: Secret
-          name: wildcard-${CLUSTER_DOMAIN//./-}
-    - name: wildcard-${COMMON_DOMAIN//./-}-https
+          name: wildcard-killinit-cc
+    - name: wildcard-lukehouge-com-https
       protocol: HTTPS
       port: 443
-      hostname: "*.${COMMON_DOMAIN}"
+      hostname: "*.lukehouge.com"
       allowedRoutes:
         namespaces:
           from: All
@@ -40,7 +40,46 @@ spec:
         certificateRefs:
         - group: ''
           kind: Secret
-          name: wildcard-${COMMON_DOMAIN//./-}
+          name: wildcard-lukehouge-com
+    - name: wildcard-rajsingh-info-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.rajsingh.info"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-rajsingh-info
+    - name: wildcard-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
     - name: forgejo-ssh
       protocol: TCP
       port: 22
@@ -64,16 +103,3 @@ spec:
         - kind: TCPRoute
         namespaces:
           from: All
-    - name: ${COMMON_DOMAIN//./-}-https
-      protocol: HTTPS
-      port: 443
-      hostname: "${COMMON_DOMAIN}"
-      allowedRoutes:
-        namespaces:
-          from: All
-      tls:
-        mode: Terminate
-        certificateRefs:
-        - group: ''
-          kind: Secret
-          name: wildcard-${COMMON_DOMAIN//./-}

--- a/clusters/common/apps/home/local-gateway/gateway-public.yaml
+++ b/clusters/common/apps/home/local-gateway/gateway-public.yaml
@@ -16,10 +16,10 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - name: wildcard-${CLUSTER_DOMAIN//./-}-https
+    - name: wildcard-killinit-cc-https
       protocol: HTTPS
       port: 443
-      hostname: "*.${CLUSTER_DOMAIN}"
+      hostname: "*.killinit.cc"
       allowedRoutes:
         namespaces:
           from: All
@@ -28,11 +28,11 @@ spec:
         certificateRefs:
         - group: ''
           kind: Secret
-          name: wildcard-${CLUSTER_DOMAIN//./-}
-    - name: wildcard-${COMMON_DOMAIN//./-}-https
+          name: wildcard-killinit-cc
+    - name: wildcard-lukehouge-com-https
       protocol: HTTPS
       port: 443
-      hostname: "*.${COMMON_DOMAIN}"
+      hostname: "*.lukehouge.com"
       allowedRoutes:
         namespaces:
           from: All
@@ -41,11 +41,50 @@ spec:
         certificateRefs:
         - group: ''
           kind: Secret
-          name: wildcard-${COMMON_DOMAIN//./-}
-    - name: wildcard-agents-${COMMON_DOMAIN//./-}-https
+          name: wildcard-lukehouge-com
+    - name: wildcard-rajsingh-info-https
       protocol: HTTPS
       port: 443
-      hostname: "*.agents.${COMMON_DOMAIN}"
+      hostname: "*.rajsingh.info"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-rajsingh-info
+    - name: wildcard-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: wildcard-agents-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.agents.keiretsu.top"
       allowedRoutes:
         namespaces:
           from: All
@@ -55,19 +94,6 @@ spec:
         - group: ''
           kind: Secret
           name: wildcard-agents-${COMMON_DOMAIN//./-}
-    - name: ${COMMON_DOMAIN//./-}-https
-      protocol: HTTPS
-      port: 443
-      hostname: "${COMMON_DOMAIN}"
-      allowedRoutes:
-        namespaces:
-          from: All
-      tls:
-        mode: Terminate
-        certificateRefs:
-        - group: ''
-          kind: Secret
-          name: wildcard-${COMMON_DOMAIN//./-}
     - name: wildcard-cdn-keiretsu-top-https
       protocol: HTTPS
       port: 443

--- a/clusters/common/apps/home/tailscale-gateway/certificate-wildcard.yaml
+++ b/clusters/common/apps/home/tailscale-gateway/certificate-wildcard.yaml
@@ -2,15 +2,15 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: wildcard-${CLUSTER_DOMAIN//./-}
+  name: wildcard-killinit-cc
 spec:
   dnsNames:
-    - '*.${CLUSTER_DOMAIN}'
+    - '*.killinit.cc'
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: ${CLUSTER_DOMAIN//./-}
-  secretName: wildcard-${CLUSTER_DOMAIN//./-}
+    name: killinit-cc
+  secretName: wildcard-killinit-cc
   usages:
     - digital signature
     - key encipherment
@@ -18,16 +18,48 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: wildcard-${COMMON_DOMAIN//./-}
+  name: wildcard-lukehouge-com
 spec:
   dnsNames:
-    - '*.${COMMON_DOMAIN}'
-    - '${COMMON_DOMAIN}'
+    - '*.lukehouge.com'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: lukehouge-com
+  secretName: wildcard-lukehouge-com
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-rajsingh-info
+spec:
+  dnsNames:
+    - '*.rajsingh.info'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: rajsingh-info
+  secretName: wildcard-rajsingh-info
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-keiretsu-top
+spec:
+  dnsNames:
+    - '*.keiretsu.top'
+    - 'keiretsu.top'
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
     name: keiretsu-top
-  secretName: wildcard-${COMMON_DOMAIN//./-}
+  secretName: wildcard-keiretsu-top
   usages:
     - digital signature
     - key encipherment

--- a/clusters/common/apps/home/tailscale-gateway/external-dns.yaml
+++ b/clusters/common/apps/home/tailscale-gateway/external-dns.yaml
@@ -44,7 +44,9 @@ spec:
       - gateway-udproute
       - service
     domainFilters:
-      - ${CLUSTER_DOMAIN}
-      - ${COMMON_DOMAIN}
+      - killinit.cc
+      - lukehouge.com
+      - rajsingh.info
+      - keiretsu.top
     txtOwnerId: ${LOCATION}-${CLUSTER_DOMAIN//./-}
     txtPrefix: k8s.${LOCATION}.

--- a/clusters/common/apps/home/tailscale-gateway/gateway.yaml
+++ b/clusters/common/apps/home/tailscale-gateway/gateway.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   gatewayClassName: home-ts
   listeners:
-    - name: wildcard-${CLUSTER_DOMAIN//./-}-https
+    - name: wildcard-killinit-cc-https
       protocol: HTTPS
       port: 443
-      hostname: "*.${CLUSTER_DOMAIN}"
+      hostname: "*.killinit.cc"
       allowedRoutes:
         namespaces:
           from: All
@@ -20,11 +20,11 @@ spec:
         certificateRefs:
         - group: ''
           kind: Secret
-          name: wildcard-${CLUSTER_DOMAIN//./-}
-    - name: wildcard-${COMMON_DOMAIN//./-}-https
+          name: wildcard-killinit-cc
+    - name: wildcard-lukehouge-com-https
       protocol: HTTPS
       port: 443
-      hostname: "*.${COMMON_DOMAIN}"
+      hostname: "*.lukehouge.com"
       allowedRoutes:
         namespaces:
           from: All
@@ -33,7 +33,46 @@ spec:
         certificateRefs:
         - group: ''
           kind: Secret
-          name: wildcard-${COMMON_DOMAIN//./-}
+          name: wildcard-lukehouge-com
+    - name: wildcard-rajsingh-info-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.rajsingh.info"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-rajsingh-info
+    - name: wildcard-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
     - name: wildcard-ts-keiretsu-top-https
       protocol: HTTPS
       port: 443
@@ -47,19 +86,6 @@ spec:
         - group: ''
           kind: Secret
           name: wildcard-ts-keiretsu-top
-    - name: ${COMMON_DOMAIN//./-}-https
-      protocol: HTTPS
-      port: 443
-      hostname: "${COMMON_DOMAIN}"
-      allowedRoutes:
-        namespaces:
-          from: All
-      tls:
-        mode: Terminate
-        certificateRefs:
-        - group: ''
-          kind: Secret
-          name: wildcard-${COMMON_DOMAIN//./-}
     - name: http
       port: 80
       protocol: HTTP

--- a/clusters/talos-robbinsdale/apps/home/app/frigate/httproute.yaml
+++ b/clusters/talos-robbinsdale/apps/home/app/frigate/httproute.yaml
@@ -17,12 +17,12 @@ spec:
       kind: Gateway
       name: private
       namespace: home
-      sectionName: luke-wildcard-https
+      sectionName: wildcard-lukehouge-com-https
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: ts
       namespace: home
-      sectionName: luke-wildcard-https
+      sectionName: wildcard-lukehouge-com-https
   hostnames:
     - "frigate.${CLUSTER_DOMAIN}"
   rules:

--- a/docs/superpowers/specs/2026-06-10-domain-ingress-repo-restructure-design.md
+++ b/docs/superpowers/specs/2026-06-10-domain-ingress-repo-restructure-design.md
@@ -111,7 +111,7 @@ spec:
 
 | Resolver | Zones | Writer | Clients |
 |---|---|---|---|
-| Cloudflare | all 4 domains (public horizon) | **one** external-dns (4 domain filters, `gateway==public`) | internet |
+| Cloudflare | all 4 domains (public horizon) | one external-dns per domain (per-account tokens, `gateway==public`) | internet |
 | Pi-hole (per cluster) | all 4 domains (tailnet horizon) | ts-external-dns (`external-dns==ts`) | tailnet via split DNS |
 | UniFi (per site) | all 4 domains + `*.internal` (LAN horizon) | external-dns-unifi (`external-dns==private`) | LAN |
 | K8GB CoreDNS | `cdn.keiretsu.top` (public NS-delegated), `ts.keiretsu.top` (tailnet) | Gslb resources | multi-cluster opt-in |

--- a/docs/superpowers/specs/2026-06-10-domain-ingress-repo-restructure-design.md
+++ b/docs/superpowers/specs/2026-06-10-domain-ingress-repo-restructure-design.md
@@ -97,9 +97,10 @@ spec:
   per-domain Cloudflare ClusterIssuers, shared by all three gateways. Replaces today's
   per-purpose cert sprawl.
 - The `ts` gateway Service stays on `loadBalancerClass: tailscale` + `tailscale.com/proxy-group:
-  common-ingress`, and gains a **Tailscale Service VIP** as its stable
-  `external-dns.alpha.kubernetes.io/target` (Tailscale Services are GA; kills per-pod address
-  churn). This matches Tailscale's official BYOD-with-Gateway-API solution doc.
+  common-ingress`, which already provisions a **Tailscale Service VIP** (verified live:
+  `ipMode: VIP`, stable `<location>-home-envoy-gateway.keiretsu.ts.net` hostname). Tailnet
+  split-DNS (tsddns) already targets `svc:<location>-home-envoy-gateway`. This matches
+  Tailscale's official BYOD-with-Gateway-API solution doc.
 - Listener hostname semantics (most-specific wins, route∩listener intersection) make the
   overlapping wildcards safe; `NoMatchingListenerHostname` should become impossible for the
   four domains.
@@ -117,9 +118,14 @@ spec:
 
 Changes from today:
 
-- Collapse the four per-domain Cloudflare external-dns instances into one.
+- Cloudflare external-dns stays one-instance-per-domain: the vanity domains live in
+  different Cloudflare accounts (kb/Luke/Raj) and external-dns takes a single
+  CF_API_TOKEN, so the split is a credential boundary. All four instances already run
+  on every cluster, so the public horizon already covers all four domains.
 - Add all four domains to the Pi-hole and UniFi instances' domain filters.
-- Delete the orphaned Tailscale DNSConfig nameserver (deployed, referenced by nothing).
+- The Tailscale DNSConfig nameserver stays: each cluster's CoreDNS forwards the
+  `ts.net` zone to it (cilium/config/coredns.yaml) for in-cluster MagicDNS
+  resolution. The earlier "orphaned" finding was wrong.
 - Keep tsddns (45-min split-DNS sync cron) — it is the right tool, now documented.
 - Keep `.internal` static DNSEndpoints under UniFi.
 - Same hostname in different horizons is by design (split horizon); per-location TXT ownership


### PR DESCRIPTION
Phase 2 of the domain/ingress restructure (spec + plan in docs/superpowers/). Every gateway (`ts`/`private`/`public`) on every cluster now terminates HTTPS for all four domains, so an HTTPRoute can use any domain at any location — the hostname picker stops requiring cluster knowledge.

- 4 literal wildcard Certificates per cluster (killinit.cc, lukehouge.com, rajsingh.info, keiretsu.top+apex); each cluster gains the 2 it was missing. Own-domain cert/secret names are unchanged (the old `${CLUSTER_DOMAIN//./-}` names resolved to the same literals), so no churn, just 2 new ACME orders per cluster
- +2 wildcard HTTPS listeners per gateway per cluster — purely additive, verified per-cluster in the rendered diffs
- pihole + unifi external-dns domainFilters cover all four domains (TXT ownership untouched; additive)
- frigate (robbinsdale) parentRefs pointed at a listener that never existed (`luke-wildcard-https`) — fixed to `wildcard-lukehouge-com-https`
- spec corrected on three points found during planning: cloudflare external-dns stays per-domain (the vanity domains live in different cloudflare accounts — one token per instance is a hard constraint), the tailscale DNSConfig nameserver stays (cluster CoreDNS forwards ts.net to it), and the ts gateway's Tailscale Service VIP already exists (verified live, ipMode VIP)

The flate diff comments below are the authoritative per-cluster change inventory: expect exactly +2 Certificates, +2 listeners ×3 gateways, the two external-dns filter changes, and (robbinsdale) the frigate fix.