### PR TITLE
feat: templatize garage.rajsingh.info/cluster label via kustomize commonLabels

### DIFF
--- a/clusters/talos-ottawa/apps/garage/nodes/kustomization.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: garage
+commonLabels:
+  garage.rajsingh.info/cluster: garage
 resources:
   - ottawa-garage-smb.yaml
   - ottawa-garage-localpath-shiro.yaml

--- a/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-asuka.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-asuka.yaml
@@ -2,8 +2,6 @@ apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageNode
 metadata:
   name: ottawa-garage-localpath-asuka
-  labels:
-    garage.rajsingh.info/cluster: garage
 spec:
   clusterRef:
     name: garage

--- a/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-kaji.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-kaji.yaml
@@ -2,8 +2,6 @@ apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageNode
 metadata:
   name: ottawa-garage-localpath-kaji
-  labels:
-    garage.rajsingh.info/cluster: garage
 spec:
   clusterRef:
     name: garage

--- a/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-rei.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-rei.yaml
@@ -2,8 +2,6 @@ apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageNode
 metadata:
   name: ottawa-garage-localpath-rei
-  labels:
-    garage.rajsingh.info/cluster: garage
 spec:
   clusterRef:
     name: garage

--- a/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-shiro.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-localpath-shiro.yaml
@@ -12,8 +12,6 @@ apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageNode
 metadata:
   name: ottawa-garage-localpath-shiro
-  labels:
-    garage.rajsingh.info/cluster: garage
 spec:
   clusterRef:
     name: garage

--- a/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-smb.yaml
+++ b/clusters/talos-ottawa/apps/garage/nodes/ottawa-garage-smb.yaml
@@ -13,8 +13,6 @@ apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageNode
 metadata:
   name: ottawa-garage-smb
-  labels:
-    garage.rajsingh.info/cluster: garage
 spec:
   clusterRef:
     name: garage

--- a/clusters/talos-robbinsdale/apps/garage/nodes/kustomization.yaml
+++ b/clusters/talos-robbinsdale/apps/garage/nodes/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: garage
+commonLabels:
+  garage.rajsingh.info/cluster: garage
 resources:
   - robbinsdale-garage-smb.yaml
   - robbinsdale-garage-localpath-tank.yaml

--- a/clusters/talos-stpetersburg/apps/garage/nodes/kustomization.yaml
+++ b/clusters/talos-stpetersburg/apps/garage/nodes/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 # CRs to the garage namespace — without it cluster-apps applies them with no
 # namespace and fails ("namespace not specified").
 namespace: garage
+commonLabels:
+  garage.rajsingh.info/cluster: garage
 resources:
   - stpetersburg-garage-localpath-spark-0.yaml
   - stpetersburg-garage-localpath-spark-1.yaml


### PR DESCRIPTION
## What

Moves the `garage.rajsingh.info/cluster: garage` label from individual GarageNode YAML files into a kustomize `commonLabels` transformer in each cluster's `nodes/kustomization.yaml`.

## Why

During the recent Garage Degraded-cluster RCA, 5 storage GarageNode CRs were missing this label because it had to be manually added to each YAML. The operator uses this label to find child nodes when computing `readyReplicas`, and missing it caused:

```
readyReplicas=2 (only gateways counted) < desiredReplicas=3 → Phase=Degraded → all buckets stuck Pending for ~39h
```

With kustomize `commonLabels`, every GarageNode CR gets the label at build time — no way to forget it.

## Changes

| File | Change |
|------|--------|
| `talos-ottawa/apps/garage/nodes/kustomization.yaml` | +commonLabels |
| `talos-robbinsdale/apps/garage/nodes/kustomization.yaml` | +commonLabels |
| `talos-stpetersburg/apps/garage/nodes/kustomization.yaml` | +commonLabels |
| 5 Ottawa GarageNode YAMLs | removed redundant inline label (now provided by kustomize) |

## Verification

All 12 GarageNode CRs across 3 clusters get `garage.rajsingh.info/cluster: garage` injected at kustomize build time. The label also propagates to auto-generated TS Service resources.