### PR TITLE
cert-manager: acme cname delegation for the k8gb-delegated cdn zone

### DIFF
--- a/clusters/common/apps/cert-manager/issuers/keiretsu-clusterissuer.yaml
+++ b/clusters/common/apps/cert-manager/issuers/keiretsu-clusterissuer.yaml
@@ -11,6 +11,9 @@ spec:
       name: letsencrypt-keiretsu-key
     solvers:
     - dns01:
+        # follow the _acme-challenge CNAME that k8gb coredns serves for the
+        # NS-delegated cdn zone; no-op for names without a CNAME
+        cnameStrategy: Follow
         cloudflare:
           email: ${RAJSINGH_INFO_CLOUDFLARE_EMAIL}
           apiTokenSecretRef:

--- a/clusters/common/apps/k8gb/app/helmrelease.yaml
+++ b/clusters/common/apps/k8gb/app/helmrelease.yaml
@@ -24,6 +24,15 @@ spec:
         - parentZone: "keiretsu.top"
           loadBalancedZone: "cdn.keiretsu.top"
           dnsZoneNegTTL: 30
+          # cdn.keiretsu.top is NS-delegated here, which occludes the
+          # _acme-challenge TXT cert-manager writes into cloudflare. Answer the
+          # challenge name with a CNAME back into the undelegated parent zone
+          # (cert-manager follows it via the issuer's cnameStrategy: Follow).
+          extraPlugins:
+            - |
+              template IN ANY _acme-challenge.cdn.keiretsu.top {
+                answer "_acme-challenge.cdn.keiretsu.top. 30 IN CNAME _acme-challenge-cdn.keiretsu.top."
+              }
         - parentZone: "keiretsu.top"
           loadBalancedZone: "ts.keiretsu.top"
           dnsZoneNegTTL: 30


### PR DESCRIPTION
cdn.keiretsu.top is publicly NS-delegated to k8gb coredns, so the
_acme-challenge TXT cert-manager writes into cloudflare sits below the
zone cut and never propagates — renewals have been stuck 23 days and the
cert expires 2026-06-17. k8gb coredns now answers the challenge name
with a CNAME into the undelegated parent zone and the issuer follows it.
