### PR TITLE
migrate: unpoller and blackbox-exporter into the kubernetes tree (adopt)

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,68 @@
+# kubernetes/ — the new tree
+
+apps live here exactly once; clusters opt in with thin pointer files.
+
+```
+kubernetes/
+├── apps/
+│   ├── base/<namespace>/<app>/        # ALL real config, exactly once (verbatim manifests)
+│   └── <location>/<namespace>/        # ottawa | robbinsdale | stpetersburg
+│       ├── kustomization.yaml         # lists the pointer files (+ namespace.yaml when owned here)
+│       └── <app>.yaml                 # the app's Flux Kustomization CR → base path
+└── components/                        # kustomize components shared across apps
+```
+
+deploy-to-some-clusters = the pointer file exists only in those location trees.
+each location is reconciled by the `kubernetes-apps` Flux Kustomization
+(defined in `clusters/talos-<location>/flux/config/cluster.yaml`), which injects
+sops decryption + the settings/secrets substituteFrom stack into every child,
+same as the old `common-apps` parent.
+
+## moving an app out of clusters/ (the proven recipe)
+
+the old tree already gives every app its own Flux Kustomization CR; the move
+re-parents that CR without ever touching workload ownership. validated on the
+kromgo pilot 2026-06-10: ownership label flips, zero pod restarts, old parent
+GC skips the foreign-owned CR.
+
+**PR-A — adopt (touches only kubernetes/):**
+
+1. `cp -r clusters/.../​<app>/app kubernetes/apps/base/<ns>/<app>` — VERBATIM.
+   no variable cleanup, no refactors. byte-identical render is what makes the
+   move provably safe (cleanup is a separate commit after the move).
+2. per target location: copy the app's old `ks.yaml` to
+   `kubernetes/apps/<loc>/<ns>/<app>.yaml` changing ONLY `spec.path`. the CR
+   `metadata.name` must stay identical — that's the adoption key. multi-CR
+   apps (e.g. blackbox-exporter app+config) keep all their CRs in one pointer.
+3. list the pointer in `kubernetes/apps/<loc>/<ns>/kustomization.yaml`.
+4. prove it: `make test`, then byte-identical check —
+   `flate build ks --path clusters/talos-ottawa/flux/config <app>` before/after
+   (git stash) must diff empty.
+5. merge, then per cluster: reconcile `kubernetes-apps`, confirm
+   `kubectl get kustomization <app> -n flux-system` shows
+   label `kustomize.toolkit.fluxcd.io/name: kubernetes-apps` and the new path,
+   and the app's pods kept their start times.
+
+**PR-B — release (touches only clusters/):**
+
+6. `git rm -r clusters/common/apps/<app>` (or the cluster-specific dir). the
+   old parent auto-discovers by directory, there is no registration list.
+7. merge, reconcile `common-apps`, confirm the CR still exists, pods
+   untouched, `flux get ks <app>` Ready. flux GC skips objects whose ownership
+   labels were taken by another Kustomization — that's the safety mechanism.
+
+keep the A→B window short (hours): during it both parents apply the same CR
+and the ownership label can flap. never batch A and B into one PR.
+
+## namespaces
+
+when an app's namespace is owned by the old tree, move the `namespace.yaml`
+into `kubernetes/apps/<loc>/<ns>/` in PR-A (listed in that kustomization) and
+keep its `kustomize.toolkit.fluxcd.io/prune: disabled` label. one tree must
+own each namespace — never both for longer than the A→B window.
+
+## validation
+
+every PR touching `kubernetes/**` or `clusters/**` gets flate render tests and
+per-cluster rendered-diff comments. a move PR-A must show ONLY the CR path
+change; anything else in the diff means the copy wasn't verbatim.

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/app/helmrelease.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app blackbox-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: blackbox-exporter
+  interval: 1h
+  values:
+    fullnameOverride: *app
+    config:
+      modules:
+        http_2xx:
+          prober: http
+          timeout: 5s
+          http:
+            valid_http_versions:
+              - HTTP/1.1
+              - HTTP/2.0
+            follow_redirects: true
+            preferred_ip_protocol: ip4
+        http_2xx_insecure:
+          prober: http
+          timeout: 5s
+          http:
+            valid_http_versions:
+              - HTTP/1.1
+              - HTTP/2.0
+            follow_redirects: true
+            preferred_ip_protocol: ip4
+            tls_config:
+              insecure_skip_verify: true
+        http_401:
+          prober: http
+          timeout: 5s
+          http:
+            valid_http_versions:
+              - HTTP/1.1
+              - HTTP/2.0
+            valid_status_codes: [401]
+            preferred_ip_protocol: ip4
+            tls_config:
+              insecure_skip_verify: true
+        icmp:
+          prober: icmp
+          timeout: 5s
+          icmp:
+            preferred_ip_protocol: ip4
+        tcp_connect:
+          prober: tcp
+          timeout: 5s
+          tcp:
+            preferred_ip_protocol: ip4
+        dns_a:
+          prober: dns
+          timeout: 5s
+          dns:
+            query_name: google.com
+            query_type: A
+            preferred_ip_protocol: ip4
+            valid_rcodes:
+              - NOERROR
+    serviceMonitor:
+      enabled: true
+      selfMonitor:
+        enabled: true
+    prometheusRule:
+      enabled: false

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/app/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kromgo.yaml
-  - ./unpoller.yaml
-  - ./blackbox-exporter.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: blackbox-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 11.11.0
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/config/dashboard.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/config/dashboard.yaml
@@ -1,0 +1,69 @@
+---
+# Prometheus Blackbox Exporter (id 7587).
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: blackbox-exporter-prometheus
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  grafanaCom:
+    id: 7587
+  datasources:
+    - inputName: DS_SIGNCL-PROMETHEUS
+      datasourceName: Prometheus
+---
+# Blackbox Exporter (HTTP prober) (id 13659).
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: blackbox-http-prober
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  grafanaCom:
+    id: 13659
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---
+# Prometheus Blackbox Exporter (id 14928) — alternate Prom-relabeled view.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: blackbox-exporter-relabeled
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  grafanaCom:
+    id: 14928
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---
+# Blackbox Exporter Overview (id 5345) — declares its input as
+# DS_PROMETHEUS-APL (with a dash). Mapped accordingly.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: blackbox-exporter-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  grafanaCom:
+    id: 5345
+  datasources:
+    - inputName: DS_PROMETHEUS-APL
+      datasourceName: Prometheus

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/config/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/config/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prometheusrule.yaml
+  - ./dashboard.yaml
+  - ./probes-k8s-api.yaml
+  - ./probes-internet.yaml

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/config/probes-internet.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/config/probes-internet.yaml
@@ -1,0 +1,37 @@
+---
+# Internet reachability — TCP and HTTPS to 1.1.1.1.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-internet
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://1.1.1.1
+        - https://8.8.8.8
+      labels:
+        service: internet
+        target: dns-public
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-internet-icmp
+spec:
+  jobName: blackbox
+  module: icmp
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - 1.1.1.1
+        - 8.8.8.8
+      labels:
+        service: internet
+        target: ping

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/config/probes-k8s-api.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/config/probes-k8s-api.yaml
@@ -1,0 +1,21 @@
+---
+# Kubernetes API server self-probe. Each cluster probes its own apiserver via
+# in-cluster DNS — gives per-cluster API uptime distinguished by the
+# X-Scope-OrgID tenant label that Prometheus applies on remote_write.
+# Returns 401 without creds — still proves the API is up.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-k8s-api-readyz
+spec:
+  jobName: blackbox
+  module: http_401
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://kubernetes.default.svc:443/readyz
+      labels:
+        service: kubernetes-api
+        target: in-cluster

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/config/prometheusrule.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/config/prometheusrule.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: blackbox-exporter-rules
+spec:
+  groups:
+    - name: blackbox-exporter.rules
+      rules:
+        - alert: ProbeFailed
+          expr: probe_success == 0
+          for: 5m
+          annotations:
+            summary: >-
+              Probe failed for {{ $labels.instance }}
+            description: >-
+              The blackbox probe targeting {{ $labels.instance }} has been failing for 5 minutes.
+          labels:
+            severity: critical
+
+        - alert: ProbeSlowResponse
+          expr: probe_duration_seconds > 5
+          for: 10m
+          annotations:
+            summary: >-
+              Slow probe response for {{ $labels.instance }}
+            description: >-
+              The blackbox probe targeting {{ $labels.instance }} is responding slowly (>5s).
+          labels:
+            severity: warning
+
+        - alert: SSLCertExpiringSoon
+          expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 14
+          for: 1h
+          annotations:
+            summary: >-
+              SSL certificate expiring soon for {{ $labels.instance }}
+            description: >-
+              SSL certificate for {{ $labels.instance }} expires in less than 14 days.
+          labels:
+            severity: warning
+
+        - alert: SSLCertExpired
+          expr: probe_ssl_earliest_cert_expiry - time() < 0
+          for: 0m
+          annotations:
+            summary: >-
+              SSL certificate expired for {{ $labels.instance }}
+            description: >-
+              SSL certificate for {{ $labels.instance }} has expired.
+          labels:
+            severity: critical

--- a/kubernetes/apps/base/monitoring/unpoller/helmrelease.yaml
+++ b/kubernetes/apps/base/monitoring/unpoller/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app unpoller
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: unpoller
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: unpoller
+        namespace: flux-system
+  values:
+    fullnameOverride: *app
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+    dashboards:
+      create: true
+      grafana:
+        create: false
+      selectorLabels:
+        grafana.internal/instance: grafana
+    upConfig: |
+      [poller]
+          debug = false
+          quiet = false
+          plugins = []
+      [prometheus]
+          disable = false
+          http_listen = "0.0.0.0:9130"
+          report_errors = false
+      [influxdb]
+          disable = true
+      [unifi]
+          dynamic = false
+      [loki]
+          disable = true
+      [[unifi.controller]]
+          url         = "https://${LAN_GATEWAY_IP}"
+          user        = "unpoller"
+          pass        = "Keiretsu${DEFAULT_PASSWORD}0"
+          sites       = ["all"]
+          save_ids    = true
+          save_dpi    = true
+          save_sites  = true
+          hash_pii    = false
+          verify_ssl  = false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: GrafanaDashboard
+            patch: |
+              - op: replace
+                path: /spec/instanceSelector/matchLabels
+                value:
+                  grafana.internal/instance: grafana
+              - op: add
+                path: /spec/folder
+                value: UniFi
+              - op: add
+                path: /spec/resyncPeriod
+                value: "168h"

--- a/kubernetes/apps/base/monitoring/unpoller/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/unpoller/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kromgo.yaml
-  - ./unpoller.yaml
-  - ./blackbox-exporter.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ottawa/monitoring/blackbox-exporter.yaml
+++ b/kubernetes/apps/ottawa/monitoring/blackbox-exporter.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app blackbox-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: blackbox-exporter-config
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: blackbox-exporter
+  dependsOn:
+    - name: blackbox-exporter
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/monitoring/unpoller.yaml
+++ b/kubernetes/apps/ottawa/monitoring/unpoller.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app unpoller
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/unpoller
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/monitoring/blackbox-exporter.yaml
+++ b/kubernetes/apps/robbinsdale/monitoring/blackbox-exporter.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app blackbox-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: blackbox-exporter-config
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: blackbox-exporter
+  dependsOn:
+    - name: blackbox-exporter
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/monitoring/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/monitoring/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./kromgo.yaml
+  - ./unpoller.yaml
+  - ./blackbox-exporter.yaml

--- a/kubernetes/apps/robbinsdale/monitoring/unpoller.yaml
+++ b/kubernetes/apps/robbinsdale/monitoring/unpoller.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app unpoller
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/unpoller
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/monitoring/blackbox-exporter.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/blackbox-exporter.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app blackbox-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: blackbox-exporter-config
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: blackbox-exporter
+  dependsOn:
+    - name: blackbox-exporter
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/monitoring/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./kromgo.yaml
+  - ./unpoller.yaml
+  - ./blackbox-exporter.yaml

--- a/kubernetes/apps/stpetersburg/monitoring/unpoller.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/unpoller.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app unpoller
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/unpoller
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Wave 1 of the move recipe (see kubernetes/README.md, added here): all
three monitoring-namespace apps now render byte-identical from base
paths; release PR follows after live adoption verification.
