### PR TITLE
migrate(batch-c/monitoring): adopt blackbox-exporter-ottawa, grafana, smartctl-exporter

### DIFF
--- a/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/helmrelease.yaml
+++ b/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clickhouse-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: altinity-clickhouse-operator
+      version: 0.27.1
+      sourceRef:
+        kind: HelmRepository
+        name: clickhouse
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Keep the resource name aligned with the existing ServiceMonitor selector
+    # (app.kubernetes.io/name: clickhouse-operator).
+    nameOverride: clickhouse-operator
+    operator:
+      # Watch all namespaces. The operator's default when running outside
+      # kube-system is to watch only its own namespace; ".*" forces watch-all.
+      env:
+        - name: WATCH_NAMESPACES
+          value: ".*"
+    metrics:
+      enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: monitoring

--- a/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: clickhouse-operator-system
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - helmrelease.yaml

--- a/kubernetes/apps/base/clickhouse/clickhouse/clickhousecluster.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/clickhousecluster.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: clickhouse
+  namespace: clickhouse
+spec:
+  configuration:
+    clusters:
+      - name: "${LOCATION}"
+        layout:
+          shardsCount: 1
+          replicasCount: 1
+        templates:
+          podTemplate: clickhouse-pod-template
+          dataVolumeClaimTemplate: data-volume-template
+          clusterServiceTemplate: clickhouse-cluster-service-template
+    settings:
+      prometheus/endpoint: /metrics
+      prometheus/port: 9363
+      prometheus/metrics: 1
+      prometheus/events: 1
+      prometheus/asynchronous_metrics: 1
+      prometheus/status_info: 1
+      compression/case/method: lz4
+      compression/case/min_part_size: 0
+      compression/case/min_part_size_ratio: "0.0"
+  defaults:
+    templates:
+      podTemplate: clickhouse-pod-template
+      dataVolumeClaimTemplate: data-volume-template
+      serviceTemplate: clickhouse-cluster-service-template
+  templates:
+    podTemplates:
+      - name: clickhouse-pod-template
+        metadata:
+          labels:
+            app.kubernetes.io/name: clickhouse
+            app.kubernetes.io/instance: clickhouse
+            app.kubernetes.io/cluster: "${LOCATION}"
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 1000
+          containers:
+            - name: clickhouse
+              image: clickhouse/clickhouse-server:26.5
+              ports:
+                - name: tcp
+                  containerPort: 9000
+                - name: http
+                  containerPort: 8123
+                - name: interserver
+                  containerPort: 9009
+                - name: metrics
+                  containerPort: 9363
+              resources:
+                requests:
+                  cpu: 2
+                  memory: 8Gi
+                limits:
+                  cpu: 4
+                  memory: 16Gi
+    volumeClaimTemplates:
+      - name: data-volume-template
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 50Gi
+    serviceTemplates:
+      - name: clickhouse-cluster-service-template
+        # Produce a stable Service named "clickhouse" so existing probes,
+        # HTTPRoutes and Tailscale services keep working.
+        generateName: clickhouse
+        spec:
+          ports:
+            - name: tcp
+              port: 9000
+              targetPort: 9000
+            - name: http
+              port: 8123
+              targetPort: 8123
+            - name: interserver
+              port: 9009
+              targetPort: 9009
+            - name: metrics
+              port: 9363
+              targetPort: 9363
+          type: ClusterIP

--- a/kubernetes/apps/base/clickhouse/clickhouse/dashboard.json
+++ b/kubernetes/apps/base/clickhouse/clickhouse/dashboard.json
@@ -1,0 +1,427 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ClickHouse monitoring dashboard for multi-cluster deployment",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(rate(clickhouse_query_duration_seconds{job=\"clickhouse\"}[$__rate_interval]))",
+          "legendFormat": "Queries/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+           ="text",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+           ="off"
+          },
+          "mappings": [],
+          "thresholds": {
+           ="absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_memory_used_bytes{job=\"clickhouse\"})",
+         ="mean",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_memory_total_bytes{job=\"clickhouse\"})",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Memory Usage",
+     ="timeseries"
+    },
+    {
+     ="datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode":": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+             {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "options": {
+        "legend": {"calcs": ["max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+     ="targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "clickhouse_replication_queue_length{job=\"clickhouse\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication Queue Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+       ="defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "linear",
+           ="lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode":": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+           ="steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 4,
+     ="options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode":": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_query_duration_seconds_sum{job=\"clickhouse\"}) / sum(clickhouse_query_duration_seconds_count{job=\"clickhouse\"})",
+          "legendFormat": "Avg query time",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Query Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+           ="axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type":": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode":": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+         ="thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 5,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort":": "desc"}
+      },
+      "targets": [
+        {
+         ="datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "count(clickhouse_metric_log{job=\"clickhouse\"})",
+          "legendFormat": "Error count",
+          "refId": "A"
+        }
+      ],
+     ="title": "Error Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+         ="custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+           ="hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps":": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+      "id": 6,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+       ="tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_table_size_bytes{job=\"clickhouse\"}) by (table)",
+          "legendFormat": "{{table}}",
+         ="refId": "A"
+        }
+      ],
+      "title": "Table Size",
+     ="type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+     ="fieldConfig": {
+        "defaults": {
+          "color": {"mode":": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+           ="axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+           ="lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type":": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+      "id": 7,
+     ="options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode":": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "count(clickhouse_query_duration_seconds_count{job=\"clickhouse\"})",
+          "legendFormat": "Total queries",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Query Count",
+     ="type": "timeseries"
+    }
+  ],
+ ="schemaVersion": 38,
+  "tags": ["clickhouse", "analytics", "database"],
+ ="templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+       ="name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+       ="regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ClickHouse Multi-Cluster",
+  "uid": "clickhouse-multi-cluster",
+  "version": 1,
+  "weekStart": ""
+}
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/egress.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/egress.yaml
@@ -1,0 +1,85 @@
+---
+# Tailscale egress proxies for cross-cluster ClickHouse access
+# Using ExternalName services for cross-cluster connectivity via Tailscale
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: clickhouse-global
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: ottawa-clickhouse
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+    - name: http
+      port: 8123
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: robbinsdale-clickhouse
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+    - name: http
+      port: 8123
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: stpetersburg-clickhouse
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+    - name: http
+      port: 8123
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      protocol: TCP
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/grafana-dashboard.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/grafana-dashboard.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: clickhouse
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: ClickHouse
+  configMapRef:
+    name: clickhouse-grafana-dashboard
+    key: dashboard.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/httproute.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/httproute.yaml
@@ -1,0 +1,75 @@
+---
+# HTTP interface for ClickHouse
+# Allows direct HTTP queries via Gateway API
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: clickhouse-http
+  annotations:
+    item.homer.rajsingh.info/name: "ClickHouse"
+    item.homer.rajsingh.info/subtitle: "Analytical Database"
+    item.homer.rajsingh.info/logo: "https://clickhouse.com/img/logo.svg"
+    item.homer.rajsingh.info/keywords: "clickhouse, analytics, database, s3"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-database"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "clickhouse.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: clickhouse-ts
+          port: 8123
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s
+        backendRequest: 300s
+
+---
+# ClickHouse HTTP interface via CDN (for public access)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: clickhouse-cdn
+  annotations:
+    item.homer.rajsingh.info/name: "ClickHouse CDN"
+    item.homer.rajsingh.info/subtitle: "Analytical Database"
+    item.homer.rajsingh.info/logo: "https://clickhouse.com/img/logo.svg"
+    item.homer.rajsingh.info/keywords: "clickhouse, analytics, database, s3"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-database"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "analytics.${COMMON_DOMAIN}"
+    - "analytics.cdn.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: clickhouse-ts
+          port: 8123
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: clickhouse
+resources:
+  - clickhousecluster.yaml
+  - service-ts.yaml
+  - egress.yaml
+  - httproute.yaml
+  - probes.yaml
+  - grafana-dashboard.yaml
+  - service-monitor.yaml
+# Wrap dashboard.json in the ConfigMap that the GrafanaDashboard CR references
+# via configMapRef. Without this the grafana-operator endlessly retries SSA
+# against the apiserver and drives apiserver_request_total{code=5..} through
+# the roof, tripping KubeAPIErrorsHigh.
+configMapGenerator:
+  - name: clickhouse-grafana-dashboard
+    files:
+      - dashboard.json
+generatorOptions:
+  disableNameSuffixHash: true
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/probes.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/probes.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-clickhouse-local
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - clickhouse.clickhouse:9000
+        - clickhouse.clickhouse:8123
+      labels:
+        service: clickhouse
+        target: local
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-clickhouse-cross-cluster
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - ottawa-clickhouse.clickhouse:9000
+        - ottawa-clickhouse.clickhouse:8123
+        - robbinsdale-clickhouse.clickhouse:9000
+        - robbinsdale-clickhouse.clickhouse:8123
+        - stpetersburg-clickhouse.clickhouse:9000
+        - stpetersburg-clickhouse.clickhouse:8123
+      labels:
+        service: clickhouse
+        target: cross-cluster

--- a/kubernetes/apps/base/clickhouse/clickhouse/service-monitor.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/service-monitor.yaml
@@ -1,0 +1,78 @@
+---
+# ServiceMonitor for ClickHouse operator metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clickhouse-operator
+  namespace: clickhouse
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse-operator
+  namespaceSelector:
+    matchNames:
+      - clickhouse-operator-system
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: labeldrop
+          regex: __.*
+
+---
+# ClickHouse pod metrics (from ClickHouse itself)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clickhouse-pods
+  namespace: clickhouse
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+      app.kubernetes.io/instance: clickhouse
+  namespaceSelector:
+    matchNames:
+      - clickhouse
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: labeldrop
+          regex: __.*
+
+---
+# ClickHouse HTTP interface metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clickhouse-http
+  namespace: clickhouse
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+      app.kubernetes.io/instance: clickhouse
+  namespaceSelector:
+    matchNames:
+      - clickhouse
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: labeldrop
+          regex: __.*
+
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/service-ts.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/service-ts.yaml
@@ -1,0 +1,62 @@
+---
+# Tailscale LoadBalancer for cross-cluster connectivity
+# This is the primary service for cross-cluster access via Tailscale
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-clickhouse
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: "common-ingress"
+  name: clickhouse-ts
+spec:
+  # Allow routing to pods before they're ready - essential for multi-cluster
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: http
+      port: 8123
+      protocol: TCP
+      targetPort: 8123
+    - name: interserver
+      port: 9009
+      protocol: TCP
+      targetPort: 9009
+  selector:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/instance: clickhouse
+    app.kubernetes.io/cluster: ${LOCATION}
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+
+---
+# Global clickhouse service for cross-cluster queries
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: clickhouse
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+  name: clickhouse-global-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: http
+      port: 8123
+      protocol: TCP
+      targetPort: 8123
+  selector:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/instance: clickhouse
+    app.kubernetes.io/cluster: ${LOCATION}
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - probes-nodes.yaml
+  - probes-cluster-infra.yaml
+  - probes-gateways.yaml

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-cluster-infra.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-cluster-infra.yaml
@@ -1,0 +1,55 @@
+---
+# Cluster-local Kubernetes API (via the cluster VIP / DNS name).
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-k8s-api-local
+spec:
+  jobName: blackbox
+  module: http_401
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://k8s.killinit.internal:6443/readyz
+      labels:
+        service: kubernetes-api
+        target: cluster-vip
+---
+# etcd metrics ports on each control-plane node.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-etcd
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://rei.killinit.internal:2381/metrics
+        - http://asuka.killinit.internal:2381/metrics
+        - http://kaji.killinit.internal:2381/metrics
+      labels:
+        service: etcd
+---
+# CoreDNS and Flux source-controller (cluster-local).
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-cluster-services
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://kube-dns.kube-system:9153/metrics
+        - http://source-controller.flux-system:8080/metrics
+      labels:
+        service: cluster-infra

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-gateways.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-gateways.yaml
@@ -1,0 +1,18 @@
+---
+# Envoy gateway reachability via the public status endpoint.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-gateway-public
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://status.killinit.cc
+      labels:
+        service: gateway
+        target: public

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-nodes.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-nodes.yaml
@@ -1,0 +1,60 @@
+---
+# Talos node control-plane ports.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-nodes-tcp
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - rei.killinit.internal:6443
+        - asuka.killinit.internal:6443
+        - kaji.killinit.internal:6443
+      labels:
+        service: nodes
+        target: kubelet-port
+---
+# NAS (SMB) + JetKVM
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-nas-tcp
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - nagato.killinit.internal:445
+        - jetkvm.killinit.internal:80
+      labels:
+        service: nodes
+        target: nas
+---
+# ICMP reachability for nodes.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-nodes-icmp
+spec:
+  jobName: blackbox
+  module: icmp
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - rei.killinit.internal
+        - asuka.killinit.internal
+        - kaji.killinit.internal
+        - nagato.killinit.internal
+      labels:
+        service: nodes
+        target: ping

--- a/kubernetes/apps/base/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app grafana-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: grafana-operator
+  interval: 1h
+  values:
+    fullnameOverride: *app
+    serviceMonitor:
+      enabled: true
+    # Watch all namespaces (default behavior when namespaceScope: false)
+    namespaceScope: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/base/monitoring/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/monitoring/grafana/app/ocirepository.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: grafana-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.24.0
+  url: oci://ghcr.io/grafana/helm-charts/grafana-operator

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/cnpg/dashboards.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/cnpg/dashboards.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cnpg-cluster
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: PostgreSQL
+  url: https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/main/charts/cluster/grafana-dashboard.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/cnpg/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/cnpg/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dashboards.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/default/external-dns.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/default/external-dns.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: external-dns
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Default
+  grafanaCom:
+    id: 23969
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/default/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/default/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./external-dns.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/flux/cluster.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/flux/cluster.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: flux-cluster
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Flux
+  url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/cluster.json
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/flux/control-plane.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/flux/control-plane.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: flux-control-plane
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Flux
+  url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/flux/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/flux/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./control-plane.yaml
+  - ./logs.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/flux/logs.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/flux/logs.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: flux-logs
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Flux
+  url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/logs.json
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+    - inputName: DS_LOKI
+      datasourceName: Loki

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/k6/k6-prometheus.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/k6/k6-prometheus.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k6-prometheus
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: k6
+  grafanaCom:
+    id: 19665
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/k6/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/k6/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - k6-prometheus.yaml
+  - tailscale-paths.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/k6/tailscale-paths.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/k6/tailscale-paths.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k6-tailscale-paths
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: k6
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+  json: |
+    {
+      "title": "Tailscale Paths - k6 Comparison",
+      "uid": "k6-tailscale-paths",
+      "tags": ["k6", "tailscale"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "refresh": "30s",
+      "time": { "from": "now-6h", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "datasource",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": { "text": "DS_PROMETHEUS", "value": "DS_PROMETHEUS" }
+          },
+          {
+            "name": "cluster_src",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "${datasource}" },
+            "query": "label_values(k6_http_reqs_total, cluster_src)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true
+          },
+          {
+            "name": "cluster_dst",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "${datasource}" },
+            "query": "label_values(k6_http_reqs_total, cluster_dst)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "P95 latency by transport",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "k6_http_req_duration_p95{cluster_src=~\"$cluster_src\", cluster_dst=~\"$cluster_dst\"}",
+              "legendFormat": "{{cluster_src}} -> {{cluster_dst}} ({{transport}})"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 2,
+          "title": "P99 latency by transport",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": { "x": 0, "y": 8, "w": 24, "h": 8 },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "k6_http_req_duration_p99{cluster_src=~\"$cluster_src\", cluster_dst=~\"$cluster_dst\"}",
+              "legendFormat": "{{cluster_src}} -> {{cluster_dst}} ({{transport}})"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 3,
+          "title": "Throughput (received bytes/sec)",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "rate(k6_data_received_total{cluster_src=~\"$cluster_src\", cluster_dst=~\"$cluster_dst\"}[1m])",
+              "legendFormat": "{{cluster_src}} -> {{cluster_dst}} ({{transport}})"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "Bps" } }
+        },
+        {
+          "id": 4,
+          "title": "Connection establishment time (P95)",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "k6_http_req_connecting_p95{cluster_src=~\"$cluster_src\", cluster_dst=~\"$cluster_dst\"}",
+              "legendFormat": "{{cluster_src}} -> {{cluster_dst}} ({{transport}}) connect"
+            },
+            {
+              "refId": "B",
+              "expr": "k6_http_req_tls_handshaking_p95{cluster_src=~\"$cluster_src\", cluster_dst=~\"$cluster_dst\"}",
+              "legendFormat": "{{cluster_src}} -> {{cluster_dst}} ({{transport}}) tls"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 5,
+          "title": "Error rate by transport",
+          "type": "timeseries",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": { "x": 0, "y": 24, "w": 24, "h": 6 },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "k6_http_req_failed_rate{cluster_src=~\"$cluster_src\", cluster_dst=~\"$cluster_dst\"}",
+              "legendFormat": "{{cluster_src}} -> {{cluster_dst}} ({{transport}})"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percentunit" } }
+        }
+      ]
+    }

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/api-server.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/api-server.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-api-server
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Kubernetes
+  grafanaCom:
+    id: 15761
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/coredns.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/coredns.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-coredns
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Kubernetes
+  grafanaCom:
+    id: 15762
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/global.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/global.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-global
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Kubernetes
+  grafanaCom:
+    id: 15757
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - api-server.yaml
+  - coredns.yaml
+  - global.yaml
+  - namespaces.yaml
+  - nodes.yaml
+  - pods.yaml
+  - volumes.yaml
+  - node-exporter.yaml
+  - prometheus.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/namespaces.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/namespaces.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-namespaces
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Kubernetes
+  grafanaCom:
+    id: 15758
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/node-exporter.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/node-exporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: node-exporter-full
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Kubernetes
+  grafanaCom:
+    id: 1860
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/nodes.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/nodes.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-nodes
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Kubernetes
+  grafanaCom:
+    id: 15759
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/pods.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/pods.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-pods
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Kubernetes
+  grafanaCom:
+    id: 15760
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/prometheus.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/prometheus.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: prometheus
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Kubernetes
+  grafanaCom:
+    id: 19105
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/volumes.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kubernetes/volumes.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-volumes
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Kubernetes
+  grafanaCom:
+    id: 11454
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./flux
+  - ./default
+  - ./kubernetes
+  - ./network
+  - ./mimir
+  - ./loki
+  - ./cnpg
+  - ./k6
+  - ./vllm

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/loki/dashboards.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/loki/dashboards.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: loki-operational
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Loki
+  url: https://raw.githubusercontent.com/grafana/loki/main/production/loki-mixin-compiled/dashboards/loki-operational.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+    - inputName: DS_LOKI
+      datasourceName: Loki
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: loki-writes
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Loki
+  url: https://raw.githubusercontent.com/grafana/loki/main/production/loki-mixin-compiled/dashboards/loki-writes.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: loki-reads
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Loki
+  url: https://raw.githubusercontent.com/grafana/loki/main/production/loki-mixin-compiled/dashboards/loki-reads.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: loki-chunks
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Loki
+  url: https://raw.githubusercontent.com/grafana/loki/main/production/loki-mixin-compiled/dashboards/loki-chunks.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: loki-retention
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Loki
+  url: https://raw.githubusercontent.com/grafana/loki/main/production/loki-mixin-compiled/dashboards/loki-retention.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: loki-logs
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Loki
+  url: https://raw.githubusercontent.com/grafana/loki/main/production/loki-mixin-compiled/dashboards/loki-logs.json
+  datasources:
+    - inputName: DS_LOKI
+      datasourceName: Loki

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/loki/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/loki/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dashboards.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/mimir/dashboards.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/mimir/dashboards.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mimir-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Mimir
+  url: https://raw.githubusercontent.com/grafana/mimir/main/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+  datasources:
+    - inputName: datasource
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mimir-writes
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Mimir
+  url: https://raw.githubusercontent.com/grafana/mimir/main/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+  datasources:
+    - inputName: datasource
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mimir-reads
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Mimir
+  url: https://raw.githubusercontent.com/grafana/mimir/main/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+  datasources:
+    - inputName: datasource
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mimir-queries
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Mimir
+  url: https://raw.githubusercontent.com/grafana/mimir/main/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+  datasources:
+    - inputName: datasource
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mimir-compactor
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Mimir
+  url: https://raw.githubusercontent.com/grafana/mimir/main/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+  datasources:
+    - inputName: datasource
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mimir-object-store
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Mimir
+  url: https://raw.githubusercontent.com/grafana/mimir/main/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+  datasources:
+    - inputName: datasource
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mimir-config
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Mimir
+  url: https://raw.githubusercontent.com/grafana/mimir/main/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+  datasources:
+    - inputName: datasource
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/mimir/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/mimir/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dashboards.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/network/cilium-operator.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/network/cilium-operator.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cilium-operator
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  grafanaCom:
+    id: 16612
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/network/cilium-overview.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/network/cilium-overview.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cilium-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  grafanaCom:
+    id: 16611
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/network/hubble-overview.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/network/hubble-overview.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: hubble-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  grafanaCom:
+    id: 16613
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/network/k8gb-gslb.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/network/k8gb-gslb.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8gb-gslb
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Network
+  url: "https://raw.githubusercontent.com/k8gb-io/k8gb/master/grafana/custom-metrics/pretty-custom-metrics-dashboard.json"
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/network/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/network/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cilium-overview.yaml
+  - cilium-operator.yaml
+  - hubble-overview.yaml
+  - k8gb-gslb.yaml

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/vllm/dashboards.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/vllm/dashboards.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: vllm-performance
+  namespace: ai
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: AI
+  url: https://raw.githubusercontent.com/vllm-project/vllm/main/examples/observability/dashboards/grafana/performance_statistics.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: vllm-queries
+  namespace: ai
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: AI
+  url: https://raw.githubusercontent.com/vllm-project/vllm/main/examples/observability/dashboards/grafana/query_statistics.json

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/vllm/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/vllm/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dashboards.yaml

--- a/kubernetes/apps/base/monitoring/grafana/datasources/alertmanager.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/alertmanager.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: alertmanager
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Alertmanager
+    type: alertmanager
+    uid: alertmanager
+    access: proxy
+    url: http://alertmanager.monitoring:9093
+    jsonData:
+      implementation: prometheus
+    editable: false

--- a/kubernetes/apps/base/monitoring/grafana/datasources/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./alertmanager.yaml
+  - ./loki.yaml
+  - ./mimir.yaml
+  - ./mimir-local.yaml
+  - ./mimir-robbinsdale.yaml
+  - ./mimir-ottawa.yaml
+  - ./mimir-stpetersburg.yaml

--- a/kubernetes/apps/base/monitoring/grafana/datasources/loki.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/loki.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: loki
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki-gateway.loki.svc.cluster.local
+    jsonData:
+      maxLines: 1000
+      timeout: 60
+      httpHeaderName1: "X-Scope-OrgID"
+    secureJsonData:
+      httpHeaderValue1: "talos-robbinsdale|talos-ottawa|talos-stpetersburg"
+    editable: false
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: loki-local
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Loki-${CLUSTER_DISPLAY_NAME}
+    type: loki
+    uid: loki-local
+    access: proxy
+    url: http://loki-gateway.loki.svc.cluster.local
+    jsonData:
+      maxLines: 1000
+      timeout: 60
+      httpHeaderName1: "X-Scope-OrgID"
+    secureJsonData:
+      httpHeaderValue1: "${CLUSTER_NAME}"
+    editable: false

--- a/kubernetes/apps/base/monitoring/grafana/datasources/mimir-local.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/mimir-local.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: mimir-local
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Prometheus
+    type: prometheus
+    uid: mimir-local
+    access: proxy
+    url: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus
+    isDefault: true
+    jsonData:
+      timeInterval: 30s
+      httpMethod: GET
+      httpHeaderName1: "X-Scope-OrgID"
+    secureJsonData:
+      httpHeaderValue1: "${CLUSTER_NAME}"
+    editable: false

--- a/kubernetes/apps/base/monitoring/grafana/datasources/mimir-ottawa.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/mimir-ottawa.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: mimir-ottawa
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Mimir-Ottawa
+    type: prometheus
+    uid: mimir-ottawa
+    access: proxy
+    url: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus
+    isDefault: false
+    jsonData:
+      timeInterval: 30s
+      httpMethod: GET
+      httpHeaderName1: "X-Scope-OrgID"
+    secureJsonData:
+      httpHeaderValue1: "talos-ottawa"
+    editable: false

--- a/kubernetes/apps/base/monitoring/grafana/datasources/mimir-robbinsdale.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/mimir-robbinsdale.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: mimir-robbinsdale
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Mimir-Robbinsdale
+    type: prometheus
+    uid: mimir-robbinsdale
+    access: proxy
+    url: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus
+    isDefault: false
+    jsonData:
+      timeInterval: 30s
+      httpMethod: GET
+      httpHeaderName1: "X-Scope-OrgID"
+    secureJsonData:
+      httpHeaderValue1: "talos-robbinsdale"
+    editable: false

--- a/kubernetes/apps/base/monitoring/grafana/datasources/mimir-stpetersburg.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/mimir-stpetersburg.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: mimir-stpetersburg
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Mimir-StPetersburg
+    type: prometheus
+    uid: mimir-stpetersburg
+    access: proxy
+    url: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus
+    isDefault: false
+    jsonData:
+      timeInterval: 30s
+      httpMethod: GET
+      httpHeaderName1: "X-Scope-OrgID"
+    secureJsonData:
+      httpHeaderValue1: "talos-stpetersburg"
+    editable: false

--- a/kubernetes/apps/base/monitoring/grafana/datasources/mimir.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/mimir.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: mimir
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    name: Mimir
+    type: prometheus
+    uid: mimir
+    access: proxy
+    url: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus
+    isDefault: false
+    jsonData:
+      timeInterval: 30s
+      httpMethod: GET
+      httpHeaderName1: "X-Scope-OrgID"
+    secureJsonData:
+      httpHeaderValue1: "talos-robbinsdale|talos-ottawa|talos-stpetersburg"
+    editable: false

--- a/kubernetes/apps/base/monitoring/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/instance/grafana.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    grafana.internal/instance: grafana
+spec:
+  persistentVolumeClaim:
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+  config:
+    log:
+      mode: console
+    server:
+      root_url: https://grafana.${CLUSTER_DOMAIN}
+      domain: grafana.${CLUSTER_DOMAIN}
+    security:
+      admin_user: admin
+      admin_password: "${DEFAULT_PASSWORD}"
+    auth.generic_oauth:
+      enabled: "true"
+      name: TailscaleIDP
+      allow_sign_up: "true"
+      client_id: "${TS_IDP_GRAFANA_CLIENT_ID}"
+      scopes: openid email profile
+      auth_url: https://${LOCATION}-idp.keiretsu.ts.net/authorize
+      token_url: https://${LOCATION}-idp.keiretsu.ts.net/token
+      api_url: https://${LOCATION}-idp.keiretsu.ts.net/userinfo
+      redirect_uri: https://grafana.${CLUSTER_DOMAIN}/login/generic_oauth
+      login_attribute: preferred_username
+  deployment:
+    spec:
+      replicas: 1

--- a/kubernetes/apps/base/monitoring/grafana/instance/httproute.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/instance/httproute.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  annotations:
+    item.homer.rajsingh.info/name: "Grafana"
+    item.homer.rajsingh.info/subtitle: "Analytics & Monitoring"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/grafana.png"
+    item.homer.rajsingh.info/keywords: "monitoring, metrics, dashboard, visualization"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "grafana.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: grafana-service
+          port: 3000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana-public
+  annotations:
+    item.homer.rajsingh.info/name: "Grafana"
+    item.homer.rajsingh.info/subtitle: "Analytics & Monitoring"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/grafana.png"
+    item.homer.rajsingh.info/keywords: "monitoring, metrics, dashboard, visualization"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "grafana.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: grafana-service
+          port: 3000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: grafana-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: grafana-public
+  oidc:
+    provider:
+      issuer: "https://pocket-id.keiretsu.top"
+    clientID: "${ENVOY_GATEWAY_OIDC_CLIENT_ID}"
+    clientSecret:
+      name: grafana-oidc-secret
+    redirectURL: "https://grafana.${CLUSTER_DOMAIN}/oauth2/callback"
+    logoutPath: "/logout"
+    cookieDomain: "${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/base/monitoring/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/instance/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./grafana.yaml
+  - ./httproute.yaml
+  - ./servicemonitor.yaml
+  - ./secret.yaml
+  - ../plugins/image-renderer/deployment.yaml
+  - ../plugins/image-renderer/service.yaml

--- a/kubernetes/apps/base/monitoring/grafana/instance/secret.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/instance/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-oidc-secret
+type: Opaque
+stringData:
+  client-secret: "${ENVOY_GATEWAY_OIDC_CLIENT_SECRET}"

--- a/kubernetes/apps/base/monitoring/grafana/instance/servicemonitor.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/instance/servicemonitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  endpoints:
+    - port: grafana
+      path: /metrics
+      interval: 30s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana

--- a/kubernetes/apps/base/monitoring/grafana/plugins/image-renderer/deployment.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/plugins/image-renderer/deployment.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-image-renderer
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana-image-renderer
+  template:
+    metadata:
+      labels:
+        app: grafana-image-renderer
+      annotations:
+        rendering/grafana: "true"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+      containers:
+        - name: grafana-image-renderer
+          image: docker.io/grafana/grafana-image-renderer:v5.8.8
+          imagePullPolicy: IfNotPresent
+          args: ["server", "--server.addr=:8081"]
+          ports:
+            - name: renderer
+              containerPort: 8081
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              port: renderer
+              path: /healthz
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              port: renderer
+              path: /healthz
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/kubernetes/apps/base/monitoring/grafana/plugins/image-renderer/service.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/plugins/image-renderer/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-image-renderer
+  namespace: monitoring
+spec:
+  ports:
+    - name: renderer
+      port: 8081
+      targetPort: renderer
+      protocol: TCP
+  selector:
+    app: grafana-image-renderer

--- a/kubernetes/apps/base/monitoring/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/base/monitoring/smartctl-exporter/app/helmrelease.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app smartctl-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: smartctl-exporter
+  interval: 1h
+  values:
+    fullnameOverride: *app
+    serviceMonitor:
+      enabled: true
+    prometheusRules:
+      enabled: false

--- a/kubernetes/apps/base/monitoring/smartctl-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/smartctl-exporter/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/monitoring/smartctl-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/base/monitoring/smartctl-exporter/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: smartctl-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.16.1
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter

--- a/kubernetes/apps/base/monitoring/smartctl-exporter/config/dashboard.yaml
+++ b/kubernetes/apps/base/monitoring/smartctl-exporter/config/dashboard.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: smartctl
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: SMART
+  grafanaCom:
+    id: 22604

--- a/kubernetes/apps/base/monitoring/smartctl-exporter/config/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/smartctl-exporter/config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prometheusrule.yaml
+  - ./dashboard.yaml

--- a/kubernetes/apps/base/monitoring/smartctl-exporter/config/prometheusrule.yaml
+++ b/kubernetes/apps/base/monitoring/smartctl-exporter/config/prometheusrule.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: smartctl-exporter-rules
+spec:
+  groups:
+    - name: smartctl-exporter.rules
+      rules:
+        - alert: SmartDeviceHighTemperature
+          expr: |-
+            smartctl_device_temperature{temperature_type="current"} > 65
+          for: 5m
+          annotations:
+            summary: >-
+              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has a temperature higher than 65°C
+          labels:
+            severity: critical
+
+        - alert: SmartDeviceTestFailed
+          expr: |-
+            (smartctl_device_smart_status != 1 or smartctl_device_status != 1)
+          for: 5m
+          annotations:
+            summary: >-
+              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} did not pass its SMART test
+          labels:
+            severity: critical
+
+        - alert: SmartDeviceCriticalWarning
+          expr: |-
+            smartctl_device_critical_warning != 0
+          for: 5m
+          annotations:
+            summary: >-
+              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} is in a critical state
+          labels:
+            severity: critical
+
+        - alert: SmartDeviceMediaErrors
+          expr: |-
+            smartctl_device_media_errors != 0
+          for: 5m
+          annotations:
+            summary: >-
+              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has media errors
+          labels:
+            severity: critical
+
+        - alert: SmartDeviceAvailableSpareUnderThreshold
+          expr: |-
+            smartctl_device_available_spare_threshold > smartctl_device_available_spare
+          for: 5m
+          annotations:
+            summary: >-
+              Device {{ $labels.device }} on instance {{ $labels.instance }} is under available spare threshold
+          labels:
+            severity: critical
+
+        - alert: SmartDeviceInterfaceSlow
+          expr: |-
+            smartctl_device_interface_speed{speed_type="current"} != on(device, instance, namespace, pod) smartctl_device_interface_speed{speed_type="max"}
+          for: 5m
+          annotations:
+            summary: >-
+              Device {{ $labels.device }} on instance {{ $labels.instance }} interface is slower than it should be
+          labels:
+            severity: critical

--- a/kubernetes/apps/ottawa/clickhouse-operator-system/clickhouse-operator-system.yaml
+++ b/kubernetes/apps/ottawa/clickhouse-operator-system/clickhouse-operator-system.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-operator-system
+  namespace: flux-system
+spec:
+  targetNamespace: clickhouse-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/clickhouse-operator-system/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml
+  - ./clickhouse-operator-system.yaml

--- a/kubernetes/apps/ottawa/clickhouse-operator-system/namespace.yaml
+++ b/kubernetes/apps/ottawa/clickhouse-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/clickhouse/clickhouse.yaml
+++ b/kubernetes/apps/ottawa/clickhouse/clickhouse.yaml
@@ -1,0 +1,30 @@
+# DESCHEDULED 2026-06-06 — ClickHouse is not in use and its ~16Gi burst on the DGX
+# Sparks was the main OOM risk blocking the DeepSeek-V4-Flash inference rollout.
+# Commenting out this Flux Kustomization makes common-apps (prune: true) remove the
+# `clickhouse` Kustomization cluster-wide, and the operator then deletes the CHI pods,
+# freeing memory on spark-1 (and the ottawa/robbinsdale equivalents).
+# To restore: un-comment this file and reconcile.
+#
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app clickhouse
+#   namespace: flux-system
+# spec:
+#   targetNamespace: clickhouse
+#   commonMetadata:
+#     labels:
+#       app.kubernetes.io/name: *app
+#   path: ./kubernetes/apps/base/clickhouse/clickhouse
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: kubernetes-manifests
+#   wait: false
+#   interval: 0s
+#   retryInterval: 1m
+#   timeout: 5m
+#   dependsOn:
+#     - name: clickhouse-operator-system
+# ---

--- a/kubernetes/apps/ottawa/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/ottawa/clickhouse/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml

--- a/kubernetes/apps/ottawa/clickhouse/namespace.yaml
+++ b/kubernetes/apps/ottawa/clickhouse/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/monitoring/blackbox-exporter-ottawa.yaml
+++ b/kubernetes/apps/ottawa/monitoring/blackbox-exporter-ottawa.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: blackbox-exporter-ottawa
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: blackbox-exporter
+  dependsOn:
+    - name: blackbox-exporter
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/monitoring/grafana.yaml
+++ b/kubernetes/apps/ottawa/monitoring/grafana.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: grafana
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/grafana/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-instance
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: grafana
+  dependsOn:
+    - name: grafana
+  path: ./kubernetes/apps/base/monitoring/grafana/instance
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-datasources
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: grafana
+  dependsOn:
+    - name: grafana-instance
+  path: ./kubernetes/apps/base/monitoring/grafana/datasources
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-dashboards
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: grafana
+  dependsOn:
+    - name: grafana-datasources
+  path: ./kubernetes/apps/base/monitoring/grafana/dashboards
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/monitoring/kustomization.yaml
+++ b/kubernetes/apps/ottawa/monitoring/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
   - ./kromgo.yaml
   - ./unpoller.yaml
   - ./blackbox-exporter.yaml
+  - ./blackbox-exporter-ottawa.yaml
+  - ./grafana.yaml
+  - ./smartctl-exporter.yaml

--- a/kubernetes/apps/ottawa/monitoring/smartctl-exporter.yaml
+++ b/kubernetes/apps/ottawa/monitoring/smartctl-exporter.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: smartctl-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: smartctl-exporter
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/smartctl-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: smartctl-exporter-config
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: smartctl-exporter
+  dependsOn:
+    - name: smartctl-exporter
+  path: ./kubernetes/apps/base/monitoring/smartctl-exporter/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/clickhouse-operator-system/clickhouse-operator-system.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse-operator-system/clickhouse-operator-system.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-operator-system
+  namespace: flux-system
+spec:
+  targetNamespace: clickhouse-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse-operator-system/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml
+  - ./clickhouse-operator-system.yaml

--- a/kubernetes/apps/robbinsdale/clickhouse-operator-system/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/clickhouse/clickhouse.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse/clickhouse.yaml
@@ -1,0 +1,30 @@
+# DESCHEDULED 2026-06-06 — ClickHouse is not in use and its ~16Gi burst on the DGX
+# Sparks was the main OOM risk blocking the DeepSeek-V4-Flash inference rollout.
+# Commenting out this Flux Kustomization makes common-apps (prune: true) remove the
+# `clickhouse` Kustomization cluster-wide, and the operator then deletes the CHI pods,
+# freeing memory on spark-1 (and the ottawa/robbinsdale equivalents).
+# To restore: un-comment this file and reconcile.
+#
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app clickhouse
+#   namespace: flux-system
+# spec:
+#   targetNamespace: clickhouse
+#   commonMetadata:
+#     labels:
+#       app.kubernetes.io/name: *app
+#   path: ./kubernetes/apps/base/clickhouse/clickhouse
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: kubernetes-manifests
+#   wait: false
+#   interval: 0s
+#   retryInterval: 1m
+#   timeout: 5m
+#   dependsOn:
+#     - name: clickhouse-operator-system
+# ---

--- a/kubernetes/apps/robbinsdale/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml

--- a/kubernetes/apps/robbinsdale/clickhouse/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./monitoring
+  - ./clickhouse-operator-system
+  - ./clickhouse

--- a/kubernetes/apps/stpetersburg/clickhouse-operator-system/clickhouse-operator-system.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse-operator-system/clickhouse-operator-system.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-operator-system
+  namespace: flux-system
+spec:
+  targetNamespace: clickhouse-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse-operator-system/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml
+  - ./clickhouse-operator-system.yaml

--- a/kubernetes/apps/stpetersburg/clickhouse-operator-system/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/clickhouse/clickhouse.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse/clickhouse.yaml
@@ -1,0 +1,30 @@
+# DESCHEDULED 2026-06-06 — ClickHouse is not in use and its ~16Gi burst on the DGX
+# Sparks was the main OOM risk blocking the DeepSeek-V4-Flash inference rollout.
+# Commenting out this Flux Kustomization makes common-apps (prune: true) remove the
+# `clickhouse` Kustomization cluster-wide, and the operator then deletes the CHI pods,
+# freeing memory on spark-1 (and the ottawa/robbinsdale equivalents).
+# To restore: un-comment this file and reconcile.
+#
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app clickhouse
+#   namespace: flux-system
+# spec:
+#   targetNamespace: clickhouse
+#   commonMetadata:
+#     labels:
+#       app.kubernetes.io/name: *app
+#   path: ./kubernetes/apps/base/clickhouse/clickhouse
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: kubernetes-manifests
+#   wait: false
+#   interval: 0s
+#   retryInterval: 1m
+#   timeout: 5m
+#   dependsOn:
+#     - name: clickhouse-operator-system
+# ---

--- a/kubernetes/apps/stpetersburg/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml

--- a/kubernetes/apps/stpetersburg/clickhouse/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./monitoring
+  - ./clickhouse-operator-system
+  - ./clickhouse


### PR DESCRIPTION
## summary

PR-A (adopt) for batch C group 1: monitoring namespace apps moving to the kubernetes/ tree.

**apps:** blackbox-exporter-ottawa, grafana (4 CRs), smartctl-exporter (2 CRs)
**old parent:** cluster-apps (all 7 CRs)
**target namespace:** monitoring

## changes

- verbatim copy of app dirs to `kubernetes/apps/base/monitoring/{blackbox-exporter-ottawa,grafana,smartctl-exporter}`
- blackbox-exporter-ottawa uses `-ottawa` suffix path to avoid collision with base/monitoring/blackbox-exporter (batch B)
- pointer files at `kubernetes/apps/ottawa/monitoring/{blackbox-exporter-ottawa,grafana,smartctl-exporter}.yaml` — CR names unchanged, only spec.path updated
- monitoring kustomization updated to list new pointer files

## verification

- `make test` green ×3 clusters
- `flate build ks` byte-identical before/after stash: all 7 CRs confirmed