### PR TITLE
migrate: clickhouse-operator-system + clickhouse into kubernetes tree (adopt)

### DIFF
--- a/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/helmrelease.yaml
+++ b/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clickhouse-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: altinity-clickhouse-operator
+      version: 0.27.1
+      sourceRef:
+        kind: HelmRepository
+        name: clickhouse
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Keep the resource name aligned with the existing ServiceMonitor selector
+    # (app.kubernetes.io/name: clickhouse-operator).
+    nameOverride: clickhouse-operator
+    operator:
+      # Watch all namespaces. The operator's default when running outside
+      # kube-system is to watch only its own namespace; ".*" forces watch-all.
+      env:
+        - name: WATCH_NAMESPACES
+          value: ".*"
+    metrics:
+      enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: monitoring

--- a/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: clickhouse-operator-system
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - helmrelease.yaml

--- a/kubernetes/apps/base/clickhouse/clickhouse/clickhousecluster.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/clickhousecluster.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: clickhouse
+  namespace: clickhouse
+spec:
+  configuration:
+    clusters:
+      - name: "${LOCATION}"
+        layout:
+          shardsCount: 1
+          replicasCount: 1
+        templates:
+          podTemplate: clickhouse-pod-template
+          dataVolumeClaimTemplate: data-volume-template
+          clusterServiceTemplate: clickhouse-cluster-service-template
+    settings:
+      prometheus/endpoint: /metrics
+      prometheus/port: 9363
+      prometheus/metrics: 1
+      prometheus/events: 1
+      prometheus/asynchronous_metrics: 1
+      prometheus/status_info: 1
+      compression/case/method: lz4
+      compression/case/min_part_size: 0
+      compression/case/min_part_size_ratio: "0.0"
+  defaults:
+    templates:
+      podTemplate: clickhouse-pod-template
+      dataVolumeClaimTemplate: data-volume-template
+      serviceTemplate: clickhouse-cluster-service-template
+  templates:
+    podTemplates:
+      - name: clickhouse-pod-template
+        metadata:
+          labels:
+            app.kubernetes.io/name: clickhouse
+            app.kubernetes.io/instance: clickhouse
+            app.kubernetes.io/cluster: "${LOCATION}"
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 1000
+          containers:
+            - name: clickhouse
+              image: clickhouse/clickhouse-server:26.5
+              ports:
+                - name: tcp
+                  containerPort: 9000
+                - name: http
+                  containerPort: 8123
+                - name: interserver
+                  containerPort: 9009
+                - name: metrics
+                  containerPort: 9363
+              resources:
+                requests:
+                  cpu: 2
+                  memory: 8Gi
+                limits:
+                  cpu: 4
+                  memory: 16Gi
+    volumeClaimTemplates:
+      - name: data-volume-template
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 50Gi
+    serviceTemplates:
+      - name: clickhouse-cluster-service-template
+        # Produce a stable Service named "clickhouse" so existing probes,
+        # HTTPRoutes and Tailscale services keep working.
+        generateName: clickhouse
+        spec:
+          ports:
+            - name: tcp
+              port: 9000
+              targetPort: 9000
+            - name: http
+              port: 8123
+              targetPort: 8123
+            - name: interserver
+              port: 9009
+              targetPort: 9009
+            - name: metrics
+              port: 9363
+              targetPort: 9363
+          type: ClusterIP

--- a/kubernetes/apps/base/clickhouse/clickhouse/dashboard.json
+++ b/kubernetes/apps/base/clickhouse/clickhouse/dashboard.json
@@ -1,0 +1,427 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ClickHouse monitoring dashboard for multi-cluster deployment",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(rate(clickhouse_query_duration_seconds{job=\"clickhouse\"}[$__rate_interval]))",
+          "legendFormat": "Queries/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+           ="text",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+           ="off"
+          },
+          "mappings": [],
+          "thresholds": {
+           ="absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_memory_used_bytes{job=\"clickhouse\"})",
+         ="mean",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_memory_total_bytes{job=\"clickhouse\"})",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Memory Usage",
+     ="timeseries"
+    },
+    {
+     ="datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode":": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+             {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "options": {
+        "legend": {"calcs": ["max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+     ="targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "clickhouse_replication_queue_length{job=\"clickhouse\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication Queue Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+       ="defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "linear",
+           ="lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode":": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+           ="steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 4,
+     ="options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode":": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_query_duration_seconds_sum{job=\"clickhouse\"}) / sum(clickhouse_query_duration_seconds_count{job=\"clickhouse\"})",
+          "legendFormat": "Avg query time",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Query Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+           ="axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type":": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode":": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+         ="thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 5,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort":": "desc"}
+      },
+      "targets": [
+        {
+         ="datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "count(clickhouse_metric_log{job=\"clickhouse\"})",
+          "legendFormat": "Error count",
+          "refId": "A"
+        }
+      ],
+     ="title": "Error Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+         ="custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+           ="hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps":": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+      "id": 6,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+       ="tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(clickhouse_table_size_bytes{job=\"clickhouse\"}) by (table)",
+          "legendFormat": "{{table}}",
+         ="refId": "A"
+        }
+      ],
+      "title": "Table Size",
+     ="type": "timeseries"
+    },
+    {
+      "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+     ="fieldConfig": {
+        "defaults": {
+          "color": {"mode":": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+           ="axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": true, "viz": false},
+            "lineInterpolation": "smooth",
+           ="lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type":": "linear"},
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+      "id": 7,
+     ="options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode":": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type":": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "count(clickhouse_query_duration_seconds_count{job=\"clickhouse\"})",
+          "legendFormat": "Total queries",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Query Count",
+     ="type": "timeseries"
+    }
+  ],
+ ="schemaVersion": 38,
+  "tags": ["clickhouse", "analytics", "database"],
+ ="templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+       ="name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+       ="regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ClickHouse Multi-Cluster",
+  "uid": "clickhouse-multi-cluster",
+  "version": 1,
+  "weekStart": ""
+}
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/egress.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/egress.yaml
@@ -1,0 +1,85 @@
+---
+# Tailscale egress proxies for cross-cluster ClickHouse access
+# Using ExternalName services for cross-cluster connectivity via Tailscale
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: clickhouse-global
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: ottawa-clickhouse
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+    - name: http
+      port: 8123
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: robbinsdale-clickhouse
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+    - name: http
+      port: 8123
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-clickhouse.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: stpetersburg-clickhouse
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+    - name: http
+      port: 8123
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      protocol: TCP
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/grafana-dashboard.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/grafana-dashboard.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: clickhouse
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: ClickHouse
+  configMapRef:
+    name: clickhouse-grafana-dashboard
+    key: dashboard.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/httproute.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/httproute.yaml
@@ -1,0 +1,75 @@
+---
+# HTTP interface for ClickHouse
+# Allows direct HTTP queries via Gateway API
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: clickhouse-http
+  annotations:
+    item.homer.rajsingh.info/name: "ClickHouse"
+    item.homer.rajsingh.info/subtitle: "Analytical Database"
+    item.homer.rajsingh.info/logo: "https://clickhouse.com/img/logo.svg"
+    item.homer.rajsingh.info/keywords: "clickhouse, analytics, database, s3"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-database"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "clickhouse.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: clickhouse-ts
+          port: 8123
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s
+        backendRequest: 300s
+
+---
+# ClickHouse HTTP interface via CDN (for public access)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: clickhouse-cdn
+  annotations:
+    item.homer.rajsingh.info/name: "ClickHouse CDN"
+    item.homer.rajsingh.info/subtitle: "Analytical Database"
+    item.homer.rajsingh.info/logo: "https://clickhouse.com/img/logo.svg"
+    item.homer.rajsingh.info/keywords: "clickhouse, analytics, database, s3"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-database"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "analytics.${COMMON_DOMAIN}"
+    - "analytics.cdn.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: clickhouse-ts
+          port: 8123
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: clickhouse
+resources:
+  - clickhousecluster.yaml
+  - service-ts.yaml
+  - egress.yaml
+  - httproute.yaml
+  - probes.yaml
+  - grafana-dashboard.yaml
+  - service-monitor.yaml
+# Wrap dashboard.json in the ConfigMap that the GrafanaDashboard CR references
+# via configMapRef. Without this the grafana-operator endlessly retries SSA
+# against the apiserver and drives apiserver_request_total{code=5..} through
+# the roof, tripping KubeAPIErrorsHigh.
+configMapGenerator:
+  - name: clickhouse-grafana-dashboard
+    files:
+      - dashboard.json
+generatorOptions:
+  disableNameSuffixHash: true
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/probes.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/probes.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-clickhouse-local
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - clickhouse.clickhouse:9000
+        - clickhouse.clickhouse:8123
+      labels:
+        service: clickhouse
+        target: local
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-clickhouse-cross-cluster
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - ottawa-clickhouse.clickhouse:9000
+        - ottawa-clickhouse.clickhouse:8123
+        - robbinsdale-clickhouse.clickhouse:9000
+        - robbinsdale-clickhouse.clickhouse:8123
+        - stpetersburg-clickhouse.clickhouse:9000
+        - stpetersburg-clickhouse.clickhouse:8123
+      labels:
+        service: clickhouse
+        target: cross-cluster

--- a/kubernetes/apps/base/clickhouse/clickhouse/service-monitor.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/service-monitor.yaml
@@ -1,0 +1,78 @@
+---
+# ServiceMonitor for ClickHouse operator metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clickhouse-operator
+  namespace: clickhouse
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse-operator
+  namespaceSelector:
+    matchNames:
+      - clickhouse-operator-system
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: labeldrop
+          regex: __.*
+
+---
+# ClickHouse pod metrics (from ClickHouse itself)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clickhouse-pods
+  namespace: clickhouse
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+      app.kubernetes.io/instance: clickhouse
+  namespaceSelector:
+    matchNames:
+      - clickhouse
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: labeldrop
+          regex: __.*
+
+---
+# ClickHouse HTTP interface metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clickhouse-http
+  namespace: clickhouse
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+      app.kubernetes.io/instance: clickhouse
+  namespaceSelector:
+    matchNames:
+      - clickhouse
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: labeldrop
+          regex: __.*
+
+---

--- a/kubernetes/apps/base/clickhouse/clickhouse/service-ts.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/service-ts.yaml
@@ -1,0 +1,62 @@
+---
+# Tailscale LoadBalancer for cross-cluster connectivity
+# This is the primary service for cross-cluster access via Tailscale
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-clickhouse
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: "common-ingress"
+  name: clickhouse-ts
+spec:
+  # Allow routing to pods before they're ready - essential for multi-cluster
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: http
+      port: 8123
+      protocol: TCP
+      targetPort: 8123
+    - name: interserver
+      port: 9009
+      protocol: TCP
+      targetPort: 9009
+  selector:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/instance: clickhouse
+    app.kubernetes.io/cluster: ${LOCATION}
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+
+---
+# Global clickhouse service for cross-cluster queries
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: clickhouse
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+  name: clickhouse-global-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: http
+      port: 8123
+      protocol: TCP
+      targetPort: 8123
+  selector:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/instance: clickhouse
+    app.kubernetes.io/cluster: ${LOCATION}
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---

--- a/kubernetes/apps/ottawa/clickhouse-operator-system/clickhouse-operator-system.yaml
+++ b/kubernetes/apps/ottawa/clickhouse-operator-system/clickhouse-operator-system.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-operator-system
+  namespace: flux-system
+spec:
+  targetNamespace: clickhouse-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/clickhouse-operator-system/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml
+  - ./clickhouse-operator-system.yaml

--- a/kubernetes/apps/ottawa/clickhouse-operator-system/namespace.yaml
+++ b/kubernetes/apps/ottawa/clickhouse-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/clickhouse/clickhouse.yaml
+++ b/kubernetes/apps/ottawa/clickhouse/clickhouse.yaml
@@ -1,0 +1,30 @@
+# DESCHEDULED 2026-06-06 — ClickHouse is not in use and its ~16Gi burst on the DGX
+# Sparks was the main OOM risk blocking the DeepSeek-V4-Flash inference rollout.
+# Commenting out this Flux Kustomization makes common-apps (prune: true) remove the
+# `clickhouse` Kustomization cluster-wide, and the operator then deletes the CHI pods,
+# freeing memory on spark-1 (and the ottawa/robbinsdale equivalents).
+# To restore: un-comment this file and reconcile.
+#
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app clickhouse
+#   namespace: flux-system
+# spec:
+#   targetNamespace: clickhouse
+#   commonMetadata:
+#     labels:
+#       app.kubernetes.io/name: *app
+#   path: ./kubernetes/apps/base/clickhouse/clickhouse
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: kubernetes-manifests
+#   wait: false
+#   interval: 0s
+#   retryInterval: 1m
+#   timeout: 5m
+#   dependsOn:
+#     - name: clickhouse-operator-system
+# ---

--- a/kubernetes/apps/ottawa/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/ottawa/clickhouse/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml

--- a/kubernetes/apps/ottawa/clickhouse/namespace.yaml
+++ b/kubernetes/apps/ottawa/clickhouse/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/clickhouse-operator-system/clickhouse-operator-system.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse-operator-system/clickhouse-operator-system.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-operator-system
+  namespace: flux-system
+spec:
+  targetNamespace: clickhouse-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse-operator-system/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml
+  - ./clickhouse-operator-system.yaml

--- a/kubernetes/apps/robbinsdale/clickhouse-operator-system/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/clickhouse/clickhouse.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse/clickhouse.yaml
@@ -1,0 +1,30 @@
+# DESCHEDULED 2026-06-06 — ClickHouse is not in use and its ~16Gi burst on the DGX
+# Sparks was the main OOM risk blocking the DeepSeek-V4-Flash inference rollout.
+# Commenting out this Flux Kustomization makes common-apps (prune: true) remove the
+# `clickhouse` Kustomization cluster-wide, and the operator then deletes the CHI pods,
+# freeing memory on spark-1 (and the ottawa/robbinsdale equivalents).
+# To restore: un-comment this file and reconcile.
+#
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app clickhouse
+#   namespace: flux-system
+# spec:
+#   targetNamespace: clickhouse
+#   commonMetadata:
+#     labels:
+#       app.kubernetes.io/name: *app
+#   path: ./kubernetes/apps/base/clickhouse/clickhouse
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: kubernetes-manifests
+#   wait: false
+#   interval: 0s
+#   retryInterval: 1m
+#   timeout: 5m
+#   dependsOn:
+#     - name: clickhouse-operator-system
+# ---

--- a/kubernetes/apps/robbinsdale/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml

--- a/kubernetes/apps/robbinsdale/clickhouse/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/clickhouse/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./monitoring
+  - ./clickhouse-operator-system
+  - ./clickhouse

--- a/kubernetes/apps/stpetersburg/clickhouse-operator-system/clickhouse-operator-system.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse-operator-system/clickhouse-operator-system.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-operator-system
+  namespace: flux-system
+spec:
+  targetNamespace: clickhouse-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/clickhouse-operator-system/clickhouse-operator-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/clickhouse-operator-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse-operator-system/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml
+  - ./clickhouse-operator-system.yaml

--- a/kubernetes/apps/stpetersburg/clickhouse-operator-system/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/clickhouse/clickhouse.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse/clickhouse.yaml
@@ -1,0 +1,30 @@
+# DESCHEDULED 2026-06-06 — ClickHouse is not in use and its ~16Gi burst on the DGX
+# Sparks was the main OOM risk blocking the DeepSeek-V4-Flash inference rollout.
+# Commenting out this Flux Kustomization makes common-apps (prune: true) remove the
+# `clickhouse` Kustomization cluster-wide, and the operator then deletes the CHI pods,
+# freeing memory on spark-1 (and the ottawa/robbinsdale equivalents).
+# To restore: un-comment this file and reconcile.
+#
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app clickhouse
+#   namespace: flux-system
+# spec:
+#   targetNamespace: clickhouse
+#   commonMetadata:
+#     labels:
+#       app.kubernetes.io/name: *app
+#   path: ./kubernetes/apps/base/clickhouse/clickhouse
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: kubernetes-manifests
+#   wait: false
+#   interval: 0s
+#   retryInterval: 1m
+#   timeout: 5m
+#   dependsOn:
+#     - name: clickhouse-operator-system
+# ---

--- a/kubernetes/apps/stpetersburg/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./monitoring
-  - ./clickhouse-operator-system
-  - ./clickhouse
+  - ./namespace.yaml

--- a/kubernetes/apps/stpetersburg/clickhouse/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/clickhouse/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./monitoring
+  - ./clickhouse-operator-system
+  - ./clickhouse


### PR DESCRIPTION
## Summary

- verbatim copy of `clusters/common/apps/clickhouse-operator-system/app` and `clusters/common/apps/clickhouse/app` to `kubernetes/apps/base/{clickhouse-operator-system,clickhouse}/`
- pointer files for all 3 locations (`ottawa`, `robbinsdale`, `stpetersburg`) with spec.path updated to new base — CR names unchanged (adoption key)
- namespace.yaml files moved to each location tree with `prune: disabled` labels preserved
- clickhouse pointer is all-comments (descheduled 2026-06-06) — namespace.yaml still moves to new tree

## Validation

- `make test` ×3 green (223 passed)
- `flate build ks clickhouse-operator-system` before/after git stash: byte-identical

## Ordering

garage-operator-system + garage follow in a later PR pair (same batch).