### PR TITLE
migrate(batch-d/monitoring): adopt blackbox-exporter-robbinsdale + smartctl-exporter (PR-A)

### DIFF
--- a/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - probes-nodes.yaml
+  - probes-cluster-infra.yaml

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-cluster-infra.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-cluster-infra.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-k8s-api-local
+spec:
+  jobName: blackbox
+  module: http_401
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://k8s.robbinsdale.local:6443/readyz
+      labels:
+        service: kubernetes-api
+        target: cluster-vip
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-cluster-services
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://kube-dns.kube-system:9153/metrics
+        - http://source-controller.flux-system:8080/metrics
+      labels:
+        service: cluster-infra

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-nodes.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-nodes.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-nodes-tcp
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - tank.local:6443
+        - titan.local:6443
+        - stone.local:6443
+      labels:
+        service: nodes
+        target: kubelet-port
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-nas-https
+spec:
+  jobName: blackbox
+  module: http_2xx_insecure
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://nas.local
+      labels:
+        service: nodes
+        target: nas
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-nodes-icmp
+spec:
+  jobName: blackbox
+  module: icmp
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - tank.local
+        - titan.local
+        - stone.local
+        - nas.local
+      labels:
+        service: nodes
+        target: ping

--- a/kubernetes/apps/robbinsdale/monitoring/blackbox-exporter-robbinsdale.yaml
+++ b/kubernetes/apps/robbinsdale/monitoring/blackbox-exporter-robbinsdale.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: blackbox-exporter-robbinsdale
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: blackbox-exporter
+  dependsOn:
+    - name: blackbox-exporter
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/monitoring/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/monitoring/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - ./kromgo.yaml
   - ./unpoller.yaml
   - ./blackbox-exporter.yaml
+  - ./blackbox-exporter-robbinsdale.yaml
+  - ./smartctl-exporter.yaml

--- a/kubernetes/apps/robbinsdale/monitoring/smartctl-exporter.yaml
+++ b/kubernetes/apps/robbinsdale/monitoring/smartctl-exporter.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: smartctl-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: smartctl-exporter
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/smartctl-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: smartctl-exporter-config
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: smartctl-exporter
+  dependsOn:
+    - name: smartctl-exporter
+  path: ./kubernetes/apps/base/monitoring/smartctl-exporter/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

- **blackbox-exporter-robbinsdale**: verbatim copy of `clusters/talos-robbinsdale/apps/blackbox-exporter/app/` to `kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/`; pointer in `kubernetes/apps/robbinsdale/monitoring/blackbox-exporter-robbinsdale.yaml` changes only `spec.path`. CR name `blackbox-exporter-robbinsdale` is the adoption key.
- **smartctl-exporter** + **smartctl-exporter-config**: base already in tree from batch-c (`kubernetes/apps/base/monitoring/smartctl-exporter/`); pointer `kubernetes/apps/robbinsdale/monitoring/smartctl-exporter.yaml` added for both CRs.

## Verification

- `make test`: all 3 clusters pass
- `flate build ks` diff before/after (git stash trick): empty for all 3 CRs
- old parent: `cluster-apps`

## Test plan
- [ ] CI flate green ×3 clusters
- [ ] merge → reconcile `kubernetes-apps` on robbinsdale → confirm `blackbox-exporter-robbinsdale` and `smartctl-exporter` label flips to `kubernetes-apps`
- [ ] confirm pod start times unchanged