### PR TITLE
migrate(batch-e/g1): adopt loki, mimir, mimir-ruler (stpetersburg)

### DIFF
--- a/kubernetes/apps/base/loki/loki/app/egress.yaml
+++ b/kubernetes/apps/base/loki/loki/app/egress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-gateway
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: loki.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP

--- a/kubernetes/apps/base/loki/loki/app/kustomization.yaml
+++ b/kubernetes/apps/base/loki/loki/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: loki
+resources:
+  - egress.yaml

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/blackbox.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/blackbox.yaml
@@ -1,0 +1,47 @@
+# Ported from clusters/common/apps/blackbox-exporter/config/prometheusrule.yaml.
+groups:
+  - name: blackbox-exporter.rules
+    rules:
+      - alert: ProbeFailed
+        expr: probe_success == 0
+        for: 5m
+        annotations:
+          summary: >-
+            Probe failed for {{ $labels.instance }}
+          description: >-
+            The blackbox probe targeting {{ $labels.instance }} has been failing for 5 minutes.
+        labels:
+          severity: critical
+
+      - alert: ProbeSlowResponse
+        expr: probe_duration_seconds > 5
+        for: 10m
+        annotations:
+          summary: >-
+            Slow probe response for {{ $labels.instance }}
+          description: >-
+            The blackbox probe targeting {{ $labels.instance }} is responding slowly (>5s).
+        labels:
+          severity: warning
+
+      - alert: SSLCertExpiringSoon
+        expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 14
+        for: 1h
+        annotations:
+          summary: >-
+            SSL certificate expiring soon for {{ $labels.instance }}
+          description: >-
+            SSL certificate for {{ $labels.instance }} expires in less than 14 days.
+        labels:
+          severity: warning
+
+      - alert: SSLCertExpired
+        expr: probe_ssl_earliest_cert_expiry - time() < 0
+        for: 0m
+        annotations:
+          summary: >-
+            SSL certificate expired for {{ $labels.instance }}
+          description: >-
+            SSL certificate for {{ $labels.instance }} has expired.
+        labels:
+          severity: critical

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/deployment.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/deployment.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir-ruler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir-ruler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir-ruler
+    spec:
+      serviceAccountName: mimir-ruler
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: copy-rules
+          image: busybox:1.38.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /data/rules/talos-stpetersburg && \
+              cp /rules-source/*.yaml /data/rules/talos-stpetersburg/
+          volumeMounts:
+            - name: rules
+              mountPath: /rules-source
+              readOnly: true
+            - name: data
+              mountPath: /data
+      containers:
+        - name: ruler
+          image: grafana/mimir:3.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -target=ruler
+            - -config.file=/conf/mimir.yaml
+          workingDir: /data
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+            - containerPort: 9095
+              name: grpc
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+            - name: rules
+              mountPath: /rules-source
+              readOnly: true
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: mimir-ruler-config
+        - name: rules
+          configMap:
+            name: mimir-ruler-rules
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir-ruler

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/flux.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/flux.yaml
@@ -1,0 +1,18 @@
+# Ported from clusters/common/apps/flux-system/flux-instance/app/prometheusrule.yaml.
+groups:
+  - name: flux-instance.rules
+    rules:
+      - alert: FluxInstanceAbsent
+        expr: absent(flux_instance_info{exported_namespace="flux-system",name="flux"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Flux instance is absent
+      - alert: FluxInstanceNotReady
+        expr: flux_instance_info{exported_namespace="flux-system",name="flux",ready!="True"}
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Flux instance is not ready

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/garage.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/garage.yaml
@@ -1,0 +1,39 @@
+# Ported from clusters/common/apps/garage/app/prometheusrule.yaml.
+groups:
+  - name: garage.rules
+    rules:
+      # probe_success==0 on the local serving probe means /health returned
+      # non-2xx (503 = a partition lost write-quorum) or the endpoint is
+      # unreachable. Scoped to target=local so a known-down remote region's
+      # cross-cluster probe doesn't fire this.
+      - alert: GarageServingUnavailable
+        expr: probe_success{service="garage", check="serving", target="local"} == 0
+        for: 3m
+        annotations:
+          summary: Garage cannot serve writes in this region ({{ $labels.instance }})
+          description: >-
+            The Garage /health serving probe has been non-2xx for 3m
+            (503 Unavailable = a partition lost its write-quorum of up storage
+            nodes, or the admin endpoint is unreachable). Reads may still work
+            in degraded mode, but writes are failing. With replication.factor=2
+            this is one storage node away from a full write outage — restore the
+            missing storage node or add write headroom.
+        labels:
+          severity: critical
+
+      # The gateway tier is the S3 client path (COMMON_S3_ENDPOINT ->
+      # garage-gateway svc). Fires when the gateway Service has no reachable
+      # endpoint — clients fail — even when storage is up.
+      - alert: GarageGatewayUnreachable
+        expr: probe_success{service="garage", tier="gateway", check="port-open", target="local"} == 0
+        for: 2m
+        annotations:
+          summary: Garage gateway tier unreachable in this region ({{ $labels.instance }})
+          description: >-
+            The garage-gateway Service has had no reachable endpoint for 2m.
+            In-cluster S3 clients reach Garage through it (COMMON_S3_ENDPOINT),
+            so they are failing. Check the gateway pods (garage-gateway-N) and
+            their readiness — storage may still be up (this won't show in the
+            storage probes).
+        labels:
+          severity: critical

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/k8gb.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/k8gb.yaml
@@ -1,0 +1,67 @@
+# Ported from clusters/common/apps/k8gb/config/prometheusrules.yaml.
+groups:
+  - name: k8gb.rules
+    rules:
+      - alert: K8gbGslbUnhealthy
+        expr: |
+          k8gb_gslb_ingress_hosts_per_status{status="Unhealthy"} > 0
+        for: 5m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} has {{ $value }}
+            unhealthy host(s).
+        labels:
+          severity: warning
+
+      - alert: K8gbGslbNotFound
+        expr: |
+          k8gb_gslb_ingress_hosts_per_status{status="NotFound"} > 0
+        for: 5m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} has {{ $value }}
+            host(s) in NotFound status.
+        labels:
+          severity: critical
+
+      - alert: K8gbHighErrorRate
+        expr: |
+          sum(rate(k8gb_gslb_errors_total[5m])) by (namespace, name) > 0.1
+        for: 10m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} is generating
+            errors at {{ printf "%.2f" $value }}/s.
+        labels:
+          severity: warning
+
+      - alert: K8gbReconciliationStalled
+        expr: |
+          rate(k8gb_gslb_reconciliation_loops_total{name!="init"}[15m]) == 0
+        for: 15m
+        annotations:
+          summary: >-
+            k8gb reconciliation has stalled - no successful loops in 15 minutes.
+        labels:
+          severity: critical
+
+      - alert: K8gbNoHealthyRecords
+        expr: |
+          k8gb_gslb_healthy_records{name!="init"} == 0
+        for: 5m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} has zero healthy
+            DNS records.
+        labels:
+          severity: critical
+
+      - alert: K8gbEndpointNoTargets
+        expr: |
+          k8gb_endpoint_status_num{name!="init"} == 0
+        for: 5m
+        annotations:
+          summary: >-
+            DNS endpoint {{ $labels.dns_name }} has zero targets.
+        labels:
+          severity: warning

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mimir
+resources:
+  - deployment.yaml
+configMapGenerator:
+  - name: mimir-ruler-config
+    files:
+      - mimir.yaml=mimir-config.yaml
+  - name: mimir-ruler-rules
+    files:
+      - blackbox.yaml
+      - flux.yaml
+      - garage.yaml
+      - k8gb.yaml
+      - monitoring.yaml
+      - smartctl.yaml

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/mimir-config.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/mimir-config.yaml
@@ -1,0 +1,12 @@
+multitenancy_enabled: true
+ruler_storage:
+  backend: local
+  local:
+    directory: /data/rules
+ruler:
+  query_frontend:
+    address: dns:///mimir-qf.mimir.svc.cluster.local:9095
+  alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093/
+  ring:
+    kvstore:
+      store: inmemory

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/monitoring.yaml
@@ -1,0 +1,203 @@
+# Ported from clusters/common/apps/monitoring/config/prometheusrules.yaml.
+# Mimir ruler evaluates these per tenant; the PrometheusRule CRs are no longer
+# evaluated now that Prometheus runs in agent mode.
+groups:
+  - name: container.rules
+    rules:
+      - alert: OomKilled
+        expr: |
+          (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1)
+          and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1
+        for: 0m
+        annotations:
+          summary: >-
+            Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }}
+            has been OOMKilled {{ $value }} times in the last 10 minutes.
+        labels:
+          severity: critical
+
+      - alert: ContainerHighCpuUtilization
+        expr: |
+          (sum(rate(container_cpu_usage_seconds_total{container!="",pod!=""}[5m])) by (pod, container, namespace)
+          / sum(kube_pod_container_resource_limits{resource="cpu",container!=""}) by (pod, container, namespace)) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }}
+            is using {{ printf "%.0f" $value }}% of its CPU limit.
+        labels:
+          severity: warning
+
+      - alert: ContainerHighMemoryUtilization
+        expr: |
+          (sum(container_memory_working_set_bytes{container!="",pod!=""}) by (pod, container, namespace)
+          / sum(kube_pod_container_resource_limits{resource="memory",container!=""}) by (pod, container, namespace)) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }}
+            is using {{ printf "%.0f" $value }}% of its memory limit.
+        labels:
+          severity: warning
+
+  - name: node.rules
+    rules:
+      - alert: NodeHighCpuUsage
+        expr: |
+          (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Node {{ $labels.instance }} has high CPU usage ({{ printf "%.0f" $value }}%).
+        labels:
+          severity: warning
+
+      - alert: NodeHighMemoryUsage
+        expr: |
+          (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Node {{ $labels.instance }} has high memory usage ({{ printf "%.0f" $value }}%).
+        labels:
+          severity: warning
+
+      - alert: NodeDiskPressure
+        expr: |
+          (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) * 100 > 85
+        for: 15m
+        annotations:
+          summary: >-
+            Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} is {{ printf "%.0f" $value }}% full.
+        labels:
+          severity: warning
+
+      - alert: NodeDiskCritical
+        expr: |
+          (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) * 100 > 95
+        for: 5m
+        annotations:
+          summary: >-
+            Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} is {{ printf "%.0f" $value }}% full.
+        labels:
+          severity: critical
+
+      - alert: NodeNotReady
+        expr: |
+          kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 5m
+        annotations:
+          summary: >-
+            Node {{ $labels.node }} is not ready.
+        labels:
+          severity: critical
+
+  - name: kubernetes.rules
+    rules:
+      - alert: KubeAPILatencyHigh
+        expr: |
+          histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!~"WATCH|CONNECT"}[5m])) by (le, verb, resource)) > 4
+        for: 10m
+        annotations:
+          summary: >-
+            Kubernetes API server has high latency for {{ $labels.verb }} {{ $labels.resource }} requests (p99 > 4s).
+        labels:
+          severity: warning
+
+      - alert: KubeAPIErrorsHigh
+        expr: |
+          sum(rate(apiserver_request_total{code=~"5.."}[5m])) by (resource, verb)
+          / sum(rate(apiserver_request_total[5m])) by (resource, verb) * 100 > 5
+        for: 10m
+        annotations:
+          summary: >-
+            Kubernetes API server has high error rate ({{ printf "%.1f" $value }}%) for {{ $labels.verb }} {{ $labels.resource }}.
+        labels:
+          severity: warning
+
+      - alert: PodCrashLooping
+        expr: |
+          increase(kube_pod_container_status_restarts_total[1h]) > 5
+        for: 15m
+        annotations:
+          summary: >-
+            Pod {{ $labels.namespace }}/{{ $labels.pod }} is crash looping ({{ $value }} restarts in the last hour).
+        labels:
+          severity: warning
+
+      - alert: PodNotReady
+        expr: |
+          sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown"}) > 0
+        for: 15m
+        annotations:
+          summary: >-
+            Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 15 minutes.
+        labels:
+          severity: warning
+
+      - alert: DeploymentReplicasMismatch
+        expr: |
+          kube_deployment_spec_replicas != kube_deployment_status_replicas_available
+        for: 15m
+        annotations:
+          summary: >-
+            Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has {{ $value }} replicas mismatch.
+        labels:
+          severity: warning
+
+  - name: dockerhub.rules
+    rules:
+      - alert: DockerhubRateLimitRisk
+        expr: |
+          count(time() - container_last_seen{image=~"(docker.io).*",container!=""} < 30) > 100
+        for: 5m
+        annotations:
+          summary: >-
+            There are {{ $value }} containers pulling from Dockerhub. This may lead to rate limiting.
+        labels:
+          severity: warning
+
+  - name: prometheus.rules
+    rules:
+      - alert: PrometheusTargetDown
+        expr: |
+          up == 0
+        for: 10m
+        annotations:
+          summary: >-
+            Prometheus target {{ $labels.job }}/{{ $labels.instance }} is down.
+        labels:
+          severity: warning
+
+  - name: kubelet.rules
+    rules:
+      # Override of the upstream kube-prometheus-stack KubeletDown rule, kept
+      # from the agent-mode migration. Joins on `node` because our kubelet
+      # ServiceMonitor's synthetic `up` series has an empty `cluster` label.
+      - alert: KubeletDown
+        expr: |
+          absent(up{job="kubelet"} == 1) or
+          (
+            count by (node) (up{job="kubelet"} == 0)
+            and on (node) kube_node_info
+          ) > 0
+        for: 15m
+        annotations:
+          summary: >-
+            Kubelet on {{ $labels.node }} is down or unreachable.
+        labels:
+          severity: critical
+
+  - name: watchdog.rules
+    rules:
+      # Dead man's switch: always-firing heartbeat that drives the Gatus
+      # heartbeat receiver. Replaces the kube-prometheus-stack Watchdog default
+      # rule, which is no longer created (defaultRules.create=false).
+      - alert: Watchdog
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: >-
+            This is an always-firing alert used as an end-to-end liveness check
+            for the alerting pipeline.

--- a/kubernetes/apps/base/mimir/mimir-ruler/app/smartctl.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ruler/app/smartctl.yaml
@@ -1,0 +1,65 @@
+# Ported from clusters/*/apps/smartctl-exporter/config/prometheusrule.yaml.
+# Loaded into every tenant; inert where smartctl_* metrics are absent
+# (e.g. stpetersburg has no smartctl-exporter).
+groups:
+  - name: smartctl-exporter.rules
+    rules:
+      - alert: SmartDeviceHighTemperature
+        expr: |-
+          smartctl_device_temperature{temperature_type="current"} > 65
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has a temperature higher than 65°C
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceTestFailed
+        expr: |-
+          (smartctl_device_smart_status != 1 or smartctl_device_status != 1)
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} did not pass its SMART test
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceCriticalWarning
+        expr: |-
+          smartctl_device_critical_warning != 0
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} is in a critical state
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceMediaErrors
+        expr: |-
+          smartctl_device_media_errors != 0
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has media errors
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceAvailableSpareUnderThreshold
+        expr: |-
+          smartctl_device_available_spare_threshold > smartctl_device_available_spare
+        for: 5m
+        annotations:
+          summary: >-
+            Device {{ $labels.device }} on instance {{ $labels.instance }} is under available spare threshold
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceInterfaceSlow
+        expr: |-
+          smartctl_device_interface_speed{speed_type="current"} != on(device, instance, namespace, pod) smartctl_device_interface_speed{speed_type="max"}
+        for: 5m
+        annotations:
+          summary: >-
+            Device {{ $labels.device }} on instance {{ $labels.instance }} interface is slower than it should be
+        labels:
+          severity: critical

--- a/kubernetes/apps/base/mimir/mimir/app/egress.yaml
+++ b/kubernetes/apps/base/mimir/mimir/app/egress.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mimir-gateway
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: mimir.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mimir-qf
+  annotations:
+    tailscale.com/tailnet-fqdn: mimir-qf.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: grpc
+      port: 9095
+      targetPort: 9095
+      protocol: TCP

--- a/kubernetes/apps/base/mimir/mimir/app/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mimir
+resources:
+  - egress.yaml

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - ./monitoring
   - ./clickhouse-operator-system
   - ./clickhouse
+  - ./loki
+  - ./mimir

--- a/kubernetes/apps/stpetersburg/loki/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/loki/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./loki.yaml

--- a/kubernetes/apps/stpetersburg/loki/loki.yaml
+++ b/kubernetes/apps/stpetersburg/loki/loki.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app loki
+  namespace: flux-system
+spec:
+  targetNamespace: loki
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/loki/loki/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/loki/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/loki/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loki
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/mimir/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/mimir/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./mimir.yaml
+  - ./mimir-ruler.yaml

--- a/kubernetes/apps/stpetersburg/mimir/mimir-ruler.yaml
+++ b/kubernetes/apps/stpetersburg/mimir/mimir-ruler.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mimir-ruler
+  namespace: flux-system
+spec:
+  targetNamespace: mimir
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: mimir-egress
+  path: ./kubernetes/apps/base/mimir/mimir-ruler/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/mimir/mimir.yaml
+++ b/kubernetes/apps/stpetersburg/mimir/mimir.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mimir-egress
+  namespace: flux-system
+spec:
+  targetNamespace: mimir
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/mimir/mimir/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/mimir/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/mimir/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mimir
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary

- verbatim copy of `clusters/talos-stpetersburg/apps/{loki,mimir,mimir-ruler}/app` to `kubernetes/apps/base/{loki/loki,mimir/mimir,mimir/mimir-ruler}/app`
- pointer files in `kubernetes/apps/stpetersburg/{loki,mimir}/` with `spec.path` changed to new tree; CR names unchanged (adoption key)
- `loki` and `mimir` namespace dirs created with `namespace.yaml` (prune: disabled)
- old parent: `cluster-apps` (stpetersburg)
- byte-identical flate check: loki ✓, mimir-egress ✓, mimir-ruler ✓
- make test ×3: all 223 passed

Part of #1553 Batch E.