### PR TITLE
migrate(batch-c/agents): adopt agents namespace

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/configmap.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/configmap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-placeholder-config
+data:
+  GATEWAY_ALLOW_ALL_USERS: "true"
+  API_SERVER_ENABLED: "true"
+  API_SERVER_HOST: "0.0.0.0"
+  API_SERVER_PORT: "8642"
+  API_SERVER_KEY: "${DEFAULT_PASSWORD}"
+  OPENAI_BASE_URL: "http://stpetersburg-vllm/v1"
+  OPENAI_API_KEY: "unused"
+  AGENT_NAME: "placeholder"
+  AGENT_SYSTEM_PROMPT: |
+    You are a group assistant. Override this per group.

--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/deployment.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/deployment.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-placeholder
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-placeholder
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hermes-placeholder
+    spec:
+      containers:
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["gateway", "run"]
+          envFrom:
+            - configMapRef:
+                name: hermes-placeholder-config
+            - secretRef:
+                name: hermes-placeholder-secrets
+          env:
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "127.0.0.1"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: gateway
+              containerPort: 8642
+            - name: dashboard
+              containerPort: 9119
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              memory: 6Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+        - name: workspace
+          image: ghcr.io/outsourc-e/hermes-workspace@sha256:2d2ba9aa5b1230766267322817e8e51113541780a5797802a582a47cc34a3df3
+          env:
+            - name: HERMES_API_URL
+              value: "http://127.0.0.1:8642"
+            - name: HERMES_DASHBOARD_URL
+              value: "http://127.0.0.1:9119"
+            - name: HERMES_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-placeholder-secrets
+                  key: API_SERVER_KEY
+            # Autologin: no HERMES_PASSWORD so the workspace's own gate stays off
+            # (isAuthRequired = getConfiguredPassword().length>0). Binding 0.0.0.0
+            # without a password trips the workspace's safety refusal, so we set
+            # HERMES_ALLOW_INSECURE_REMOTE=1 to bypass it. Safe here: the Service is
+            # ClusterIP and the only external path is Envoy's Pocket ID OIDC gate,
+            # so every reachable caller is already authenticated. HERMES_API_TOKEN
+            # above still secures the workspace->gateway loopback call.
+            - name: HERMES_ALLOW_INSECURE_REMOTE
+              value: "1"
+            - name: PORT
+              value: "3000"
+          ports:
+            - name: workspace
+              containerPort: 3000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-placeholder-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/garagekey.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/garagekey.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: hermes-placeholder-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "hermes-placeholder"
+  secretTemplate:
+    name: hermes-placeholder-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: agents
+        namespace: garage
+      read: true
+      write: true

--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/httproute.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/httproute.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hermes-placeholder
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "placeholder.agents.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: hermes-placeholder
+          port: 3000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/kustomization.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - securitypolicy.yaml
+  - storagestack.yaml
+  - garagekey.yaml
+replacements:
+  - source:
+      kind: ConfigMap
+      name: group-meta
+      fieldPath: data.name
+    targets:
+      - select: { kind: Deployment, name: hermes-placeholder }
+        fieldPaths:
+          - metadata.name
+          - spec.selector.matchLabels.[app.kubernetes.io/name]
+          - spec.template.metadata.labels.[app.kubernetes.io/name]
+          - spec.template.spec.volumes.0.persistentVolumeClaim.claimName
+          - spec.template.spec.containers.0.envFrom.0.configMapRef.name
+          - spec.template.spec.containers.0.envFrom.1.secretRef.name
+          - spec.template.spec.containers.1.env.2.valueFrom.secretKeyRef.name
+        options: { delimiter: "-", index: 1 }
+      - select: { kind: Service, name: hermes-placeholder }
+        fieldPaths:
+          - metadata.name
+          - spec.selector.[app.kubernetes.io/name]
+        options: { delimiter: "-", index: 1 }
+      - select: { kind: HTTPRoute, name: hermes-placeholder }
+        fieldPaths:
+          - metadata.name
+          - spec.rules.0.backendRefs.0.name
+        options: { delimiter: "-", index: 1 }
+      - select: { group: gateway.envoyproxy.io, kind: SecurityPolicy, name: hermes-placeholder }
+        fieldPaths:
+          - metadata.name
+          - spec.targetRefs.0.name
+          - spec.oidc.clientSecret.name
+        options: { delimiter: "-", index: 1 }
+      - select: { kind: StorageStack, name: hermes-placeholder-data }
+        fieldPaths:
+          - metadata.name
+          - spec.name
+        options: { delimiter: "-", index: 1 }
+      - select: { group: garage.rajsingh.info, kind: GarageKey }
+        fieldPaths:
+          - metadata.name
+          - spec.name
+          - spec.secretTemplate.name
+        options: { delimiter: "-", index: 1 }
+      - select: { kind: ConfigMap, name: hermes-placeholder-config }
+        fieldPaths:
+          - metadata.name
+        options: { delimiter: "-", index: 1 }
+  - source: { kind: ConfigMap, name: group-meta, fieldPath: data.name }
+    targets:
+      - select: { kind: ConfigMap }
+        reject:
+          - name: group-meta
+        fieldPaths:
+          - data.AGENT_NAME
+  - source: { kind: ConfigMap, name: group-meta, fieldPath: data.name }
+    targets:
+      - select: { kind: StorageStack }
+        fieldPaths: [ spec.s3Path ]
+        options: { delimiter: "/", index: 1 }
+  - source: { kind: ConfigMap, name: group-meta, fieldPath: data.host }
+    targets:
+      - select: { kind: HTTPRoute }
+        fieldPaths: [ spec.hostnames.0 ]
+      - select: { group: gateway.envoyproxy.io, kind: SecurityPolicy }
+        fieldPaths: [ spec.oidc.redirectURL ]
+        options: { delimiter: "/", index: 2 }
+  - source: { kind: ConfigMap, name: group-meta, fieldPath: data.clientID }
+    targets:
+      - select: { group: gateway.envoyproxy.io, kind: SecurityPolicy }
+        fieldPaths: [ spec.oidc.clientID ]
+  - source: { kind: ConfigMap, name: group-meta, fieldPath: data.size }
+    targets:
+      - select: { kind: StorageStack }
+        fieldPaths: [ spec.size ]

--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/securitypolicy.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/securitypolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: hermes-placeholder
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hermes-placeholder
+  oidc:
+    provider:
+      issuer: "https://pocket-id.keiretsu.top"
+    clientID: "placeholder-client-id"
+    clientSecret:
+      name: hermes-placeholder-oidc
+    redirectURL: "https://placeholder/oauth2/callback"
+    logoutPath: "/logout"
+    cookieDomain: "agents.${COMMON_DOMAIN}"

--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/service.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-placeholder
+spec:
+  selector:
+    app.kubernetes.io/name: hermes-placeholder
+  ports:
+    - name: workspace
+      port: 3000
+      targetPort: 3000
+    - name: gateway
+      port: 8642
+      targetPort: 8642

--- a/kubernetes/apps/base/agents/agents/app/_component/hermes-group/storagestack.yaml
+++ b/kubernetes/apps/base/agents/agents/app/_component/hermes-group/storagestack.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: hermes-placeholder-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: hermes-placeholder-data
+  size: 20Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/placeholder/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot
+  restorePaused: false

--- a/kubernetes/apps/base/agents/agents/app/abtar/configmap.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/configmap.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: abtar-config
+data:
+  GATEWAY_ALLOW_ALL_USERS: "true"
+  API_SERVER_ENABLED: "true"
+  API_SERVER_HOST: "0.0.0.0"
+  API_SERVER_PORT: "8642"
+  API_SERVER_KEY: "${DEFAULT_PASSWORD}"
+  DISCORD_REQUIRE_MENTION: "false"
+  DISCORD_AUTO_THREAD: "true"
+  DISCORD_REACTIONS: "true"
+
+  # ---- Browser toolset (web_extract / browser_* tools) ----
+  # The image already bundles Chromium (Chrome for Testing) + the agent-browser
+  # CLI. Hermes auto-injects --no-sandbox only when running as root or on
+  # AppArmor-restricted hosts. This pod runs as uid 10000 (non-root, via
+  # s6-setuidgid) on Talos with no AppArmor userns flag, so neither trigger
+  # fires and Chromium dies with "No usable sandbox". Setting the flag
+  # explicitly is the documented fix (browser_tool.py honours AGENT_BROWSER_ARGS).
+  AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+
+  # ---- Camofox browser backend (watchable browser) ----
+  # Routes the browser_* tools through the camofox deployment instead of the
+  # bundled headless shell. Camofox runs headed with a noVNC viewer, so raj can
+  # watch live and take over (logins) at https://camofox.keiretsu.ts.net.
+  # Cluster-internal API; no auth header is sent by Hermes, so the API service
+  # is ClusterIP-only.
+  CAMOFOX_URL: "http://camofox.agents.svc.cluster.local:9377"
+
+  # ---- Web extract backend (self-hosted Firecrawl) ----
+  # web_extract routes to the self-hosted Firecrawl canary in the firecrawl ns
+  # (clusters/talos-ottawa/apps/firecrawl). SearXNG is search-only and cannot
+  # extract URL content, so web.extract_backend=firecrawl in /opt/data/config.yaml
+  # plus this URL is what makes web_extract work. Same-cluster ClusterIP; no key
+  # needed for self-hosted scrape->markdown.
+  FIRECRAWL_API_URL: "http://api.firecrawl.svc.cluster.local:3002"
+
+  # LLM endpoint lives in /opt/data/config.yaml inside the PVC (set once via
+  # kubectl exec; reachable through the `stpetersburg-vllm` ExternalName).
+  # OPENAI_BASE_URL is kept so Hermes auxiliary clients (summarization /
+  # compression) route to the same vLLM endpoint when they're invoked.
+  OPENAI_BASE_URL: "http://stpetersburg-vllm/v1"
+  OPENAI_API_KEY: "unused"
+
+  # ---- WhatsApp bridge (Baileys, self-chat mode) ----
+  # Pair once: kubectl exec -it deploy/abtar -c gateway --
+  #   /opt/hermes/.venv/bin/hermes whatsapp
+  # Session persists at /opt/data/whatsapp/session/ in the PVC.
+  WHATSAPP_ENABLED: "true"
+  WHATSAPP_MODE: "self-chat"
+  WHATSAPP_ALLOWED_USERS: "16516051093"
+
+  # ---- Persona ----
+  AGENT_NAME: "abtar"
+  AGENT_PERSONA: "assistant"
+  AGENT_SYSTEM_PROMPT: |
+    You are Abtar, a personal assistant.
+    You manage calendar, email, notes, reminders, and life logistics.
+    Default tone: warm, proactive, terse. Remember context across days.
+    When uncertain, prefer to ask one clarifying question over guessing.

--- a/kubernetes/apps/base/agents/agents/app/abtar/deployment.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: abtar
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: abtar
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: abtar
+        agents.keiretsu.ts.net/persona: assistant
+        agents.keiretsu.ts.net/owner: raj
+    spec:
+      initContainers:
+        - name: seed-aws-credentials
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /opt/data/.aws
+              umask 077
+              cat >/opt/data/.aws/credentials <<EOF
+              [default]
+              aws_access_key_id = $${AWS_ACCESS_KEY_ID}
+              aws_secret_access_key = $${AWS_SECRET_ACCESS_KEY}
+              EOF
+              cat >/opt/data/.aws/config <<EOF
+              [default]
+              region = $${AWS_REGION}
+              endpoint_url = $${AWS_ENDPOINT_URL}
+              s3 =
+                  endpoint_url = $${AWS_ENDPOINT_URL_S3}
+                  addressing_style = path
+              EOF
+          envFrom:
+            - secretRef:
+                name: abtar-s3
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      containers:
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["gateway", "run"]
+          envFrom:
+            - configMapRef:
+                name: abtar-config
+            - secretRef:
+                name: abtar-secrets
+            - secretRef:
+                name: abtar-s3
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/data/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /opt/data/.aws/config
+            # v2026.5.29 introduced s6 supervision — dashboard runs in the same
+            # container as the gateway. HERMES_DASHBOARD=1 spawns it; TUI=1
+            # enables the embedded chat tab; HOST=0.0.0.0 exposes it.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            # Skip the dashboard's OAuth gate. Safe here because access is
+            # already gated at the network layer by Tailscale `tag:raj` ACL.
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: gateway
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              memory: 6Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: abtar-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/apps/base/agents/agents/app/abtar/garagekey.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/garagekey.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: abtar-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "abtar S3 Reader Key"
+  allBuckets:
+    read: true
+  secretTemplate:
+    name: abtar-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://${COMMON_S3_ENDPOINT}"
+      AWS_ENDPOINT_URL_S3: "http://${COMMON_S3_ENDPOINT}"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/agents/agents/app/abtar/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - deployment.yaml
+  - service.yaml
+  - service-tailscale.yaml
+  - storagestack.yaml
+  - garagekey.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/agents/agents/app/abtar/secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/secret.yaml
@@ -1,0 +1,14 @@
+---
+# Fill in real values then re-apply. Encrypt before committing real tokens:
+#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: abtar-secrets
+type: Opaque
+stringData:
+  # Discord disabled until a real token is provided.
+  # DISCORD_BOT_TOKEN: ""
+  GOOGLE_OAUTH_CLIENT_ID: ""
+  GOOGLE_OAUTH_CLIENT_SECRET: ""
+  NOTION_TOKEN: ""

--- a/kubernetes/apps/base/agents/agents/app/abtar/service-tailscale.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/service-tailscale.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: abtar-ts
+  annotations:
+    tailscale.com/hostname: abtar
+    tailscale.com/tags: "tag:raj"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: abtar
+  ports:
+    - name: dashboard
+      port: 80
+      targetPort: 9119
+      protocol: TCP
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/abtar/service.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: abtar
+spec:
+  selector:
+    app.kubernetes.io/name: abtar
+  ports:
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: 9119
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/abtar/storagestack.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/storagestack.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: abtar-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: abtar-data
+  size: 20Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/abtar/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot
+  restorePaused: false

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/bucket.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/bucket.yaml
@@ -1,0 +1,23 @@
+---
+# Garage bucket for raj-assistant's static website (served via Garage Web API)
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: raj-assistant-web
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: raj-assistant-web
+  quotas:
+    maxSize: 1Gi
+    maxObjects: 10000
+  website:
+    indexDocument: "index.html"
+    errorDocument: "error.html"
+  keyPermissions:
+    - keyRef:
+        name: raj-assistant-web-s3-key
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/configmap.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/configmap.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: assistant-raj-config
+data:
+  GATEWAY_ALLOW_ALL_USERS: "true"
+  API_SERVER_ENABLED: "true"
+  API_SERVER_HOST: "0.0.0.0"
+  API_SERVER_PORT: "8642"
+  API_SERVER_KEY: "${DEFAULT_PASSWORD}"
+  DISCORD_REQUIRE_MENTION: "false"
+  DISCORD_AUTO_THREAD: "true"
+  DISCORD_REACTIONS: "true"
+
+  # ---- Browser toolset (web_extract / browser_* tools) ----
+  # The image already bundles Chromium (Chrome for Testing) + the agent-browser
+  # CLI. Hermes auto-injects --no-sandbox only when running as root or on
+  # AppArmor-restricted hosts. This pod runs as uid 10000 (non-root, via
+  # s6-setuidgid) on Talos with no AppArmor userns flag, so neither trigger
+  # fires and Chromium dies with "No usable sandbox". Setting the flag
+  # explicitly is the documented fix (browser_tool.py honours AGENT_BROWSER_ARGS).
+  AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+
+  # ---- Camofox browser backend (watchable browser) ----
+  # Routes the browser_* tools through the camofox deployment instead of the
+  # bundled headless shell. Camofox runs headed with a noVNC viewer, so raj can
+  # watch live and take over (logins) at https://camofox.keiretsu.ts.net.
+  # Cluster-internal API; no auth header is sent by Hermes, so the API service
+  # is ClusterIP-only.
+  CAMOFOX_URL: "http://camofox.agents.svc.cluster.local:9377"
+
+  # LLM endpoint lives in /opt/data/config.yaml inside the PVC (set once via
+  # kubectl exec; reachable through the `stpetersburg-vllm` ExternalName).
+  # OPENAI_BASE_URL is kept so Hermes auxiliary clients (summarization /
+  # compression) route to the same vLLM endpoint when they're invoked.
+  OPENAI_BASE_URL: "http://stpetersburg-vllm/v1"
+  OPENAI_API_KEY: "unused"
+
+  # ---- WhatsApp bridge (Baileys, self-chat mode) ----
+  # Pair once: kubectl exec -it deploy/assistant-raj -c gateway --
+  #   /opt/hermes/.venv/bin/hermes whatsapp
+  # Session persists at /opt/data/whatsapp/session/ in the PVC.
+  WHATSAPP_ENABLED: "true"
+  WHATSAPP_MODE: "self-chat"
+  WHATSAPP_ALLOWED_USERS: "16516051493"
+
+  # ---- Persona ----
+  AGENT_NAME: "assistant-raj"
+  AGENT_PERSONA: "assistant"
+  AGENT_SYSTEM_PROMPT: |
+    You are Assistant-Raj, Raj's personal assistant.
+    You manage calendar, email, notes, reminders, and life logistics.
+    Default tone: warm, proactive, terse. Remember context across days.
+    When uncertain, prefer to ask one clarifying question over guessing.

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/deployment.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assistant-raj
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: assistant-raj
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: assistant-raj
+        agents.keiretsu.ts.net/persona: assistant
+        agents.keiretsu.ts.net/owner: raj
+    spec:
+      initContainers:
+        - name: seed-aws-credentials
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /opt/data/.aws
+              umask 077
+              cat >/opt/data/.aws/credentials <<EOF
+              [default]
+              aws_access_key_id = $${AWS_ACCESS_KEY_ID}
+              aws_secret_access_key = $${AWS_SECRET_ACCESS_KEY}
+              EOF
+              cat >/opt/data/.aws/config <<EOF
+              [default]
+              region = $${AWS_REGION}
+              endpoint_url = $${AWS_ENDPOINT_URL}
+              s3 =
+                  endpoint_url = $${AWS_ENDPOINT_URL_S3}
+                  addressing_style = path
+              EOF
+          envFrom:
+            - secretRef:
+                name: assistant-raj-s3
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      containers:
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["gateway", "run"]
+          envFrom:
+            - configMapRef:
+                name: assistant-raj-config
+            - secretRef:
+                name: assistant-raj-secrets
+            - secretRef:
+                name: assistant-raj-s3
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/data/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /opt/data/.aws/config
+            # v2026.5.29 introduced s6 supervision — dashboard runs in the same
+            # container as the gateway. HERMES_DASHBOARD=1 spawns it; TUI=1
+            # enables the embedded chat tab; HOST=0.0.0.0 exposes it.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            # Skip the dashboard's OAuth gate. Safe here because access is
+            # already gated at the network layer by Tailscale `tag:raj` ACL.
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: gateway
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              memory: 6Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: assistant-raj-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/egress.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/egress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-vllm
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-vllm.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/garagekey-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/garagekey-web.yaml
@@ -1,0 +1,24 @@
+---
+# S3 key for raj-assistant to write to its web bucket (raj-assistant-web).
+# Used by the status-page cron job to upload HTML/CSS to Garage.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: raj-assistant-web-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "raj-assistant web S3 key"
+  allBuckets:
+    read: true
+    write: true
+  secretTemplate:
+    name: raj-assistant-web-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://garage.garage.svc.cluster.local:3900"
+      AWS_ENDPOINT_URL_S3: "http://garage.garage.svc.cluster.local:3900"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/garagekey.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/garagekey.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: assistant-raj-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "assistant-raj S3 Reader Key"
+  allBuckets:
+    read: true
+  secretTemplate:
+    name: assistant-raj-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://${COMMON_S3_ENDPOINT}"
+      AWS_ENDPOINT_URL_S3: "http://${COMMON_S3_ENDPOINT}"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-web.yaml
@@ -1,0 +1,43 @@
+---
+# raj-assistant-web static site served from Garage S3 via web API (port 3902)
+# OIDC-gated through the public/private gateways (same pattern as grafana).
+# Garage resolves buckets by stripping the root_domain suffix from the Host
+# header, so we rewrite hostname → raj-assistant-web.keiretsu.top (bucket name).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: raj-assistant-web
+  annotations:
+    item.homer.rajsingh.info/name: "Raj Assistant Web"
+    item.homer.rajsingh.info/subtitle: "Status Page"
+    item.homer.rajsingh.info/keywords: "website, raj, assistant, agent"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-globe"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "raj.agents.${COMMON_DOMAIN}"
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: "raj-assistant-web.${COMMON_DOMAIN}"
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          namespace: garage
+          port: 3902
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - deployment.yaml
+  - service.yaml
+  - service-tailscale.yaml
+  - storagestack.yaml
+  - garagekey.yaml
+  - garagekey-web.yaml
+  - bucket.yaml
+  - httproute-web.yaml
+  - securitypolicy-web.yaml
+  - oidc-secret.yaml
+  - egress.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/oidc-secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/oidc-secret.yaml
@@ -1,0 +1,10 @@
+---
+# Shared envoy Gateway OIDC client secret — same creds used by grafana, frigate, etc.
+# ${ENVOY_GATEWAY_OIDC_CLIENT_SECRET} from common-secrets via Flux postBuild substitution.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: raj-assistant-web-oidc
+type: Opaque
+stringData:
+  client-secret: "${ENVOY_GATEWAY_OIDC_CLIENT_SECRET}"

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/secret.yaml
@@ -1,0 +1,14 @@
+---
+# Fill in real values then re-apply. Encrypt before committing real tokens:
+#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: assistant-raj-secrets
+type: Opaque
+stringData:
+  # Discord disabled until a real token is provided.
+  # DISCORD_BOT_TOKEN: ""
+  GOOGLE_OAUTH_CLIENT_ID: ""
+  GOOGLE_OAUTH_CLIENT_SECRET: ""
+  NOTION_TOKEN: ""

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/securitypolicy-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/securitypolicy-web.yaml
@@ -1,0 +1,22 @@
+---
+# OIDC gate for raj-assistant-web — uses the shared/envoy gateway OIDC client
+# (the same one grafana, frigate, etc. use) so users don't need a separate
+# Pocket ID client per agent web app.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: raj-assistant-web-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: raj-assistant-web
+  oidc:
+    provider:
+      issuer: "https://pocket-id.keiretsu.top"
+    clientID: "${ENVOY_GATEWAY_OIDC_CLIENT_ID}"
+    clientSecret:
+      name: raj-assistant-web-oidc
+    redirectURL: "https://raj.agents.${COMMON_DOMAIN}/oauth2/callback"
+    logoutPath: "/logout"
+    cookieDomain: "agents.${COMMON_DOMAIN}"

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/service-tailscale.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/service-tailscale.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: assistant-raj-ts
+  annotations:
+    tailscale.com/hostname: assistant-raj
+    tailscale.com/tags: "tag:raj"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: assistant-raj
+  ports:
+    - name: dashboard
+      port: 80
+      targetPort: 9119
+      protocol: TCP
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/service.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: assistant-raj
+spec:
+  selector:
+    app.kubernetes.io/name: assistant-raj
+  ports:
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: 9119
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/storagestack.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/storagestack.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: assistant-raj-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: assistant-raj-data
+  size: 20Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/assistant-raj/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot
+  restorePaused: false

--- a/kubernetes/apps/base/agents/agents/app/bucket.yaml
+++ b/kubernetes/apps/base/agents/agents/app/bucket.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: agents
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: agents
+  quotas:
+    maxSize: 100Gi
+    maxObjects: 10000000
+  keyPermissions:
+    - keyRef:
+        name: assistant-raj-s3-key
+      read: true
+      write: true
+      owner: true
+    - keyRef:
+        name: abtar-s3-key
+      read: true
+      write: true
+      owner: true
+    - keyRef:
+        name: kartik-s3-key
+      read: true
+      write: true
+      owner: true
+    - keyRef:
+        name: teaspoon-s3-key
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/agents/agents/app/camofox/configmap.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/configmap.yaml
@@ -1,0 +1,22 @@
+---
+# Overrides the image's baked-in /app/camofox.config.json. The shipped config
+# sets vnc.enabled=false, and the plugin loader builds its allowlist from this
+# file BEFORE the plugin's register() runs — so ENABLE_VNC env alone is ignored
+# (it's only read inside the plugin). We must enable vnc here. Password,
+# resolution and novncPort are supplied via env (VNC_PASSWORD/NOVNC_PORT), which
+# the plugin treats as overrides.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: camofox-config
+data:
+  camofox.config.json: |
+    {
+      "id": "camofox-browser",
+      "name": "Camofox Browser",
+      "plugins": {
+        "youtube": { "enabled": true },
+        "persistence": { "enabled": true },
+        "vnc": { "enabled": true, "resolution": "1920x1080", "novncPort": 6080 }
+      }
+    }

--- a/kubernetes/apps/base/agents/agents/app/camofox/deployment.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/deployment.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: camofox
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: camofox
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: camofox
+    spec:
+      containers:
+        - name: camofox
+          # Upstream prebuilt image (no vendored blob). Camoufox is baked in at
+          # build time (~300MB) so first start is fast.
+          image: ghcr.io/jo-inc/camofox-browser:1.11.2
+          # The published image bakes the vnc plugin CODE but not its runtime
+          # binaries (install-plugin-deps.sh runs against the shipped config
+          # where vnc.enabled=false, so x11vnc/noVNC/websockify are absent).
+          # Install them at startup (runs as root, apt egress available), then
+          # hand off to the image's normal CMD. ~15s added to cold start.
+          # NOTE future hardening: bake a thin custom image (FROM this + apt
+          # install) in Harbor to drop the runtime install + network dep.
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              if ! command -v x11vnc >/dev/null 2>&1; then
+                apt-get update
+                apt-get install -y --no-install-recommends \
+                  x11vnc novnc python3-websockify net-tools procps
+                rm -rf /var/lib/apt/lists/*
+              fi
+              exec node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-128} server.js
+          env:
+            # REST API port consumed by Hermes via CAMOFOX_URL (cluster-internal).
+            - name: CAMOFOX_PORT
+              value: "9377"
+            # Headed mode + interactive noVNC web viewer so raj can watch the
+            # browser live and take over (e.g. logins) mid-task.
+            - name: ENABLE_VNC
+              value: "1"
+            - name: NOVNC_PORT
+              value: "6080"
+            # websockify defaults to binding 127.0.0.1; the Tailscale LB routes
+            # to the pod IP, so bind 0.0.0.0. Safe because VNC is password
+            # protected (VNC_PASSWORD) and only the noVNC port is LB-exposed.
+            - name: VNC_BIND
+              value: "0.0.0.0"
+          envFrom:
+            # VNC_PASSWORD = ${DEFAULT_PASSWORD} (see secret.yaml).
+            - secretRef:
+                name: camofox-secrets
+          ports:
+            - name: api
+              containerPort: 9377
+              protocol: TCP
+            - name: novnc
+              containerPort: 6080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: api
+            initialDelaySeconds: 90
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 3Gi
+          volumeMounts:
+            - name: shm
+              mountPath: /dev/shm
+            - name: config
+              mountPath: /app/camofox.config.json
+              subPath: camofox.config.json
+            # Persistent browser profile (cookies, logins, per-user storage
+            # state) so they survive pod restarts. HOME=/root, and camofox
+            # writes profiles/cookies under ~/.camofox.
+            - name: data
+              mountPath: /root/.camofox
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        - name: config
+          configMap:
+            name: camofox-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: camofox-data
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/apps/base/agents/agents/app/camofox/httproute.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/httproute.yaml
@@ -1,0 +1,35 @@
+---
+# noVNC viewer over the tailnet via the `ts` gateway (HTTPS on *.${CLUSTER_DOMAIN}).
+# Using the gateway (not just the plain-HTTP camofox-ts LB) gives a real TLS
+# endpoint, so noVNC connects with wss:// and the stream actually renders —
+# the L4 LB on port 80 forced ws:// and browsers auto-upgrading to https broke it.
+# Routes ONLY the noVNC web UI (6080); the camofox REST API (9377) is never exposed.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: camofox
+  annotations:
+    item.homer.rajsingh.info/name: "Camofox"
+    item.homer.rajsingh.info/subtitle: "Watchable browser"
+    item.homer.rajsingh.info/keywords: "browser, vnc, camofox, agent"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-globe"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "camofox.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: camofox
+          port: 6080
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/camofox/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - service-tailscale.yaml
+  - httproute.yaml
+  - storagestack.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/agents/agents/app/camofox/secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/secret.yaml
@@ -1,0 +1,11 @@
+---
+# VNC password for the noVNC viewer. ${DEFAULT_PASSWORD} is substituted by
+# Flux postBuild (common-secrets) — same pattern as assistant-raj API_SERVER_KEY
+# and tracearr. Not SOPS-encrypted because the value is injected at reconcile
+# time, not stored here.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camofox-secrets
+stringData:
+  VNC_PASSWORD: ${DEFAULT_PASSWORD}

--- a/kubernetes/apps/base/agents/agents/app/camofox/service-tailscale.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/service-tailscale.yaml
@@ -1,0 +1,22 @@
+---
+# Live browser viewer over the tailnet. Exposes ONLY the noVNC web UI (6080)
+# on port 80, gated to tag:raj. raj opens https://camofox.keiretsu.ts.net to
+# watch the browser live and take over (logins, etc.). VNC itself is password
+# protected (VNC_PASSWORD=${DEFAULT_PASSWORD}) as defense-in-depth.
+apiVersion: v1
+kind: Service
+metadata:
+  name: camofox-ts
+  annotations:
+    tailscale.com/hostname: camofox
+    tailscale.com/tags: "tag:raj"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: camofox
+  ports:
+    - name: novnc
+      port: 80
+      targetPort: 6080
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/camofox/service.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/service.yaml
@@ -1,0 +1,26 @@
+---
+# Cluster-internal REST API. Hermes (assistant-raj) reaches camofox at
+# http://camofox.agents.svc.cluster.local:9377 via CAMOFOX_URL.
+# NOT exposed beyond the cluster: Hermes's camofox client sends no auth
+# header, so the API must stay unauthenticated AND unreachable externally.
+apiVersion: v1
+kind: Service
+metadata:
+  name: camofox
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: camofox
+  ports:
+    - name: api
+      port: 9377
+      targetPort: 9377
+      protocol: TCP
+    # noVNC web viewer — exposed cluster-internally so the HTTPRoute on the
+    # `ts` gateway can target it (camofox.${CLUSTER_DOMAIN} over HTTPS, which
+    # makes noVNC use wss and fixes the broken stream over the plain-HTTP LB).
+    # The API (9377) is deliberately NOT routed externally.
+    - name: novnc
+      port: 6080
+      targetPort: 6080
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/camofox/storagestack.yaml
+++ b/kubernetes/apps/base/agents/agents/app/camofox/storagestack.yaml
@@ -1,0 +1,21 @@
+---
+# Persistent browser profile storage for camofox. Without this, the browser
+# profile (cookies, logins, storage-state.json per user) lives on the pod's
+# ephemeral overlay and is WIPED on every restart (liveness probe, OOM near the
+# 3Gi limit, node events) — forcing re-login every time. camofox already writes
+# per-user storage state to ~/.camofox/profiles/<userId>/storage-state.json and
+# restores it on the next session; this PVC just makes that directory durable.
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: camofox-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: camofox-data
+  size: 10Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/camofox/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot
+  restorePaused: false

--- a/kubernetes/apps/base/agents/agents/app/egress.yaml
+++ b/kubernetes/apps/base/agents/agents/app/egress.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ai.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aperture
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: aperture.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/groups/demo/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/groups/demo/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+components:
+  - ../../_component/hermes-group
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    config.kubernetes.io/local-config: "true"
+configMapGenerator:
+  - name: group-meta
+    literals:
+      - name=demo
+      - host=demo.agents.${COMMON_DOMAIN}
+      - clientID=521f2f61-f465-4f06-8c84-eafd501cdf62
+      - size=20Gi
+resources:
+  - secret.sops.yaml
+patches:
+  - target:
+      kind: ConfigMap
+      name: hermes-placeholder-config
+    patch: |-
+      - op: replace
+        path: /data/AGENT_SYSTEM_PROMPT
+        value: |
+          You are the Demo group's shared assistant.
+          Keep answers terse and technical.

--- a/kubernetes/apps/base/agents/agents/app/groups/demo/secret.sops.yaml
+++ b/kubernetes/apps/base/agents/agents/app/groups/demo/secret.sops.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hermes-demo-secrets
+type: Opaque
+stringData:
+    API_SERVER_KEY: ENC[AES256_GCM,data:eulAnKgEfjIMerT1hCcf50hO8H6cOLP6lRat7pe/3f9IDJGukyKcVQPgBRaVF0mn,iv:8/TCDlk0cGUTTufMr7FgHmwXSJusoVB71bXS91lnbAY=,tag:PAZ7rbryPzPsXDBCeKKFAQ==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-07T19:47:57Z"
+    mac: ENC[AES256_GCM,data:XApqhwvMc4va8uCSDsvp5tJx2L3dQXY0Q45f350euYNwWkLIHvIvHCrXVdw/8d7KSh+w3yIJho0U81eB11sTwyHibWb7O79ijvXiV+NtmpWlKnrvhWaa1ullc6qInANkU5ef0RocPtZtOtRjZ/XkxvMkODWB/XL0elj6rsTQcig=,iv:zWiNN+mBFkPjKXhuUdVTyJeuhmVZRVRQz2fMMtoxroY=,tag:Ah8ZLvVrb92kS0sQqDjQEA==,type:str]
+    pgp:
+        - created_at: "2026-06-07T19:47:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveARAAmRtBCzPLl5+xB5mSA7WmHdOlanrf3m1wnQ+xXAW5m7NH
+            cyLR0iKk1AZlZWUKUDW0BHZkObcary5KB7BTN0A0zn7Ti2uzkyIQ0IT6tNpZ76+P
+            QUlzLhkKfwrfQY87vZu5dYHAEAQvfyRSjZOqaJ4Z6CzDYg6dbU2ZhBuCyPpiSll/
+            mPH6fs9Vs3BTfs4WIWKZ23rZGE322yX/L9UgoLgEQqIj0cPeJ4NmHb1lVv6dZDc1
+            Jh4oU2ltLy1YegS2N4JRp7pa2EkITFiWAmjp0pQW0o88qJaBoIWXIbDoSnbMflnh
+            tYPIArZisByQ8XbIhqAYl9MpvRZuiZLw37jFLNl2XL9qJ6X+eEgsLnnxcupKQT5S
+            4PvFSfibKM+AQUaxcOkU7bZh6t4AsQw3Itrqkp+Y3fUh6y2ZEBKc4pmlab6Fjqhd
+            ghIkVaVEPqFqh0x8Bdr6FVpCl0IWfnDG8i+TE0x0yXIBl9pgM64u74RGc6L5ZsRU
+            3iofsy/8vLQLHV9ZFirXVp7rcLRpljJ36P/eCmd1inoCszxI4rmlFM/c1Q3SdK1p
+            pP35iVDTDJkgeo/mDN0SAxTe9v3wI/b+jYK+3Ce+hJzqP/M/Mi0TARgnYO1S+1iJ
+            Q3Rhub5x9kqnDOk6hglKenWuBxA6cP0Futk8KWrq2VnT5gJxjJhbmtmil0NLG/fU
+            aAEJAhBv3Hofb5nxnru8kCPU05rKRO584Y+9NHLeZaSZjfhUfafu8UmmtkaQlQwB
+            EmvP5W+HzCB3ckcPaPZG/sVjqQ6xKwOAkfEg7krmeqo187uqYcJUnCNHnGRDU2Zh
+            VZxeGVczO/IP
+            =9+zJ
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hermes-demo-oidc
+type: Opaque
+stringData:
+    client-secret: ENC[AES256_GCM,data:Zof1Wya7eaG0/hoHpAIsU1CRsi2GGk8G3znYOMBnkMw=,iv:1noyEEwKdb2XDWyDAlxR9UkedYGUuwvbf6d/BGRnVV4=,tag:Dmr+qufntmNXasbph5+f4A==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-07T19:47:57Z"
+    mac: ENC[AES256_GCM,data:XApqhwvMc4va8uCSDsvp5tJx2L3dQXY0Q45f350euYNwWkLIHvIvHCrXVdw/8d7KSh+w3yIJho0U81eB11sTwyHibWb7O79ijvXiV+NtmpWlKnrvhWaa1ullc6qInANkU5ef0RocPtZtOtRjZ/XkxvMkODWB/XL0elj6rsTQcig=,iv:zWiNN+mBFkPjKXhuUdVTyJeuhmVZRVRQz2fMMtoxroY=,tag:Ah8ZLvVrb92kS0sQqDjQEA==,type:str]
+    pgp:
+        - created_at: "2026-06-07T19:47:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveARAAmRtBCzPLl5+xB5mSA7WmHdOlanrf3m1wnQ+xXAW5m7NH
+            cyLR0iKk1AZlZWUKUDW0BHZkObcary5KB7BTN0A0zn7Ti2uzkyIQ0IT6tNpZ76+P
+            QUlzLhkKfwrfQY87vZu5dYHAEAQvfyRSjZOqaJ4Z6CzDYg6dbU2ZhBuCyPpiSll/
+            mPH6fs9Vs3BTfs4WIWKZ23rZGE322yX/L9UgoLgEQqIj0cPeJ4NmHb1lVv6dZDc1
+            Jh4oU2ltLy1YegS2N4JRp7pa2EkITFiWAmjp0pQW0o88qJaBoIWXIbDoSnbMflnh
+            tYPIArZisByQ8XbIhqAYl9MpvRZuiZLw37jFLNl2XL9qJ6X+eEgsLnnxcupKQT5S
+            4PvFSfibKM+AQUaxcOkU7bZh6t4AsQw3Itrqkp+Y3fUh6y2ZEBKc4pmlab6Fjqhd
+            ghIkVaVEPqFqh0x8Bdr6FVpCl0IWfnDG8i+TE0x0yXIBl9pgM64u74RGc6L5ZsRU
+            3iofsy/8vLQLHV9ZFirXVp7rcLRpljJ36P/eCmd1inoCszxI4rmlFM/c1Q3SdK1p
+            pP35iVDTDJkgeo/mDN0SAxTe9v3wI/b+jYK+3Ce+hJzqP/M/Mi0TARgnYO1S+1iJ
+            Q3Rhub5x9kqnDOk6hglKenWuBxA6cP0Futk8KWrq2VnT5gJxjJhbmtmil0NLG/fU
+            aAEJAhBv3Hofb5nxnru8kCPU05rKRO584Y+9NHLeZaSZjfhUfafu8UmmtkaQlQwB
+            EmvP5W+HzCB3ckcPaPZG/sVjqQ6xKwOAkfEg7krmeqo187uqYcJUnCNHnGRDU2Zh
+            VZxeGVczO/IP
+            =9+zJ
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.1

--- a/kubernetes/apps/base/agents/agents/app/groups/team-a/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/groups/team-a/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+components:
+  - ../../_component/hermes-group
+generatorOptions:
+  # group-meta only feeds the component's replacements; local-config keeps it out
+  # of the applied output so this group's Flux Kustomization never tries to own a
+  # ConfigMap/group-meta (which would clash with other groups in the namespace).
+  disableNameSuffixHash: true
+  annotations:
+    config.kubernetes.io/local-config: "true"
+configMapGenerator:
+  - name: group-meta
+    literals:
+      - name=team-a
+      - host=team-a.agents.${COMMON_DOMAIN}
+      - clientID=372060aa-2754-434c-a46b-d4c5b792c069
+      - size=20Gi
+resources:
+  - secret.sops.yaml
+patches:
+  - target:
+      kind: ConfigMap
+      name: hermes-placeholder-config
+    patch: |-
+      - op: replace
+        path: /data/AGENT_SYSTEM_PROMPT
+        value: |
+          You are the team-a group's shared assistant.
+          Keep answers terse and technical.

--- a/kubernetes/apps/base/agents/agents/app/groups/team-a/secret.sops.yaml
+++ b/kubernetes/apps/base/agents/agents/app/groups/team-a/secret.sops.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hermes-team-a-secrets
+type: Opaque
+stringData:
+    API_SERVER_KEY: ENC[AES256_GCM,data:Z0ltyNTwbUNdE55ZUB7+0anRUWHyx9aKNN2h/8vR3i8Avzpe0/Z2za7/zQ9lpv4m,iv:SJtQfUQRaSBcMiX2aJi8AI2UTBjQEKV7pVh3hlMTqzU=,tag:KYyUAEdjWG0g9U08qCvP/g==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-07T20:26:07Z"
+    mac: ENC[AES256_GCM,data:5L8CX94w+eQBjWBSiZmeFDhgaFThM0CIv9MoF3ziLA1dfyBVsong9G6/T3TBLJ4C2/mFFQxSmTnzF5kgkZhviKetSqXIIJejhWt0QS+N0q3Sq1Czk5y8MUFpVqe9GFJvWlxn3yZRcjCUWQgujpKTwgoC5nFHufkTm8D8P7yvcFE=,iv:zUEBXiCvv6G7pgQ/ofllaNXXTL0ePe35DQvJ/8HqmGc=,tag:lT1z6P4u5HP7NzvsEFpbqg==,type:str]
+    pgp:
+        - created_at: "2026-06-07T20:26:07Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveAQ//YyLWtJ530IBj8anAq2L9zA/7FoqTNKzUSYoeYVD/Ndoj
+            axCGkbVsiKebjdOF39VoF7tjKt6U6xX9WVmvxajd/08ZE0auwoi6xC39fAEDutoE
+            LCpKoF7MVOFJedIj1qpqj+Prj15OAKiKfUAxLohiyDWrzb0Q+ROOepFV4U2Giswc
+            0pBQryfk0T2t6ny8JuwaZzjfWTvBQRD2q3tPmsNlmlAtjxqApVIt3FzfyunVSs+A
+            pRK6d4okdl6EhqrmHNcl3apogiq537OqFtSSHxuWW77UZ3N3tGqZ8y7sphuXe/6q
+            9oY+JQ2aGF2dFaAG3eIT9CzGl9lyZbceFSHFLMqjcrCfH2kwRCaNjDa7NhbsrTGE
+            guk/Pym8+MaylVm3x0ms85ohrGWUgO1vf5bpNr8yXk6SsLpK/zrESeEoNbin/ytn
+            56BA7m9oQvBbCAMj0tkKSdmrftZktHqrmffi98kqsIQhC8LoplxZ4HbKvpYabrK0
+            ULrbshWD6vf6qKJQhmDiya7N+CV3VkmeYoHz7XWtxe+c7qwFx+J8U1/gERa8gklc
+            EhCyMo3LqXLJwYVS/iDAnO0an6yudTQT6SpoHENILvSk/VdsxGiIw0jM0eBuBICi
+            kSZVshx5uav3vALJhRzFiPuwZRPYOrNMTC90yWGGUqs6XlXKi3FgNOcsOSzrljTU
+            aAEJAhDxRXWc7VyVsp7Y3hwNvYK9tIudA6YUDygvbB2MSHSP4v98XhNyrQag8OYc
+            S94YIv6x5KqH/VktecXNXjhMHUNWPMaH3wLL4xGGxHkjfePTnwtmwTMwMq5d1Tco
+            h12Xy2cCxwFc
+            =LgUj
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hermes-team-a-oidc
+type: Opaque
+stringData:
+    client-secret: ENC[AES256_GCM,data:bjT41R2Zbg0FiRPB1De+yrd7gGJd6VAIP87Sf5cf13Y=,iv:BryOn+F3CXee+EaflNYApz+mX86EPry4hEDFUcDFRHw=,tag:0YTj62sB+/6CTpa0gdX7+g==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-07T20:26:07Z"
+    mac: ENC[AES256_GCM,data:5L8CX94w+eQBjWBSiZmeFDhgaFThM0CIv9MoF3ziLA1dfyBVsong9G6/T3TBLJ4C2/mFFQxSmTnzF5kgkZhviKetSqXIIJejhWt0QS+N0q3Sq1Czk5y8MUFpVqe9GFJvWlxn3yZRcjCUWQgujpKTwgoC5nFHufkTm8D8P7yvcFE=,iv:zUEBXiCvv6G7pgQ/ofllaNXXTL0ePe35DQvJ/8HqmGc=,tag:lT1z6P4u5HP7NzvsEFpbqg==,type:str]
+    pgp:
+        - created_at: "2026-06-07T20:26:07Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveAQ//YyLWtJ530IBj8anAq2L9zA/7FoqTNKzUSYoeYVD/Ndoj
+            axCGkbVsiKebjdOF39VoF7tjKt6U6xX9WVmvxajd/08ZE0auwoi6xC39fAEDutoE
+            LCpKoF7MVOFJedIj1qpqj+Prj15OAKiKfUAxLohiyDWrzb0Q+ROOepFV4U2Giswc
+            0pBQryfk0T2t6ny8JuwaZzjfWTvBQRD2q3tPmsNlmlAtjxqApVIt3FzfyunVSs+A
+            pRK6d4okdl6EhqrmHNcl3apogiq537OqFtSSHxuWW77UZ3N3tGqZ8y7sphuXe/6q
+            9oY+JQ2aGF2dFaAG3eIT9CzGl9lyZbceFSHFLMqjcrCfH2kwRCaNjDa7NhbsrTGE
+            guk/Pym8+MaylVm3x0ms85ohrGWUgO1vf5bpNr8yXk6SsLpK/zrESeEoNbin/ytn
+            56BA7m9oQvBbCAMj0tkKSdmrftZktHqrmffi98kqsIQhC8LoplxZ4HbKvpYabrK0
+            ULrbshWD6vf6qKJQhmDiya7N+CV3VkmeYoHz7XWtxe+c7qwFx+J8U1/gERa8gklc
+            EhCyMo3LqXLJwYVS/iDAnO0an6yudTQT6SpoHENILvSk/VdsxGiIw0jM0eBuBICi
+            kSZVshx5uav3vALJhRzFiPuwZRPYOrNMTC90yWGGUqs6XlXKi3FgNOcsOSzrljTU
+            aAEJAhDxRXWc7VyVsp7Y3hwNvYK9tIudA6YUDygvbB2MSHSP4v98XhNyrQag8OYc
+            S94YIv6x5KqH/VktecXNXjhMHUNWPMaH3wLL4xGGxHkjfePTnwtmwTMwMq5d1Tco
+            h12Xy2cCxwFc
+            =LgUj
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.1

--- a/kubernetes/apps/base/agents/agents/app/kartik/configmap.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/configmap.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kartik-config
+data:
+  GATEWAY_ALLOW_ALL_USERS: "true"
+  API_SERVER_ENABLED: "true"
+  API_SERVER_HOST: "0.0.0.0"
+  API_SERVER_PORT: "8642"
+  API_SERVER_KEY: "${DEFAULT_PASSWORD}"
+  DISCORD_REQUIRE_MENTION: "false"
+  DISCORD_AUTO_THREAD: "true"
+  DISCORD_REACTIONS: "true"
+
+  # ---- Browser toolset (web_extract / browser_* tools) ----
+  # The image already bundles Chromium (Chrome for Testing) + the agent-browser
+  # CLI. Hermes auto-injects --no-sandbox only when running as root or on
+  # AppArmor-restricted hosts. This pod runs as uid 10000 (non-root, via
+  # s6-setuidgid) on Talos with no AppArmor userns flag, so neither trigger
+  # fires and Chromium dies with "No usable sandbox". Setting the flag
+  # explicitly is the documented fix (browser_tool.py honours AGENT_BROWSER_ARGS).
+  AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+
+  # ---- Camofox browser backend (watchable browser) ----
+  # Routes the browser_* tools through the camofox deployment instead of the
+  # bundled headless shell. Camofox runs headed with a noVNC viewer, so raj can
+  # watch live and take over (logins) at https://camofox.keiretsu.ts.net.
+  # Cluster-internal API; no auth header is sent by Hermes, so the API service
+  # is ClusterIP-only.
+  CAMOFOX_URL: "http://camofox.agents.svc.cluster.local:9377"
+
+  # ---- Web extract backend (self-hosted Firecrawl) ----
+  # web_extract routes to the self-hosted Firecrawl canary in the firecrawl ns
+  # (clusters/talos-ottawa/apps/firecrawl). SearXNG is search-only and cannot
+  # extract URL content, so web.extract_backend=firecrawl in /opt/data/config.yaml
+  # plus this URL is what makes web_extract work. Same-cluster ClusterIP; no key
+  # needed for self-hosted scrape->markdown.
+  FIRECRAWL_API_URL: "http://api.firecrawl.svc.cluster.local:3002"
+
+  # LLM endpoint lives in /opt/data/config.yaml inside the PVC (set once via
+  # kubectl exec; reachable through the `stpetersburg-vllm` ExternalName).
+  # OPENAI_BASE_URL is kept so Hermes auxiliary clients (summarization /
+  # compression) route to the same vLLM endpoint when they're invoked.
+  OPENAI_BASE_URL: "http://stpetersburg-vllm/v1"
+  OPENAI_API_KEY: "unused"
+
+  # ---- WhatsApp bridge (Baileys, self-chat mode) ----
+  # Pair once: kubectl exec -it deploy/kartik -c gateway --
+  #   /opt/hermes/.venv/bin/hermes whatsapp
+  # Session persists at /opt/data/whatsapp/session/ in the PVC.
+  WHATSAPP_ENABLED: "true"
+  WHATSAPP_MODE: "self-chat"
+  # Kartik's WhatsApp number (E.164 without +).
+  # NOTE: must be a hardcoded quoted literal, NOT "${KARTIK_WHATSAPP_NUMBER}".
+  # kustomize strips quotes off a bare ${VAR} scalar, then Flux substitutes the
+  # numeric secret -> the ConfigMap value becomes an int -> SSA dry-run fails
+  # (".data.WHATSAPP_ALLOWED_USERS: expected string, got <int>") and WEDGES the
+  # entire agents Kustomization. To source from common-secrets, store the value
+  # already-quoted in the SOPS secret.
+  WHATSAPP_ALLOWED_USERS: "16147437286"
+
+  # ---- Persona ----
+  AGENT_NAME: "kartik"
+  AGENT_PERSONA: "assistant"
+  AGENT_SYSTEM_PROMPT: |
+    You are Karthik's personal assistant.
+    You manage calendar, email, notes, reminders, and life logistics.
+    Default tone: warm, proactive, terse. Remember context across days.
+    When uncertain, prefer to ask one clarifying question over guessing.

--- a/kubernetes/apps/base/agents/agents/app/kartik/deployment.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kartik
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kartik
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kartik
+        agents.keiretsu.ts.net/persona: assistant
+        agents.keiretsu.ts.net/owner: kartik
+    spec:
+      initContainers:
+        - name: seed-aws-credentials
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /opt/data/.aws
+              umask 077
+              cat >/opt/data/.aws/credentials <<EOF
+              [default]
+              aws_access_key_id = $${AWS_ACCESS_KEY_ID}
+              aws_secret_access_key = $${AWS_SECRET_ACCESS_KEY}
+              EOF
+              cat >/opt/data/.aws/config <<EOF
+              [default]
+              region = $${AWS_REGION}
+              endpoint_url = $${AWS_ENDPOINT_URL}
+              s3 =
+                  endpoint_url = $${AWS_ENDPOINT_URL_S3}
+                  addressing_style = path
+              EOF
+          envFrom:
+            - secretRef:
+                name: kartik-s3
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      containers:
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["gateway", "run"]
+          envFrom:
+            - configMapRef:
+                name: kartik-config
+            - secretRef:
+                name: kartik-secrets
+            - secretRef:
+                name: kartik-s3
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/data/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /opt/data/.aws/config
+            # v2026.5.29 introduced s6 supervision — dashboard runs in the same
+            # container as the gateway. HERMES_DASHBOARD=1 spawns it; TUI=1
+            # enables the embedded chat tab; HOST=0.0.0.0 exposes it.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            # Skip the dashboard's OAuth gate. Safe here because access is
+            # already gated at the network layer by Tailscale `tag:raj` ACL.
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: gateway
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              memory: 6Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: kartik-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/apps/base/agents/agents/app/kartik/garagekey.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/garagekey.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: kartik-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "kartik S3 Reader Key"
+  allBuckets:
+    read: true
+  secretTemplate:
+    name: kartik-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://${COMMON_S3_ENDPOINT}"
+      AWS_ENDPOINT_URL_S3: "http://${COMMON_S3_ENDPOINT}"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/agents/agents/app/kartik/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - deployment.yaml
+  - service.yaml
+  - service-tailscale.yaml
+  - storagestack.yaml
+  - garagekey.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/agents/agents/app/kartik/secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/secret.yaml
@@ -1,0 +1,14 @@
+---
+# Fill in real values then re-apply. Encrypt before committing real tokens:
+#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kartik-secrets
+type: Opaque
+stringData:
+  # Discord disabled until a real token is provided.
+  # DISCORD_BOT_TOKEN: ""
+  GOOGLE_OAUTH_CLIENT_ID: ""
+  GOOGLE_OAUTH_CLIENT_SECRET: ""
+  NOTION_TOKEN: ""

--- a/kubernetes/apps/base/agents/agents/app/kartik/service-tailscale.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/service-tailscale.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kartik-ts
+  annotations:
+    tailscale.com/hostname: kartik
+    tailscale.com/tags: "tag:kartik"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: kartik
+  ports:
+    - name: dashboard
+      port: 80
+      targetPort: 9119
+      protocol: TCP
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/kartik/service.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kartik
+spec:
+  selector:
+    app.kubernetes.io/name: kartik
+  ports:
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: 9119
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/kartik/storagestack.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/storagestack.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: kartik-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: kartik-data
+  size: 20Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/kartik/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot
+  restorePaused: false

--- a/kubernetes/apps/base/agents/agents/app/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - bucket.yaml
+  - egress.yaml
+  - assistant-raj
+  - abtar
+  - kartik
+  - teaspoon
+  - camofox
+# NOTE: hermes groups (groups/<name>) are NOT listed here. Each is reconciled by
+# its own Flux Kustomization (ks-<name>.yaml) so tenants build independently —
+# no shared kustomize accumulation (group-meta would collide) and one group's
+# failure can't block the others. `add-group.sh` wires those up.

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/configmap.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/configmap.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: teaspoon-config
+data:
+  GATEWAY_ALLOW_ALL_USERS: "true"
+  API_SERVER_ENABLED: "true"
+  API_SERVER_HOST: "0.0.0.0"
+  API_SERVER_PORT: "8642"
+  API_SERVER_KEY: "${DEFAULT_PASSWORD}"
+
+  # ---- Discord bridge ----
+  # teaspoon is the templated successor to the old ns/hermes Discord bot.
+  # The bot token lives in the teaspoon-secrets Secret (DISCORD_BOT_TOKEN).
+  # Mirrors the old app's Discord behaviour: respond without an explicit
+  # @mention, auto-thread replies, add status reactions.
+  DISCORD_REQUIRE_MENTION: "false"
+  DISCORD_AUTO_THREAD: "true"
+  DISCORD_REACTIONS: "true"
+
+  # ---- Browser toolset (web_extract / browser_* tools) ----
+  # The image already bundles Chromium (Chrome for Testing) + the agent-browser
+  # CLI. Hermes auto-injects --no-sandbox only when running as root or on
+  # AppArmor-restricted hosts. This pod runs as uid 10000 (non-root, via
+  # s6-setuidgid) on Talos with no AppArmor userns flag, so neither trigger
+  # fires and Chromium dies with "No usable sandbox". Setting the flag
+  # explicitly is the documented fix (browser_tool.py honours AGENT_BROWSER_ARGS).
+  AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+
+  # ---- Camofox browser backend (watchable browser) ----
+  # Routes the browser_* tools through the shared camofox deployment in this ns.
+  # Camofox runs headed with a noVNC viewer at https://camofox.keiretsu.ts.net.
+  # Cluster-internal API; no auth header is sent by Hermes, so it's ClusterIP-only.
+  CAMOFOX_URL: "http://camofox.agents.svc.cluster.local:9377"
+
+  # ---- Web extract backend (self-hosted Firecrawl) ----
+  # web_extract routes to the self-hosted Firecrawl canary in the firecrawl ns
+  # (clusters/talos-ottawa/apps/firecrawl). SearXNG is search-only and cannot
+  # extract URL content, so web.extract_backend=firecrawl in /opt/data/config.yaml
+  # plus this URL is what makes web_extract work. Same-cluster ClusterIP; no key
+  # needed for self-hosted scrape->markdown.
+  FIRECRAWL_API_URL: "http://api.firecrawl.svc.cluster.local:3002"
+
+  # LLM endpoint lives in /opt/data/config.yaml inside the PVC (set once via
+  # kubectl exec). The "new model" for templated agents is anthropic/claude-opus-4-8
+  # (Anthropic OAuth credential in /opt/data/auth.json). OPENAI_BASE_URL is kept
+  # so Hermes auxiliary clients (summarization / compression) route to the shared
+  # vLLM endpoint when invoked.
+  OPENAI_BASE_URL: "http://stpetersburg-vllm/v1"
+  OPENAI_API_KEY: "unused"
+
+  # ---- Persona ----
+  AGENT_NAME: "teaspoon"
+  AGENT_PERSONA: "assistant"
+  AGENT_SYSTEM_PROMPT: |
+    You are teaspoon, an AI infrastructure agent that lives in Discord.
+    You are co-owned by Raj and Kartik (both work at Tailscale).
+    You help maintain the keiretsu-labs/kubernetes-manifests GitOps monorepo
+    (Flux CD, 3 clusters: ottawa/robbinsdale/stpetersburg) and assist with
+    general infra, coding, and ops questions.
+    You have a full k8s toolchain, a kubeconfig with system:masters on all 3
+    clusters, the rajsinghtechbot GitHub token, and the keiretsu-k8s-contrib
+    skill — use GitOps-only discipline (never kubectl apply to mutate state;
+    contribute via git/PRs) and never cause an outage.
+    Default tone: helpful, concise, technically precise.
+    When uncertain, prefer to ask one clarifying question over guessing.

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/deployment.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: teaspoon
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: teaspoon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: teaspoon
+        agents.keiretsu.ts.net/persona: assistant
+        agents.keiretsu.ts.net/owner: raj
+    spec:
+      initContainers:
+        - name: seed-aws-credentials
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /opt/data/.aws
+              umask 077
+              cat >/opt/data/.aws/credentials <<EOF
+              [default]
+              aws_access_key_id = $${AWS_ACCESS_KEY_ID}
+              aws_secret_access_key = $${AWS_SECRET_ACCESS_KEY}
+              EOF
+              cat >/opt/data/.aws/config <<EOF
+              [default]
+              region = $${AWS_REGION}
+              endpoint_url = $${AWS_ENDPOINT_URL}
+              s3 =
+                  endpoint_url = $${AWS_ENDPOINT_URL_S3}
+                  addressing_style = path
+              EOF
+          envFrom:
+            - secretRef:
+                name: teaspoon-s3
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      containers:
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["gateway", "run"]
+          envFrom:
+            - configMapRef:
+                name: teaspoon-config
+            - secretRef:
+                name: teaspoon-secrets
+            - secretRef:
+                name: teaspoon-s3
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/data/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /opt/data/.aws/config
+            # v2026.5.29 introduced s6 supervision — dashboard runs in the same
+            # container as the gateway. HERMES_DASHBOARD=1 spawns it; TUI=1
+            # enables the embedded chat tab; HOST=0.0.0.0 exposes it.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            # Skip the dashboard's OAuth gate. Safe here because access is
+            # already gated at the network layer by Tailscale `tag:raj` ACL.
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: gateway
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              memory: 6Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: teaspoon-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/garagekey.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/garagekey.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: teaspoon-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "teaspoon S3 Key"
+  allBuckets:
+    read: true
+    write: true
+  secretTemplate:
+    name: teaspoon-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://garage.garage.svc.cluster.local:3900"
+      AWS_ENDPOINT_URL_S3: "http://garage.garage.svc.cluster.local:3900"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/httproute-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/httproute-web.yaml
@@ -1,0 +1,43 @@
+---
+# teaspoon-web static site served from Garage S3 via web API (port 3902)
+# OIDC-gated through the public/private gateways (same pattern as grafana).
+# Garage resolves buckets by stripping the root_domain suffix from the Host
+# header, so we rewrite hostname → teaspooon-web.keiretsu.top (bucket name).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: teaspoon-web
+  annotations:
+    item.homer.rajsingh.info/name: "Teaspoon Web"
+    item.homer.rajsingh.info/subtitle: "Static Website"
+    item.homer.rajsingh.info/keywords: "website, teaspoon, agent"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-globe"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "teaspoon.agents.${COMMON_DOMAIN}"
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: "teaspoon-web.${COMMON_DOMAIN}"
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          namespace: garage
+          port: 3902
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/httproute.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/httproute.yaml
@@ -1,0 +1,35 @@
+---
+# teaspoon dashboard / web UI over the tailnet via the `ts` gateway
+# (HTTPS on *.${CLUSTER_DOMAIN}). Mirrors the old ns/hermes httproute.
+# Routes the dashboard (9119); the gateway API (8642) is reached via the
+# teaspoon-ts LB, not here.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: teaspoon
+  annotations:
+    item.homer.rajsingh.info/name: "Teaspoon"
+    item.homer.rajsingh.info/subtitle: "AI Agent (Discord)"
+    item.homer.rajsingh.info/logo: "https://hermes-agent.nousresearch.com/docs/img/logo.png"
+    item.homer.rajsingh.info/keywords: "ai, agent, assistant, discord, teaspoon"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-robot"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "teaspoon.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: teaspoon
+          port: 9119
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - deployment.yaml
+  - service.yaml
+  - service-tailscale.yaml
+  # egress.yaml removed — aperture consolidated to agents/app/egress.yaml
+  - httproute.yaml
+  - httproute-web.yaml
+  - securitypolicy.yaml
+  - oidc-secret.yaml
+  - storagestack.yaml
+  - garagekey.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/oidc-secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/oidc-secret.yaml
@@ -1,0 +1,10 @@
+---
+# Shared envoy Gateway OIDC client secret — same creds used by grafana, frigate, etc.
+# ${ENVOY_GATEWAY_OIDC_CLIENT_SECRET} from common-secrets via Flux postBuild substitution.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: teaspoon-web-oidc
+type: Opaque
+stringData:
+  client-secret: "${ENVOY_GATEWAY_OIDC_CLIENT_SECRET}"

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/secret.yaml
@@ -1,0 +1,25 @@
+---
+# teaspoon-secrets — holds DISCORD_BOT_TOKEN (the migrated bot token).
+#
+# This operator cannot SOPS-encrypt (no PGP private key on the box), so the
+# real token is NOT committed here. The token is injected as LIVE cluster
+# state (kubectl patch) instead.
+#
+# CRITICAL: the `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` annotation makes
+# Flux create this Secret only if it is ABSENT, and NEVER overwrite it on
+# subsequent reconciles. Without it, Flux owns the object and re-applies the
+# empty stringData below on every reconcile, wiping the live-injected token
+# (observed: Discord dropped offline ~18 min after a reconcile). With it, the
+# live-patched token survives all reconciles.
+#
+# TO MAKE FULLY GITOPS LATER: put the real token in stringData, then
+#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
+# (and drop the IfNotPresent annotation so the encrypted value is authoritative).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: teaspoon-secrets
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+type: Opaque
+stringData: {}

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/securitypolicy.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/securitypolicy.yaml
@@ -1,0 +1,22 @@
+---
+# OIDC gate for teaspoon-web — uses the shared/enovy gateway OIDC client
+# (the same one grafana, frigate, etc. use) so users don't need a separate
+# Pocket ID client per agent web app.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: teaspoon-web-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: teaspoon-web
+  oidc:
+    provider:
+      issuer: "https://pocket-id.keiretsu.top"
+    clientID: "${ENVOY_GATEWAY_OIDC_CLIENT_ID}"
+    clientSecret:
+      name: teaspoon-web-oidc
+    redirectURL: "https://teaspoon.agents.${COMMON_DOMAIN}/oauth2/callback"
+    logoutPath: "/logout"
+    cookieDomain: "agents.${COMMON_DOMAIN}"

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/service-tailscale.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/service-tailscale.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: teaspoon-ts
+  annotations:
+    tailscale.com/hostname: teaspoon
+    # tag:k8s already exists in tailscale/policy.hujson (tagOwners incl.
+    # tag:k8s-operator), so the Tailscale LoadBalancer provisions immediately —
+    # no policy.hujson edit needed. Carried over from the old ns/hermes app.
+    tailscale.com/tags: "tag:k8s"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: teaspoon
+  ports:
+    - name: dashboard
+      port: 80
+      targetPort: 9119
+      protocol: TCP
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/service.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: teaspoon
+spec:
+  selector:
+    app.kubernetes.io/name: teaspoon
+  ports:
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: 9119
+      protocol: TCP

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/storagestack.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/storagestack.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: teaspoon-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: teaspoon-data
+  size: 20Gi
+  storageClass: ceph-block-replicated
+  s3Path: agents/teaspoon/data
+  schedule: 0 4 * * *
+  copyMethod: Snapshot
+  restorePaused: false

--- a/kubernetes/apps/ottawa/agents/agents.yaml
+++ b/kubernetes/apps/ottawa/agents/agents.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agents
+  namespace: flux-system
+spec:
+  targetNamespace: agents
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: agents
+  path: ./kubernetes/apps/base/agents/agents/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agents-demo
+  namespace: flux-system
+spec:
+  targetNamespace: agents
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: agents-demo
+  path: ./kubernetes/apps/base/agents/agents/app/groups/demo
+  prune: true
+  dependsOn:
+    - name: agents
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agents-team-a
+  namespace: flux-system
+spec:
+  targetNamespace: agents
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: agents-team-a
+  path: ./kubernetes/apps/base/agents/agents/app/groups/team-a
+  prune: true
+  dependsOn:
+    - name: agents
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/ottawa/agents/kustomization.yaml
+++ b/kubernetes/apps/ottawa/agents/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./agents.yaml

--- a/kubernetes/apps/ottawa/agents/namespace.yaml
+++ b/kubernetes/apps/ottawa/agents/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agents
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  annotations:
+    volsync.backube/privileged-movers: "true"

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./monitoring
   - ./clickhouse-operator-system
   - ./clickhouse
+  - ./agents


### PR DESCRIPTION
## summary

PR-A (adopt) for batch C group 2: agents namespace.

**apps:** agents (3 CRs: agents, agents-demo, agents-team-a)
**old parent:** cluster-apps
**target namespace:** agents

## changes

- verbatim copy to `kubernetes/apps/base/agents/agents/app` (includes `_component/hermes-group` and `groups/{demo,team-a}` dirs — verbatim, relative refs preserved)
- pointer at `kubernetes/apps/ottawa/agents/agents.yaml` with all 3 CRs; paths updated to new base location
- namespace.yaml with `prune: disabled` labels at `kubernetes/apps/ottawa/agents/namespace.yaml`
- ottawa kustomization updated to include `./agents`

## verification

- `make test` green ×3 clusters
- flate byte-identical: all 3 CRs confirmed