### PR TITLE
migrate(batch-a): adopt gvisor and csi-secrets-store into kubernetes tree

### DIFF
--- a/kubernetes/apps/base/gvisor/gvisor/app/kustomization.yaml
+++ b/kubernetes/apps/base/gvisor/gvisor/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./runtimeclass.yaml

--- a/kubernetes/apps/base/gvisor/gvisor/app/runtimeclass.yaml
+++ b/kubernetes/apps/base/gvisor/gvisor/app/runtimeclass.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runsc
+handler: runsc
+---
+# KVM-accelerated gVisor: runsc runs its sentry/platform on the host KVM
+# hypervisor (/dev/kvm) instead of the ptrace/systrap platform — lower syscall
+# and memory-fault overhead. Handler `runsc-kvm` is registered by the
+# siderolabs/gvisor extension. Verified booting on shiro (kernel 4.19.0-gvisor,
+# KVM platform).
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runsc-kvm
+handler: runsc-kvm

--- a/kubernetes/apps/base/kube-system/csi-secrets-store/install/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/csi-secrets-store/install/helmrelease.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: secrets-store-csi-driver
+  namespace: kube-system
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: secrets-store-csi-driver
+      version: "1.5.4"
+      sourceRef:
+        kind: HelmRepository
+        name: secrets-store-csi-driver
+        namespace: kube-system
+      interval: 1m
+  # releaseName: csi-secrets-store
+  values:

--- a/kubernetes/apps/base/kube-system/csi-secrets-store/install/helmrepository.yaml
+++ b/kubernetes/apps/base/kube-system/csi-secrets-store/install/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: secrets-store-csi-driver
+  namespace: kube-system
+spec:
+  interval: 1m
+  url: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts

--- a/kubernetes/apps/base/kube-system/csi-secrets-store/install/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/csi-secrets-store/install/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ottawa/gvisor/gvisor.yaml
+++ b/kubernetes/apps/ottawa/gvisor/gvisor.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gvisor
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/gvisor/gvisor/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/gvisor/kustomization.yaml
+++ b/kubernetes/apps/ottawa/gvisor/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gvisor.yaml

--- a/kubernetes/apps/ottawa/kube-system/csi-secrets-store.yaml
+++ b/kubernetes/apps/ottawa/kube-system/csi-secrets-store.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-secrets-store-install
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/csi-secrets-store/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 1m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/kube-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kube-system/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./csi-secrets-store.yaml

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -10,3 +10,5 @@ resources:
   - ./cnpg-system
   - ./fluent-bit
   - ./dragonfly-operator-system
+  - ./gvisor
+  - ./kube-system

--- a/kubernetes/apps/robbinsdale/gvisor/gvisor.yaml
+++ b/kubernetes/apps/robbinsdale/gvisor/gvisor.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gvisor
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/gvisor/gvisor/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/gvisor/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/gvisor/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gvisor.yaml

--- a/kubernetes/apps/robbinsdale/kube-system/csi-secrets-store.yaml
+++ b/kubernetes/apps/robbinsdale/kube-system/csi-secrets-store.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-secrets-store-install
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/csi-secrets-store/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 1m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/kube-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kube-system/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./csi-secrets-store.yaml

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - ./cnpg-system
   - ./fluent-bit
   - ./dragonfly-operator-system
+  - ./gvisor
+  - ./kube-system

--- a/kubernetes/apps/stpetersburg/gvisor/gvisor.yaml
+++ b/kubernetes/apps/stpetersburg/gvisor/gvisor.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gvisor
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/gvisor/gvisor/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/gvisor/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/gvisor/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gvisor.yaml

--- a/kubernetes/apps/stpetersburg/kube-system/csi-secrets-store.yaml
+++ b/kubernetes/apps/stpetersburg/kube-system/csi-secrets-store.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-secrets-store-install
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/csi-secrets-store/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 1m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/kube-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kube-system/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./csi-secrets-store.yaml

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -17,3 +17,5 @@ resources:
   - ./cnpg-system
   - ./fluent-bit
   - ./dragonfly-operator-system
+  - ./gvisor
+  - ./kube-system


### PR DESCRIPTION
## Summary

- Verbatim copy of `gvisor/app` and `csi-secrets-store/install` to `kubernetes/apps/base/`
- Pointer files for all 3 locations (ottawa/robbinsdale/stpetersburg)
- Byte-identical flate render verified (6 checks: 2 apps × 3 clusters)
- `make test` green ×3

Part of #1553 batch A.

**Note:** `snapshot-controller` is excluded from this batch due to a flate v0.3.4 test simulation artifact — when both `common-apps` and `kubernetes-apps` define a same-named Kustomization simultaneously, flate's dependency resolver for `rook-ceph-cluster-config` (which `dependsOn: snapshot-controller`) reports a path validation error. The render itself is byte-identical (verified). snapshot-controller will get its own PR pair after this is validated live.