### PR TITLE
migrate(batch-e/g2): adopt gatus, home-assistant, jellyswarrm (stpetersburg)

### DIFF
--- a/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gatus
+      version: "1.5.0"
+      sourceRef:
+        kind: HelmRepository
+        name: twin
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      tag: v5.35.0
+    # Forces a Cilium identity whose low byte != 0x08, avoiding a collision with
+    # Tailscale's LinuxBypassMark (0x80000/0xff0000) that diverts ProxyGroup egress
+    # traffic out eth0 instead of tailscale0. Do not remove without verifying
+    # the resulting identity hex; ~1 in 256 identities will reproduce the bug.
+    podLabels:
+      fwmark-workaround: v1
+    podAnnotations:
+      checksum/webhook: "${DISCORD_WEBHOOK_URL}"
+    envFrom:
+      - secretRef:
+          name: gatus
+    config:
+      alerting:
+        discord:
+          webhook-url: "$${discord-webhook-url}"
+          failure-threshold: 3
+          success-threshold: 2
+      ui:
+        title: "K8s St. Petersburg Status"
+        description: "GitOps-managed Kubernetes cluster monitoring"
+        header: "K8s-StPetersburg Infrastructure Dashboard"
+      external-endpoints:
+        - name: Heartbeat
+          group: Alertmanager
+          token: "${GATUS_HEARTBEAT_TOKEN}"
+          heartbeat:
+            interval: 5m
+          alerts:
+            - type: discord
+              send-on-resolved: true
+      endpoints:
+        - name: Kubernetes API
+          group: kubernetes
+          url: https://k8s.stpetersburg.internal:6443/readyz
+          interval: 60s
+          client:
+            insecure: true
+          conditions:
+            - "[STATUS] == 401"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === Storage: Garage Cross-Cluster ===
+        - name: Garage Local (StPetersburg)
+          group: storage
+          url: tcp://garage.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage Ottawa
+          group: storage
+          url: tcp://ottawa-garage.garage:3900
+          interval: 60s
+          client:
+            timeout: 30s
+          conditions:
+            - "[CONNECTED] == true"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage Robbinsdale
+          group: storage
+          url: tcp://robbinsdale-garage.garage:3900
+          interval: 60s
+          client:
+            timeout: 30s
+          conditions:
+            - "[CONNECTED] == true"
+          alerts:
+            - type: discord
+              send-on-resolved: true

--- a/kubernetes/apps/base/gatus/gatus/app/httproute.yaml
+++ b/kubernetes/apps/base/gatus/gatus/app/httproute.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gatus
+  namespace: gatus
+  annotations:
+    item.homer.rajsingh.info/name: "Gatus"
+    item.homer.rajsingh.info/subtitle: "Service Monitoring"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/gatus.svg"
+    item.homer.rajsingh.info/keywords: "monitoring, uptime, status"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "status.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: gatus
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/gatus/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/base/gatus/gatus/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gatus
+resources:
+  - helmrelease.yaml
+  - httproute.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/gatus/gatus/app/secret.yaml
+++ b/kubernetes/apps/base/gatus/gatus/app/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatus
+  namespace: gatus
+type: Opaque
+stringData:
+  discord-webhook-url: ${DISCORD_WEBHOOK_URL}

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/airconnect-deployment.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/airconnect-deployment.yaml
@@ -1,0 +1,60 @@
+---
+# AirConnect — bridges AirPlay senders (iPhone, Mac, Music Assistant's AirPlay
+# provider) to UPnP/DLNA devices like the Sonos Playbar group, which doesn't
+# speak AirPlay 2 natively. airupnp advertises each Sonos as an AirPlay 2
+# endpoint on the LAN via mDNS.
+#
+# Multus macvlan side-leg gives the pod its own LAN IP/MAC, so airupnp and
+# aircast can mDNS-advertise from a unique identity without competing with
+# the host or other pods. -b is omitted now that auto-detect will pick the
+# macvlan iface (default route is on the LAN). Pod is free to schedule
+# anywhere — no nodeSelector needed.
+#
+# Sonos grouping:
+#   -I  Auto-save config.xml on every UPnP scan. Persists device list so
+#       grouped Sonos devices stay grouped across restarts.
+#   -Z  Non-interactive mode. Needed so the daemon doesn't hang on stdin.
+#
+# Config lives on an emptyDir — -I regenerates it on the next discovery
+# cycle if the pod restarts. Simple, no PVC to manage.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airconnect
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: airconnect
+  template:
+    metadata:
+      labels:
+        app: airconnect
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [{"name":"lan","namespace":"home-assistant","default-route":["192.168.73.1"]}]
+    spec:
+      containers:
+        - name: airconnect
+          image: 1activegeek/airconnect:1.9.3
+          env:
+            - name: AIRUPNP_OPTS
+              value: "-l 500:1000 -r 44100 -Z -x /config/airupnp.xml -I"
+            - name: AIRCAST_OPTS
+              value: ""
+            - name: AIRCAST_VAR
+              value: "kill"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          emptyDir: {}

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/google-assistant-secret.sops.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/google-assistant-secret.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: home-assistant-google-assistant
+type: Opaque
+stringData:
+    google_assistant.yaml: ENC[AES256_GCM,data:zJ/WpeIeD3hctKp2o14OKhob3xnluvqcQfjVYzrGEOd0BvnfQ4JWUlbUtp55B4jghL9axM/1tkQlPz7qIJxf4PuCppQtaAgQ82E/ocmGzJ1zHka/FIbmvBC6MHTS+m/URf+BHGoo6u/hfwtYBtnZ5vTut0lYlrVbRLc5rboSI4F288Y+im25HC0k29BpruYbZgbw74GsWsxg4d2RxArP8V20LKoG1ggzz0qZ41Xh+JoPGhAA5Fa69MNCYGQ8JjWD3ToHGaJ8plRBy15RdUj1uknu9Wlb0bPD6r5CNBGOdskFWsri+zNMjCfatxSxItY/MogP2lHwW5HeuGIRo0FL5u5XMnYLcx6owIwljgWREYjcnWru/Kt+3fekiQubhz2ZrVfbeh0C8CpHczH+6gY40wR7i/loXEeu8k7I4cYTRfWs4p13AUgfUk3SKOMjq8bVNK0DnHkO/Ien93q36cOrpOdlIDbpZMn+cBMCJmgQNFzjBcCZrMw25z5jTq0PNo6J9qKpcSHeWK/Ruox64TH1VGTny7UkaixlxQftSf4ilsSgfDaND/R1Fb41qn8+zvDxLhCnWk2ia/ZKM/m0e5S5Kk7DCAsZYSDBDgG/2AH0JJu3HVYvbmrPIGf68m9Gd27RaL/dFJylO5uqOND+gOdkUr/X0vGMy5TbvF+tuqXiik77zhgJJmC8/LR5zGCkVYXAJeOcYS8AbUUvdSjkQg+0xN0wvo/t00CvpPNx4+G30auy4vz4jauzRrbhrbKpVIK+qXidLnKyQhUrxMF20WQKMFe36elo+4W67ApFKlsDngf/TMCVkBRVXEqq3l3n8GZjKC9Qr3lmxbR0oIjllBYI1xnDtmxXaTD6xzvqE1D2Je7722yWWQF+CceKA8bT0uiUtTuc7stxHi7unhDgLl7swLpJZgMn/n/X7GIiqQsb/7lHy+53GYXGTvWDuTyc39iOPTKtj896MFUG4j/SUlYqJIgaS7taFGwpi1o7WiN6n0fqYEgHa9zqiRmPrNvM/Pamx2vVi0uybanWlk2v3RfGzjbgJwRRFplM600lQsaXOtPVMAw5WTtNjGUQls8p2bgOi+9Z/k4HQrUB36ag4Ce6FNFNAIaDBRlSLBvwppcqqtfBHWCUECF+AWHkwzfGMEW2v6BJttODZT4ogc69gJe+lD72pBVNvofpYVYSWbR5AJxNv7mePvg55wFWOqi+JxDtvmO3Xr/QNyKcshlQ9odCwADnrqVDCvuUI1wvjVR1ZveurxJN7hf+E+U94ZDK4n3ieIY8GeSdVhM6rl7uyq594+sS2siGvvv9/TwAPrdIIBoUTIwkTbOBKe80837yawrsmEIehX9bJ2Ws2ACEmn8Vq7ykkVbMeRfDs1Wu5wgDqPlUYoOYHivyyC5jHZUCFNHpmqigntws/UP7rP2Z7aBcf7yRNXZ9jpxYxSSV9/xrxdOCOiRiXzyHlQ+bR/wpyyAYSleOTcvq+qEwwyEQoQnBD3VmqPr9QSAU9zhUmG4H5f7AGIDi2OKwGjovhVUn3Pxh1HHVVMFzpFkitX+pl40DTkmBHPXacxmDbgFd7tJec4YjLfBHnqEmN1TEx4v5RfSNEZlFmDrqjp0Ni/TRkhOebIEEh8sQctnNSFRbEJAbPnNdWbfQykUbMae4uPvIns/RnSsLIrFJ+2F3edA6njVnDindefM6d2+G2nPK1RxyM37Z1Hi125SJTe/kvJliaFi1F8QGVOpHDEI8Q0S2qio3mFRBFw5vVfsTMmHCWASr/xaZfrmuwUdohXB4dbDnH2Ax3YGOOROc5/j5ZpQhE8OEn2QgwrTwAkQTW12rpQAmblxY+LRlANeEZ9V3IKnFGRHyZtFqUh2FTBdnaly5prXRT4hSsfPjqrx4nOeBcliWszvmue13GsYx/GtycapAPdsdeir8XGAiynwbYtiAbxpOb+aj7nhVs2kNtcfHxXBvykfEdq2j1uSb+SKg7YF4X241bkVBsRE7G98LvBbPhjr0rV05Nznj+KCxVjesFXbTjKIxHedWQgCoe/Ss6HMq1FrN/xfv3AfErXFsH1fHkRPNEdNisApL2Qp7HE/kFR70z1sHVL3obu1CcmEVv4ymIG/uA+YOI+krI+kqqN9HBSUK7TEZ4ClbaY4dsS9c6j6FT1qLuwTuWB1l+O5mIRZ+/p/jmCoeP3KQY8RVnRp2JyhPtrSUZaefyYGgP1jaFFqmDanMqy7L6p45fLwm062kARxGgYPLaMq6glwI6KFq3el/MMsMqkcjM27FDc2QQrsML1BK6G8p4k35+sW1UKvBHzEBqpXcXCqicvcasvUXCDUdtlRQYXUPuYf5Xg9P7/dIqyNOF5GC/G/Qq8POf5v6pE6rNsTGCOO+MH37aWo3PlE/AbhVyXU6+04W3b/7C47qwDUKOC4h9t4P5ygvHDsOA4YCsPnJDpaeJM7B7+RdqDC9qZeRBw5qkhjk0U3mDCdEr4pDtZI812ywrNtOfNI+kVI8QeYwfqYuSMnffm12+33vWLo/N1rG42w/yuYfWXi41gLL8I5du6Mlh2B+DkgZNrrJ7C3+hUkyY8CyxA4m5GgcNmJFwtZTkHwl24VGJffyJizRUGJrOKafI+o9Jkrb9EdDT15ENULNtzxftCGX6PJZNOr1cSCB5JVY1Ise2yX1iSifpGmjqhnO1x/uP+cZyv8L4BH15ViErjIwAWY7t5frcvsZbmbKd3j5E75lij0x6HZtS+QCd7KoHyvN7ZJUJ8B0oy0ahTjhHb2dcX00TFWEOPzug368/tkMDgLuwYRZfqEXlG+5N5wWoeIn2awCth9Rild8Gah5q6rIzzcjIcxg6SYqALFK9tZjI+gKtr9sSC7Yjl2KmWNhmEruKJ2M99ENwxK5Y/1nxAjtZoD8bmwpt2MV4xmefI2D6bQ/D+2U+iR+SB3O1rbbTGchvZSiBG/EOnftNVgSxVs6yzoxH6LbkhPjMwW+9yGH8X0d+tyjrTqDyPcCqf7TKK8AeQTpWPteLTWTMawThRaFa+RlYjOA,iv:FLrrtKwrCRYZYQBkA6j3NumccPTjkt12FtCmgYlDffc=,tag:3g/8SHbF7Jw4BVJYNutlgA==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-22T15:44:50Z"
+    mac: ENC[AES256_GCM,data:x/ecqpu4NTEjocfZBTrrAZTYE26FwtDKiES240/VBYu2V/F6EX8q01Ont8Xe4ztnhlZTEHK6SiD9uCjjLCa3pYP/ucB4SrcTLeQZwLdIXkLO59jFnMmm3KfVxNxmtYBD/cLD7KJ88D4wVtv8mzjxrB6lqcjajCUERjJKRA9dnJ0=,iv:aC4a/2HJqKLRYP96/q9QwT3aNcXw046zSFexpPSzBAc=,tag:iY+Z6HEBQOBDfc5j5BsL1A==,type:str]
+    pgp:
+        - created_at: "2026-05-22T15:40:42Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveAQ/8ClOC25dy4I1v1y9WuHPIO/xYXWmnNWg/hqEBmv0w4p9H
+            ThgxR6J0MVblkTIHr/TkBZFtHs5LLJj6mZ/j5DvWv1Y+gqNEx0/5JmvCIoOVrSp5
+            2oNjRohIy8jVr4LeI/mCq8y4QTXN8oGoSWvUOe565UIaTt+i2P5QcagMgI94LDX7
+            8ssLJbBSSNJ5ycHudq0jJZ437MXNverWwnAixMsZqttKdzA1OjhM6Ix8whQNECf9
+            4zD8RSb3KtrKLtyXSpCqCUi4dmY5OUvc4BJI/WCbjZS/LDD6JOmyc78I/gquS5x6
+            G5n0MNzJnHqVDy2i8qAi8pl1jK+P+10vVs1j/w3MNAZZm2Ltzz6h0LTUqkKbyG11
+            3I9DWDrWDIye/uVpmjiPOItoUr0j1upoHDu5LjqN8b33W1dlamkRobltGMEY1ygp
+            AV6yiKl7VSSjI7Uu/MMfrbAzSKkxUAF2JXwHj0Sccx7JoJLj11f8m4JDTgD8h/LY
+            5jxB8VcYaLr/cjiwB5miWeJdjwXgRSL5UqGCkI5uRFYanE0rshZvoPgSrU4ZU5TA
+            z07n1+AqmJHcNFEh1hgVrEDfVfxlPho3W4BAwE9VnLw6zr+hTCjtoNMbvlzwPGf9
+            jENyuVA1dCChmpRisONLxkSjgDP14BIe086apxvEl5brYFMguzjyXjRB2/zcdlDU
+            ZgEJAhDnVTwRwzh0hLBRu3vqW5Ktsszrd9Yl46kGXNdNSefhQrP9uncab8ZtJwDN
+            +RxCT8LM+G4Q5Wrm+xCRxB6CpoNkzwGjJ6QMYt5BI2CU9jPFqc0KRAlLeOcdnYaq
+            lXz0Te8JMg==
+            =zrK2
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.1

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/httproute.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/httproute.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homeassistant
+  annotations:
+    item.homer.rajsingh.info/name: "Home Assistant"
+    item.homer.rajsingh.info/subtitle: "Smart Home Hub"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/home-assistant.svg"
+    item.homer.rajsingh.info/keywords: "smart home, automation, iot"
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-home"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "homeassistant.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: homeassistant
+          port: 8123
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home-assistant
+resources:
+  - ./network-attachment-lan.yaml
+  - ./storagestack.yaml
+  - ./statefulset.yaml
+  - ./service.yaml
+  - ./httproute.yaml
+  - ./music-assistant-storagestack.yaml
+  - ./music-assistant-statefulset.yaml
+  - ./music-assistant-service.yaml
+  - ./music-assistant-httproute.yaml
+  - ./airconnect-deployment.yaml
+  - ./google-assistant-secret.sops.yaml
+  - ./lights-configmap.yaml

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/lights-configmap.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/lights-configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: home-assistant-lights
+data:
+  lights.yaml: |
+    - platform: group
+      name: Master Bedroom
+      unique_id: master_bedroom
+      entities:
+        - light.bedside_lamp_left
+        - light.bedside_lamp_right

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-httproute.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-httproute.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: music-assistant
+  annotations:
+    item.homer.rajsingh.info/name: "Music Assistant"
+    item.homer.rajsingh.info/subtitle: "Music Library & Streaming"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/music-assistant.svg"
+    item.homer.rajsingh.info/keywords: "music, streaming, library, sonos, chromecast"
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-home"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "music-assistant.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: music-assistant
+          port: 8095
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-service.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: music-assistant
+spec:
+  selector:
+    app: music-assistant
+  ports:
+    - name: http
+      port: 8095
+      targetPort: 8095
+  type: ClusterIP

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-statefulset.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-statefulset.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: music-assistant
+spec:
+  replicas: 0
+  serviceName: music-assistant
+  selector:
+    matchLabels:
+      app: music-assistant
+  template:
+    metadata:
+      labels:
+        app: music-assistant
+      annotations:
+        # macvlan side-leg + default-route on LAN. MA's stream-server
+        # auto-detects its publish IP via getsockname() on a UDP socket to
+        # 8.8.8.8 — with the default route on the LAN iface, that returns
+        # the 192.168.73.x address Sonos can fetch from. Also gives the
+        # Sonos UPnP/SSDP discovery a real LAN identity.
+        k8s.v1.cni.cncf.io/networks: |
+          [{"name":"lan","namespace":"home-assistant","default-route":["192.168.73.1"]}]
+    spec:
+      initContainers:
+        - name: restic-restore
+          image: restic/restic:0.19.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              if restic snapshots --json --last 1 2>/dev/null | grep -q '"id"'; then
+                echo "Restoring latest snapshot into /data"
+                restic restore latest --target /data
+                echo "Restore complete"
+              else
+                echo "No snapshots in repo (first boot or empty), starting fresh"
+              fi
+          envFrom:
+            - secretRef:
+                name: restic-musicassistant-data
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: music-assistant
+          image: ghcr.io/music-assistant/server:2.9.0
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - DAC_READ_SEARCH
+          env:
+            - name: TZ
+              value: ${TIMEZONE}
+            - name: LOG_LEVEL
+              value: info
+          ports:
+            - name: http
+              containerPort: 8095
+            - name: stream
+              containerPort: 8097
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: musicassistant-data

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-storagestack.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/music-assistant-storagestack.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: musicassistant-data
+  labels:
+    keiretsu.ts.net/location: stpetersburg
+spec:
+  name: musicassistant-data
+  size: 20Gi
+  storageClass: local-path
+  s3Endpoint: ${COMMON_S3_ENDPOINT}
+  s3Path: music-assistant/data
+  schedule: "0 12 * * *"
+  copyMethod: Direct
+  restorePaused: false
+  restorePrevious: 1

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/network-attachment-lan.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/network-attachment-lan.yaml
@@ -1,0 +1,41 @@
+---
+# Multus NetworkAttachmentDefinition: macvlan side-leg on eth0 with DHCP IPAM
+# from the LAN's UDM, chained with Spiderpool's coordinator plugin which
+# reconciles routing against the primary CNI (Cilium). The coordinator:
+#   - pins cluster pod/service CIDRs (10.5.0.0/16 + 10.4.0.0/16) to eth0/Cilium
+#   - makes net1 (macvlan/LAN) the pod's default-route interface so
+#     HA's Zeroconf/HomeKit + mDNS bind to the 192.168.73.x address that
+#     Apple devices on the LAN can actually reach
+#   - sets rp_filter=0 so reverse-path doesn't drop reply traffic on the
+#     "wrong" interface
+#   - reads cluster pod/service CIDRs from the SpiderCoordinator/default CR
+#
+# Replaces the route-fix init container that previously had to hand-patch
+# /16 routes inside every pod.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: lan
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "lan",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "eth0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "dhcp"
+          }
+        },
+        {
+          "type": "coordinator",
+          "mode": "overlay",
+          "podCIDRType": "cluster",
+          "tunePodRoutes": true,
+          "podDefaultRouteNic": "net1"
+        }
+      ]
+    }

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/service.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: homeassistant
+spec:
+  selector:
+    app: homeassistant
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+  type: ClusterIP

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/statefulset.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/statefulset.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: homeassistant
+spec:
+  replicas: 1
+  serviceName: homeassistant
+  selector:
+    matchLabels:
+      app: homeassistant
+  template:
+    metadata:
+      labels:
+        app: homeassistant
+      annotations:
+        # macvlan side-leg on the LAN so HomeKit Bridge + HA mobile app
+        # mDNS discovery can advertise from a real 192.168.73.x IP.
+        # default-route on the LAN iface so HA's mDNS/Bonjour goes out the
+        # right interface; Cilium's BPF still handles intra-cluster traffic.
+        k8s.v1.cni.cncf.io/networks: |
+          [{"name":"lan","namespace":"home-assistant","default-route":["192.168.73.1"]}]
+    spec:
+      priorityClassName: "infra-high"
+      initContainers:
+        - name: restic-restore
+          image: restic/restic:0.19.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              if restic snapshots --json --last 1 2>/dev/null | grep -q '"id"'; then
+                echo "Restoring latest snapshot into /config"
+                restic restore latest --target /config
+                echo "Restore complete"
+              else
+                echo "No snapshots in repo (first boot or empty), starting fresh"
+              fi
+              if [ ! -f /config/configuration.yaml ]; then
+                echo "Seeding default configuration.yaml"
+                cat > /config/configuration.yaml <<EOF
+              default_config:
+              http:
+                use_x_forwarded_for: true
+                trusted_proxies:
+                  - 10.0.0.0/8
+                  - 192.168.0.0/16
+                  - 172.16.0.0/12
+                  - 100.64.0.0/10
+              google_assistant: !include google_assistant.yaml
+              light: !include lights.yaml
+              EOF
+              fi
+              if ! grep -q "^google_assistant:" /config/configuration.yaml; then
+                echo "Appending google_assistant include to configuration.yaml"
+                printf "\ngoogle_assistant: !include google_assistant.yaml\n" >> /config/configuration.yaml
+              fi
+              if ! grep -q "^light:" /config/configuration.yaml; then
+                echo "Appending light include to configuration.yaml"
+                printf "\nlight: !include lights.yaml\n" >> /config/configuration.yaml
+              fi
+          envFrom:
+            - secretRef:
+                name: restic-homeassistant-config
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      containers:
+        - name: homeassistant
+          image: homeassistant/home-assistant:2026.6
+          env:
+            - name: TZ
+              value: ${TIMEZONE}
+          ports:
+            - name: http
+              containerPort: 8123
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: google-assistant
+              mountPath: /config/google_assistant.yaml
+              subPath: google_assistant.yaml
+              readOnly: true
+            - name: lights
+              mountPath: /config/lights.yaml
+              subPath: lights.yaml
+              readOnly: true
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: homeassistant-config
+        - name: google-assistant
+          secret:
+            secretName: home-assistant-google-assistant
+        - name: lights
+          configMap:
+            name: home-assistant-lights

--- a/kubernetes/apps/base/home-assistant/home-assistant/app/storagestack.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/app/storagestack.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: homeassistant-config
+  labels:
+    keiretsu.ts.net/location: stpetersburg
+spec:
+  name: homeassistant-config
+  size: 10Gi
+  storageClass: local-path
+  # Local Garage ClusterIP — same cluster, no Tailscale egress detour.
+  # Requires cluster DNS + route-fix init container for the Multus pod to
+  # reach the cluster service CIDR over Cilium.
+  s3Endpoint: ${COMMON_S3_ENDPOINT}
+  s3Path: home-assistant/config
+  schedule: "0 12 * * *"
+  copyMethod: Direct
+  restorePaused: false
+  restorePrevious: 1

--- a/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/deployment.yaml
+++ b/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/deployment.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyswarrm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: jellyswarrm
+  template:
+    metadata:
+      labels:
+        app: jellyswarrm
+    spec:
+      containers:
+        - name: jellyswarrm
+          image: ghcr.io/llukas22/jellyswarrm:main
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: JELLYSWARRM_USERNAME
+              value: admin
+            - name: JELLYSWARRM_PASSWORD
+              value: ${DEFAULT_PASSWORD}
+            - name: JELLYSWARRM_MEDIA_STREAMING_MODE
+              value: Proxy
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: jellyswarrm-data

--- a/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/egress.yaml
+++ b/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/egress.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-jellyfin
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-jellyfin.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 8096
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ottawa-jellyfin
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-jellyfin.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 8096
+      protocol: TCP

--- a/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/httproute.yaml
+++ b/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/httproute.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyswarrm
+  annotations:
+    item.homer.rajsingh.info/name: "Jellyfin"
+    item.homer.rajsingh.info/subtitle: "TV/Movies/Music/Books"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/jellyfin/jellyfin/refs/heads/master/Jellyfin.Server/Jellyfin.Server.ico"
+    item.homer.rajsingh.info/keywords: "media, server, streaming"
+    service.homer.rajsingh.info/name: "Media"
+    service.homer.rajsingh.info/icon: "fas fa-tv"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "jellyfin.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: jellyswarrm
+          port: 3000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/kustomization.yaml
+++ b/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: jellyswarrm
+resources:
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./pvc.yaml
+  - ./httproute.yaml
+  - ./egress.yaml

--- a/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/pvc.yaml
+++ b/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyswarrm-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/service.yaml
+++ b/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyswarrm
+spec:
+  selector:
+    app: jellyswarrm
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/kubernetes/apps/stpetersburg/gatus/gatus.yaml
+++ b/kubernetes/apps/stpetersburg/gatus/gatus.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gatus
+  namespace: flux-system
+spec:
+  targetNamespace: gatus
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/gatus/gatus/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/gatus/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/gatus/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./gatus.yaml

--- a/kubernetes/apps/stpetersburg/gatus/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/gatus/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/home-assistant/home-assistant.yaml
+++ b/kubernetes/apps/stpetersburg/home-assistant/home-assistant.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-assistant
+  namespace: flux-system
+spec:
+  targetNamespace: home-assistant
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/home-assistant/home-assistant/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+    namespace: flux-system
+  wait: false
+  interval: 5m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/home-assistant/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/home-assistant/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./home-assistant.yaml

--- a/kubernetes/apps/stpetersburg/home-assistant/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/home-assistant/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: home-assistant
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/kubernetes/apps/stpetersburg/jellyswarrm/jellyswarrm.yaml
+++ b/kubernetes/apps/stpetersburg/jellyswarrm/jellyswarrm.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app jellyswarrm
+  namespace: flux-system
+spec:
+  targetNamespace: jellyswarrm
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/jellyswarrm/jellyswarrm/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+    namespace: flux-system
+  wait: false
+  interval: 1m
+  retryInterval: 1m
+  timeout: 1m

--- a/kubernetes/apps/stpetersburg/jellyswarrm/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/jellyswarrm/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./jellyswarrm.yaml

--- a/kubernetes/apps/stpetersburg/jellyswarrm/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/jellyswarrm/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jellyswarrm
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
   - ./clickhouse
   - ./loki
   - ./mimir
+  - ./gatus
+  - ./home-assistant
+  - ./jellyswarrm


### PR DESCRIPTION
## Summary

- verbatim copy of `clusters/talos-stpetersburg/apps/{gatus,home-assistant,jellyswarrm}/app` to `kubernetes/apps/base/`
- pointer files with `spec.path` changed to new tree; CR names unchanged
- namespace dirs with `namespace.yaml` (prune: disabled)
- old parent: `cluster-apps` (stpetersburg)
- byte-identical flate check: gatus ✓, home-assistant ✓, jellyswarrm ✓
- make test ×3: all passed (agents-demo failure is pre-existing on main, not caused by this PR)

Part of #1553 Batch E.