### PR TITLE
migrate(batch-c/g3g4): adopt argocd, border0, cartography, firecrawl, gatus

### DIFF
--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/application-overview.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/application-overview.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: argocd-application-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: ArgoCD
+  grafanaCom:
+    id: 19974

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/cluster-secrets.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/cluster-secrets.yaml
@@ -1,0 +1,65 @@
+---
+# ArgoCD cluster secrets for all 3 member clusters
+# Auth handled by Tailscale k8s-operator proxy (impersonation)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-ottawa
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    location: ottawa
+    tier: app-host
+    has-gslb: "true"
+type: Opaque
+stringData:
+  name: talos-ottawa
+  server: https://ottawa-k8s-operator.keiretsu.ts.net
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-robbinsdale
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    location: robbinsdale
+    tier: app-host
+    has-gslb: "true"
+type: Opaque
+stringData:
+  name: talos-robbinsdale
+  server: https://robbinsdale-k8s-operator.keiretsu.ts.net
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-stpetersburg
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    location: stpetersburg
+    tier: app-host
+    has-gslb: "true"
+type: Opaque
+stringData:
+  name: talos-stpetersburg
+  server: https://stpetersburg-k8s-operator.keiretsu.ts.net
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/helmrelease.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: argo-cd
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: argo-cd
+      version: 9.5.20
+      sourceRef:
+        kind: HelmRepository
+        name: argoproj
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    global:
+      domain: argocd.${CLUSTER_DOMAIN}
+      logging:
+        level: debug
+    configs:
+      cm:
+        url: https://argocd.${CLUSTER_DOMAIN}
+        admin.enabled: true
+        resource.ignoreResourceUpdatesEnabled: "false"
+        exec.enabled: "true"
+        kustomize.buildOptions: --enable-helm
+        resource.exclusions: |
+          - apiGroups:
+              - cilium.io
+            kinds:
+              - CiliumIdentity
+            clusters:
+              - "*"
+        dex.config: |
+          connectors:
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: $argocd-oidc-secret:oidc.clientID
+              clientSecret: $argocd-oidc-secret:oidc.clientSecret
+              orgs:
+              - name: keiretsu-labs
+      rbac: 
+        policy.csv: |
+          g, keiretsu-labs:robbinsdale, role:admin
+        policy.default: role:admin
+      params:
+        controller.repo.server.timeout.seconds: "300"
+        server.repo.server.timeout.seconds: "300"
+      repositories:
+        argoproj-helm:
+          type: helm
+          name: argo-cd
+          url: https://argoproj.github.io/argo-helm
+    server:
+      env:
+        - name: ARGOCD_GRPC_KEEP_ALIVE_MIN
+          value: "30s"
+      extraArgs:
+        - --request-timeout=300s
+        - --insecure
+        - --repo-server-timeout-seconds=300
+      resources:
+        requests:
+          cpu: 500m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+
+    controller:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+
+    applicationSet:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 128Mi
+
+    repoServer:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+        limits:
+          memory: 1Gi
+
+    notifications:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 128Mi
+
+    redis:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 512Mi
+        limits:
+          memory: 512Mi

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/httproute.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/httproute.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argocd
+  namespace: argocd
+  annotations:
+    item.homer.rajsingh.info/name: "ArgoCD"
+    item.homer.rajsingh.info/subtitle: "GitOps Deployment"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/argo-cd.png"
+    item.homer.rajsingh.info/keywords: "gitops, kubernetes, deployment"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "argocd.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: argo-cd-argocd-server
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./secret.yaml
+  # Dashboards
+  - ./operational-overview.yaml
+  - ./notifications-overview.yaml
+  - ./application-overview.yaml
+  - ./cluster-secrets.yaml
+  - ./ocm-rbac.yaml
+  - ./webhook-ingress.yaml

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/notifications-overview.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/notifications-overview.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: argocd-notifications-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: ArgoCD
+  grafanaCom:
+    id: 19975

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/ocm-rbac.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/ocm-rbac.yaml
@@ -1,0 +1,28 @@
+---
+# Allow ArgoCD ApplicationSet controller to read OCM PlacementDecisions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-ocm-placement-reader
+rules:
+  - apiGroups:
+      - cluster.open-cluster-management.io
+    resources:
+      - placementdecisions
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-ocm-placement-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-ocm-placement-reader
+subjects:
+  - kind: ServiceAccount
+    name: argocd-applicationset-controller
+    namespace: argocd

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/operational-overview.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/operational-overview.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: argocd-operational-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: ArgoCD
+  grafanaCom:
+    id: 19993

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/secret.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-oidc-secret
+  labels:
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/name: argocd-oidc-secret
+stringData:
+  oidc.clientID: ${ARGOCD_OIDC_CLIENT_ID}
+  oidc.clientSecret: ${ARGOCD_OIDC_CLIENT_SECRET}

--- a/kubernetes/apps/base/argocd/argocd-ottawa/app/webhook-ingress.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/app/webhook-ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${LOCATION}-argocd-webhook
+  annotations:
+    tailscale.com/funnel: "true"
+    tailscale.com/proxy-class: "common"
+spec:
+  defaultBackend:
+    service:
+      name: argo-cd-argocd-server
+      port:
+        number: 80
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - ${LOCATION}-argocd-webhook

--- a/kubernetes/apps/base/argocd/argocd-ottawa/apps/floating-apps.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/apps/floating-apps.yaml
@@ -1,0 +1,56 @@
+---
+# ApplicationSet for floating apps — deploys to 1 cluster selected by OCM Placement
+# When OCM detects a cluster is down, PlacementDecision changes,
+# ArgoCD moves the Application to the new cluster automatically
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: floating-apps
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - matrix:
+        generators:
+          - clusterDecisionResource:
+              configMapRef: ocm-placement-generator
+              labelSelector:
+                matchLabels:
+                  cluster.open-cluster-management.io/placement: floating-apps
+              requeueAfterSeconds: 30
+          - git:
+              repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+              revision: HEAD
+              directories:
+                - path: clusters/apps/*/floating
+  template:
+    metadata:
+      name: 'floating-{{index .path.segments 2}}-{{.clusterName}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+        targetRevision: HEAD
+        path: "{{.path.path}}"
+        kustomize:
+          commonLabels:
+            keiretsu.ts.net/location: '{{ trimPrefix "talos-" .clusterName }}'
+      destination:
+        name: "{{.clusterName}}"
+        namespace: '{{index .path.segments 2}}'
+      ignoreDifferences:
+        - group: network.keiretsu.ts.net
+          kind: AppRoute
+          managedFieldsManagers:
+            - kro
+            - kro.run/labeller
+            - kro.run/applyset
+            - kro.run/applyset-parent
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/kubernetes/apps/base/argocd/argocd-ottawa/apps/keiretsu-apps.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/apps/keiretsu-apps.yaml
@@ -1,0 +1,63 @@
+---
+# ApplicationSet for Keiretsu app resources — deploys to clusters labeled tier=app-host
+# Uses matrix generator: cluster labels × git directory discovery
+# Injects cluster-specific values (LOCATION, S3 endpoint, etc.) via Kustomize patches
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: keiretsu-apps
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  tier: app-host
+              values:
+                location: '{{ index .metadata.labels "location" }}'
+          - git:
+              repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+              revision: HEAD
+              directories:
+                - path: clusters/apps/*/app
+  template:
+    metadata:
+      name: 'keiretsu-{{index .path.segments 2}}-{{.name}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+        targetRevision: HEAD
+        path: "{{.path.path}}"
+        kustomize:
+          commonLabels:
+            keiretsu.ts.net/location: '{{.values.location}}'
+      destination:
+        name: "{{.name}}"
+        namespace: '{{index .path.segments 2}}'
+      ignoreDifferences:
+        - group: network.keiretsu.ts.net
+          kind: ServiceIngress
+          managedFieldsManagers:
+            - kro
+            - kro.run/labeller
+            - kro.run/applyset
+            - kro.run/applyset-parent
+        - group: network.keiretsu.ts.net
+          kind: AppRoute
+          managedFieldsManagers:
+            - kro
+            - kro.run/labeller
+            - kro.run/applyset
+            - kro.run/applyset-parent
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/kubernetes/apps/base/argocd/argocd-ottawa/apps/keiretsu-egress.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/apps/keiretsu-egress.yaml
@@ -1,0 +1,53 @@
+---
+# ApplicationSet for Keiretsu egress — deploys ServiceEgress to ALL clusters
+# Uses matrix generator: all clusters × git directory discovery
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: keiretsu-egress
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  argocd.argoproj.io/secret-type: cluster
+          - git:
+              repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+              revision: HEAD
+              directories:
+                - path: clusters/apps/*/egress
+  template:
+    metadata:
+      name: 'egress-{{index .path.segments 2}}-{{.name}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+        targetRevision: HEAD
+        path: "{{.path.path}}"
+      destination:
+        name: "{{.name}}"
+        namespace: '{{index .path.segments 2}}'
+      ignoreDifferences:
+        - group: network.keiretsu.ts.net
+          kind: ServiceEgress
+          managedFieldsManagers:
+            - kro
+            - kro.run/labeller
+            - kro.run/applyset
+            - kro.run/applyset-parent
+        - group: ""
+          kind: Service
+          jsonPointers:
+            - /spec/externalName
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/kubernetes/apps/base/argocd/argocd-ottawa/apps/keiretsu-gslb.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/apps/keiretsu-gslb.yaml
@@ -1,0 +1,54 @@
+---
+# ApplicationSet for Keiretsu GSLB — deploys GSLBEndpoint to clusters running k8gb
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: keiretsu-gslb
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  has-gslb: "true"
+              values:
+                location: '{{ index .metadata.labels "location" }}'
+          - git:
+              repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+              revision: HEAD
+              directories:
+                - path: clusters/apps/*/gslb
+  template:
+    metadata:
+      name: 'gslb-{{index .path.segments 2}}-{{.name}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+        targetRevision: HEAD
+        path: "{{.path.path}}"
+        kustomize:
+          commonLabels:
+            keiretsu.ts.net/location: '{{.values.location}}'
+      destination:
+        name: "{{.name}}"
+        namespace: '{{index .path.segments 2}}'
+      ignoreDifferences:
+        - group: network.keiretsu.ts.net
+          kind: GSLBEndpoint
+          managedFieldsManagers:
+            - kro
+            - kro.run/labeller
+            - kro.run/applyset
+            - kro.run/applyset-parent
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/kubernetes/apps/base/argocd/argocd-ottawa/apps/kustomization.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/apps/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocm-config.yaml
+  - floating-apps.yaml
+  - mesh-egress.yaml
+  - keiretsu-apps.yaml
+  - keiretsu-egress.yaml
+  - keiretsu-gslb.yaml

--- a/kubernetes/apps/base/argocd/argocd-ottawa/apps/mesh-egress.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/apps/mesh-egress.yaml
@@ -1,0 +1,34 @@
+---
+# ApplicationSet for mesh egress — deploys ExternalName services to ALL clusters
+# Uses ArgoCD clusters generator (not OCM Placement) so egress persists
+# even when a cluster is tainted/down — egress must be unconditional
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: mesh-egress
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            argocd.argoproj.io/secret-type: cluster
+  template:
+    metadata:
+      name: "mesh-egress-{{.name}}"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/keiretsu-labs/kubernetes-manifests
+        targetRevision: HEAD
+        path: clusters/floating-apps/egress
+      destination:
+        name: "{{.name}}"
+        namespace: keiretsu-top
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/kubernetes/apps/base/argocd/argocd-ottawa/apps/ocm-config.yaml
+++ b/kubernetes/apps/base/argocd/argocd-ottawa/apps/ocm-config.yaml
@@ -1,0 +1,50 @@
+---
+# ConfigMap that teaches ArgoCD how to read OCM PlacementDecisions
+# Required for the clusterDecisionResource generator in ApplicationSets
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocm-placement-generator
+  namespace: argocd
+data:
+  apiVersion: cluster.open-cluster-management.io/v1beta1
+  kind: placementdecisions
+  statusListKey: decisions
+  matchKey: clusterName
+---
+# ManagedClusterSetBinding — allows the argocd namespace to use the default ManagedClusterSet
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: default
+  namespace: argocd
+spec:
+  clusterSet: default
+---
+# Placement: pick 1 cluster from the set, with failover
+# When a cluster becomes unreachable, tolerate for 5 minutes then migrate
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: floating-apps
+  namespace: argocd
+spec:
+  clusterSets:
+    - default
+  numberOfClusters: 1
+  prioritizerPolicy:
+    mode: Exact
+    configurations:
+      - scoreCoordinate:
+          builtIn: ResourceAllocatableMemory
+        weight: 1
+      - scoreCoordinate:
+          builtIn: Steady
+        weight: 3
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+      tolerationSeconds: 60
+    - key: cluster.open-cluster-management.io/not-ready
+      operator: Exists
+      tolerationSeconds: 60

--- a/kubernetes/apps/base/border0/border0-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/border0/border0-ottawa/app/helmrelease.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailzero-connector
+  namespace: border0
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: tailzero-connector
+      version: 0.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: border0
+        namespace: flux-system
+      interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: ghcr.io/borderzero/tailzero
+      tag: latest
+      pullPolicy: Always
+    # api-admin grants the connector's ServiceAccount wildcard access to the
+    # kube-apiserver + impersonation. REQUIRED for Kubernetes API proxying
+    # (the Cluster Dashboard / kubectl-over-Border0 path). Per-user authz is
+    # enforced by Border0 policies in the admin portal, not k8s RBAC.
+    rbac:
+      clusterRoleMode: api-admin
+    config:
+      # PLACEHOLDER invite — intentionally NOT a live invite code.
+      #
+      # The chart's validateConfig fails on an empty inviteCode, so this must be
+      # non-empty, but it is NEVER exchanged: the connector's durable credentials
+      # are pre-seeded out-of-band into the chart's credential-cache Secret
+      # "tailzero-connector-credentials" (ns border0). On boot tailzero loads
+      # creds FROM that Secret (-cache-k8s-secret-name) and skips the invite
+      # exchange entirely. This is the Terraform-native pattern: the API/TF
+      # primitive is a CONNECTOR TOKEN (POST /connector/token), not a portal
+      # invite. The Secret's config.yaml = {connector_id, connector_token,
+      # tailscale_auth_key} for the "ottawa-tailzero" connector
+      # (id 3d4d3aae-f604-4113-968f-fdd81b5b4cfa). It is seeded with Helm
+      # ownership metadata so helm-controller adopts it; its .data is never in
+      # git and Flux's 3-way merge preserves it (manifest declares no .data).
+      # Connector: "ottawa-tailzero" (id 3d4d3aae-f604-4113-968f-fdd81b5b4cfa).
+      inviteCode: "seeded-via-credentials-secret-do-not-edit"
+      hostname: ottawa-tailzero

--- a/kubernetes/apps/base/border0/border0-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/border0/border0-ottawa/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/cartography/cartography/app/cronjob-github.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/cronjob-github.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cartography-github
+spec:
+  schedule: "30 */6 * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cartography
+              image: ghcr.io/cartography-cncf/cartography:latest
+              command: [/bin/sh, -c]
+              args:
+                - |
+                  GITHUB_CONFIG=$$(printf '{"organization":[{"token":"%s","url":"https://api.github.com/graphql","name":"%s"}]}' \
+                    "$$GITHUB_TOKEN" "$$GITHUB_ORG" | base64 -w0)
+                  export GITHUB_CONFIG
+                  exec cartography \
+                    --neo4j-uri=bolt://neo4j:7687 \
+                    --selected-modules=github \
+                    --github-config-env-var=GITHUB_CONFIG
+              envFrom:
+                - secretRef:
+                    name: cartography-secrets
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  memory: 2Gi

--- a/kubernetes/apps/base/cartography/cartography/app/cronjob-k8s.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/cronjob-k8s.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cartography-k8s-entrypoint
+data:
+  run.sh: |
+    #!/bin/sh
+    set -eu
+    KCFG=/tmp/kubeconfig
+    CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    TOKEN=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+    cat >"$$KCFG" <<EOF
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: ${LOCATION}
+      cluster:
+        server: https://kubernetes.default.svc
+        certificate-authority: $${CA}
+    contexts:
+    - name: ${LOCATION}
+      context:
+        cluster: ${LOCATION}
+        user: cartography
+    current-context: ${LOCATION}
+    users:
+    - name: cartography
+      user:
+        token: $${TOKEN}
+    EOF
+    exec cartography \
+      --neo4j-uri bolt://neo4j:7687 \
+      --selected-modules kubernetes \
+      --k8s-kubeconfig "$$KCFG"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cartography-k8s
+spec:
+  schedule: "0 */6 * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: cartography
+          containers:
+            - name: cartography
+              image: ghcr.io/cartography-cncf/cartography:latest
+              command: [/bin/sh, /scripts/run.sh]
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  memory: 2Gi
+          volumes:
+            - name: scripts
+              configMap:
+                name: cartography-k8s-entrypoint
+                defaultMode: 0755

--- a/kubernetes/apps/base/cartography/cartography/app/cronjob-tailscale.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/cronjob-tailscale.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cartography-tailscale
+spec:
+  schedule: "45 */6 * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          volumes:
+            - name: shared
+              emptyDir: {}
+          initContainers:
+            - name: oauth-exchange
+              image: alpine:3.24
+              command: [/bin/sh, -c]
+              args:
+                - |
+                  set -eu
+                  apk add --no-cache curl jq >/dev/null
+                  TOKEN=$$(curl -sS --fail -X POST https://api.tailscale.com/api/v2/oauth/token \
+                    -H "Content-Type: application/x-www-form-urlencoded" \
+                    -d "client_id=$$TS_OAUTH_CLIENT_ID" \
+                    -d "client_secret=$$TS_OAUTH_CLIENT_SECRET" \
+                    | jq -r .access_token)
+                  test -n "$$TOKEN" -a "$$TOKEN" != null
+                  printf '%s' "$$TOKEN" >/shared/token
+              envFrom:
+                - secretRef:
+                    name: cartography-secrets
+              volumeMounts:
+                - name: shared
+                  mountPath: /shared
+          containers:
+            - name: cartography
+              image: ghcr.io/cartography-cncf/cartography:latest
+              command: [/bin/sh, -c]
+              args:
+                - |
+                  export TAILSCALE_TOKEN=$$(cat /shared/token)
+                  exec cartography \
+                    --neo4j-uri=bolt://neo4j:7687 \
+                    --selected-modules=tailscale \
+                    --tailscale-token-env-var=TAILSCALE_TOKEN \
+                    --tailscale-org=${TAILSCALE_TAILNET}
+              volumeMounts:
+                - name: shared
+                  mountPath: /shared
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  memory: 1Gi

--- a/kubernetes/apps/base/cartography/cartography/app/httproute.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/httproute.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cartography
+  annotations:
+    item.homer.rajsingh.info/name: Cartography
+    item.homer.rajsingh.info/subtitle: Infrastructure graph (Neo4j)
+    item.homer.rajsingh.info/logo: https://raw.githubusercontent.com/cartography-cncf/cartography/master/docs/root/images/logo-horizontal.png
+    item.homer.rajsingh.info/keywords: graph, security, neo4j, cncf
+    service.homer.rajsingh.info/name: Tools
+    service.homer.rajsingh.info/icon: fas fa-project-diagram
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - cartography.${CLUSTER_DOMAIN}
+  rules:
+    - backendRefs:
+        - group: ''
+          kind: Service
+          name: neo4j
+          port: 7474
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/cartography/cartography/app/kustomization.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cartography
+resources:
+  - neo4j.yaml
+  - rbac.yaml
+  - cronjob-k8s.yaml
+  - cronjob-github.yaml
+  - cronjob-tailscale.yaml
+  - secrets.yaml
+  - httproute.yaml
+  - tcproute.yaml

--- a/kubernetes/apps/base/cartography/cartography/app/neo4j.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/neo4j.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: neo4j
+spec:
+  selector:
+    app: neo4j
+  ports:
+    - name: http
+      port: 7474
+      targetPort: 7474
+    - name: bolt
+      port: 7687
+      targetPort: 7687
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: neo4j
+spec:
+  serviceName: neo4j
+  replicas: 1
+  selector:
+    matchLabels:
+      app: neo4j
+  template:
+    metadata:
+      labels:
+        app: neo4j
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 7474
+      containers:
+        - name: neo4j
+          image: neo4j:5.26.27-community
+          ports:
+            - name: http
+              containerPort: 7474
+            - name: bolt
+              containerPort: 7687
+          env:
+            - name: NEO4J_AUTH
+              value: none
+            - name: NEO4J_PLUGINS
+              value: '["graph-data-science", "apoc"]'
+            - name: NEO4J_server_memory_pagecache_size
+              value: 1G
+            - name: NEO4J_server_memory_heap_initial__size
+              value: 1G
+            - name: NEO4J_server_memory_heap_max__size
+              value: 2G
+            - name: NEO4J_dbms_security_procedures_allowlist
+              value: gds.*,apoc.*
+            - name: NEO4J_dbms_security_procedures_unrestricted
+              value: gds.*,apoc.*
+            - name: NEO4J_apoc_export_file_enabled
+              value: "true"
+            - name: NEO4J_apoc_import_file_enabled
+              value: "true"
+            - name: NEO4J_apoc_import_file_use__neo4j__config
+              value: "true"
+            - name: NEO4J_server_default__listen__address
+              value: 0.0.0.0
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: logs
+              mountPath: /logs
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 7474
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 2Gi
+            limits:
+              memory: 4Gi
+      volumes:
+        - name: logs
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: ${STORAGECLASS_DEFAULT}
+        resources:
+          requests:
+            storage: 50Gi

--- a/kubernetes/apps/base/cartography/cartography/app/rbac.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/rbac.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cartography
+  namespace: cartography
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cartography-viewer
+rules:
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list]
+  - apiGroups: [""]
+    resources: [nodes, pods, services, serviceaccounts]
+    verbs: [list]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: [roles, rolebindings, clusterroles, clusterrolebindings]
+    verbs: [list]
+  - apiGroups: ["networking.k8s.io"]
+    resources: [ingresses]
+    verbs: [list]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: [gateways, httproutes]
+    verbs: [list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cartography-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cartography-viewer
+subjects:
+  - kind: ServiceAccount
+    name: cartography
+    namespace: cartography

--- a/kubernetes/apps/base/cartography/cartography/app/secrets.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/secrets.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cartography-secrets
+type: Opaque
+stringData:
+  TS_OAUTH_CLIENT_ID: ${TS_OAUTH_CLIENT_ID}
+  TS_OAUTH_CLIENT_SECRET: ${TS_OAUTH_CLIENT_SECRET}
+  GITHUB_TOKEN: ${KUBERNETES_MANIFESTS_GITHUB_TOKEN}
+  GITHUB_ORG: keiretsu-labs

--- a/kubernetes/apps/base/cartography/cartography/app/tcproute.yaml
+++ b/kubernetes/apps/base/cartography/cartography/app/tcproute.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: neo4j-bolt
+spec:
+  parentRefs:
+    - name: private
+      namespace: home
+      sectionName: neo4j-bolt
+    - name: ts
+      namespace: home
+      sectionName: neo4j-bolt
+  rules:
+    - backendRefs:
+        - name: neo4j
+          port: 7687

--- a/kubernetes/apps/base/gatus/gatus-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-ottawa/app/helmrelease.yaml
@@ -1,0 +1,627 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gatus
+      version: 1.5.0 # Pinned version from original kustomization
+      sourceRef:
+        kind: HelmRepository
+        name: twin
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      tag: v5.35.0
+    priorityClassName: "infra-critical"
+    config:
+      alerting:
+        discord:
+          webhook-url: "${DISCORD_WEBHOOK_URL}"
+          failure-threshold: 3
+          success-threshold: 2
+      ui:
+        title: "K8s Ottawa Status"
+        description: "GitOps-managed Kubernetes cluster monitoring - Single source of truth for infrastructure health"
+        header: "K8s-Ottawa Infrastructure Dashboard"
+        logo: "https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png"
+        link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+        buttons:
+          - name: "GitOps Repository"
+            link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+          # - name: "Portfolio"
+          #   link: "https://www.${CLUSTER_DOMAIN}"
+      external-endpoints:
+        - name: Heartbeat
+          group: Alertmanager
+          token: "${GATUS_HEARTBEAT_TOKEN}"
+          heartbeat:
+            interval: 5m
+          alerts:
+            - type: discord
+              send-on-resolved: true
+
+      endpoints:
+        # === Network ===
+        - name: Internet
+          group: Network
+          url: https://1.1.1.1
+          interval: 60s
+          client:
+            dns-resolver: "tcp://8.8.8.8:53"
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === Tailscale ===
+        - name: (K8s Cluster) Ottawa
+          group: Tailscale
+          url: https://ottawa-k8s-operator.keiretsu.ts.net:443/readyz
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: (K8s Cluster) Robbinsdale
+          group: Tailscale
+          url: https://robbinsdale-k8s-operator.keiretsu.ts.net:443/readyz
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: (K8s Cluster) StPetersburg
+          group: Tailscale
+          url: https://stpetersburg-k8s-operator.keiretsu.ts.net:443/readyz
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Rei (K8s Node)
+          group: Servers
+          url: tcp://rei.killinit.internal:6443
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Asuka (K8s Node)
+          group: Servers
+          url: tcp://asuka.killinit.internal:6443
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Kaji (K8s Node)
+          group: Servers
+          url: tcp://kaji.killinit.internal:6443
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Nagato (NAS)
+          group: Servers
+          url: tcp://nagato.killinit.internal:445
+          interval: 60s
+          client:
+            insecure: true
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Jetkvm
+          group: Servers
+          url: tcp://jetkvm.killinit.internal:80
+          interval: 60s
+          client:
+            insecure: true
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: etcd (rei)
+          group: Kubernetes
+          url: http://rei.killinit.internal:2381/metrics
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 500"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: etcd (asuka)
+          group: Kubernetes
+          url: http://asuka.killinit.internal:2381/metrics
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 500"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: etcd (kaji)
+          group: Kubernetes
+          url: http://kaji.killinit.internal:2381/metrics
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 500"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Kubernetes API
+          group: Kubernetes
+          url: https://k8s.killinit.internal:6443/readyz
+          interval: 60s
+          client:
+            insecure: true
+          conditions:
+            - "[STATUS] == 401"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Envoy-Public
+          group: Networking
+          url: https://status.${CLUSTER_DOMAIN}
+          interval: 60s
+          client:
+            dns-resolver: "tcp://1.1.1.1:53"
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Envoy-Tailscale
+          group: Networking
+          url: https://status.${CLUSTER_DOMAIN}
+          interval: 60s
+          client:
+            dns-resolver: "tcp://ts-pihole-dns.home:53"
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Envoy-Private
+          group: Networking
+          url: https://status.${CLUSTER_DOMAIN}
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Plex
+          group: Media
+          url: http://plex.media:32400/identity
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Jellyfin
+          group: Media
+          url: http://jellyfin.media:8096/health
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Jellystat
+          group: Media
+          url: http://jellystat.media:3000
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Jellyseerr
+          group: Media
+          url: http://jellyseerr.media:5055
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Radarr 4k Remux
+          group: Media
+          url: http://radarr-4kremux.media:7878
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Radarr 4k
+          group: Media
+          url: http://radarr-4k.media:7878
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Radarr 1080p
+          group: Media
+          url: http://radarr-1080p.media:7878
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Radarr Anime
+          group: Media
+          url: http://radarr-anime.media:7878
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Sonarr 4k
+          group: Media
+          url: http://sonarr-4k.media:8989
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Sonarr 1080p
+          group: Media
+          url: http://sonarr-1080p.media:8989
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Sonarr Anime
+          group: Media
+          url: http://sonarr-anime.media:8989
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Prowlarr
+          group: Media
+          url: http://prowlarr.media:9696
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Bazarr 4k Remux
+          group: Media
+          url: http://bazarr-4kremux.media:6767
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Bazarr 4k
+          group: Media
+          url: http://bazarr-4k.media:6767
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Bazarr 1080p
+          group: Media
+          url: http://bazarr-1080p.media:6767
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Bazarr Anime
+          group: Media
+          url: http://bazarr-anime.media:6767
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === Download Clients ===
+        - name: QBittorrent
+          group: Media
+          url: http://qbittorrent.media
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: QBittorrent PVT
+          group: Media
+          url: http://qbittorrent-pvt.media
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Sabnzbd
+          group: Media
+          url: http://sabnzbd.media:80
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Autobrr
+          group: Media
+          url: http://autobrr.media:7474
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Flaresolverr
+          group: Media
+          url: http://flaresolverr.media:8191
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === Music Management ===
+        - name: Lidarr
+          group: Media
+          url: http://lidarr.media:8686
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === Plex Utilities ===
+        - name: Tautulli
+          group: Media
+          url: http://tautulli.media:8181
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Maintainerr
+          group: Media
+          url: http://maintainerr.media:6246
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === Request/Share Management ===
+        - name: Overseerr
+          group: Media
+          url: http://overseerr.media:5055
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Wizarr
+          group: Media
+          url: http://wizarr.media:5690
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === NEW: Kubernetes Control Plane ===
+        - name: CoreDNS
+          group: Kubernetes
+          url: http://kube-dns.kube-system:9153/metrics
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === NEW: Storage ===
+        # Rook Ceph MGR Prometheus exporter - port 9283 provides Ceph cluster metrics
+        - name: Ceph Cluster (MGR Metrics)
+          group: Storage
+          url: http://rook-ceph-mgr.rook-ceph:9283
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage
+          group: Storage
+          url: tcp://garage.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage WebUI
+          group: Storage
+          url: http://garage-webui.garage:80
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage Robbinsdale (Cross-Cluster)
+          group: Storage
+          url: tcp://robbinsdale-garage.garage:3900
+          interval: 60s
+          client:
+            timeout: 30s
+          conditions:
+            - "[CONNECTED] == true"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage StPetersburg (Cross-Cluster)
+          group: Storage
+          url: tcp://stpetersburg-garage.garage:3900
+          interval: 60s
+          client:
+            timeout: 30s
+          conditions:
+            - "[CONNECTED] == true"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === NEW: Monitoring Stack ===
+        - name: Prometheus
+          group: Monitoring
+          url: http://kube-prometheus-stack-prometheus.monitoring:9090/-/healthy
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Alertmanager
+          group: Monitoring
+          url: http://kube-prometheus-stack-alertmanager.monitoring:9093
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Grafana
+          group: Monitoring
+          url: http://grafana-service.monitoring:3000/api/health
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === NEW: Applications ===
+        - name: Immich Server
+          group: Applications
+          url: http://immich-server.immich:2283
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Immich Machine Learning
+          group: Applications
+          url: http://immich-machine-learning.immich:3003
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 5000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === NEW: GitOps ===
+        - name: Flux Source Controller
+          group: GitOps
+          url: http://source-controller.flux-system:80
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true

--- a/kubernetes/apps/base/gatus/gatus-ottawa/app/httproute.yaml
+++ b/kubernetes/apps/base/gatus/gatus-ottawa/app/httproute.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gatus
+  namespace: gatus
+  annotations:
+    item.homer.rajsingh.info/name: "Gatus"
+    item.homer.rajsingh.info/subtitle: "Service Monitoring"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/gatus.svg"
+    item.homer.rajsingh.info/keywords: "monitoring, uptime, status"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "status.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: gatus
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: / 

--- a/kubernetes/apps/base/gatus/gatus-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/gatus/gatus-ottawa/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gatus
+resources:
+  - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/base/gatus/gatus-ottawa/app/postgres.yaml
+++ b/kubernetes/apps/base/gatus/gatus-ottawa/app/postgres.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: gatus-postgres
+spec:
+  inheritedMetadata:
+    labels:
+      app: gatus-postgres
+  instances: 2
+  nodeMaintenanceWindow:
+    reusePVC: false
+  storage:
+    size: 10Gi
+    storageClass: ceph-block-replicated
+  monitoring:
+    enablePodMonitor: true
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://postgres
+      endpointURL: http://rook-ceph-rgw-object-store.rook-ceph.svc.cluster.local:80
+      serverName: gatus-postgres
+      s3Credentials:
+        accessKeyId:
+          name: postgres-ceph-bucket
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: postgres-ceph-bucket
+          key: AWS_SECRET_ACCESS_KEY
+#  bootstrap:
+#    recovery:
+#      source: gatus-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: gatus-postgres
+spec:
+  schedule: "@weekly"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: gatus-postgres 

--- a/kubernetes/apps/ottawa/argocd/argocd.yaml
+++ b/kubernetes/apps/ottawa/argocd/argocd.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: argocd
+  namespace: flux-system
+spec:
+  targetNamespace: argocd
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: argocd
+  path: ./kubernetes/apps/base/argocd/argocd-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: argocd-apps
+  namespace: flux-system
+spec:
+  targetNamespace: argocd
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: argocd-apps
+  path: ./kubernetes/apps/base/argocd/argocd-ottawa/apps
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: argocd
+    - name: ocm
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets

--- a/kubernetes/apps/ottawa/argocd/kustomization.yaml
+++ b/kubernetes/apps/ottawa/argocd/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./argocd.yaml

--- a/kubernetes/apps/ottawa/argocd/namespace.yaml
+++ b/kubernetes/apps/ottawa/argocd/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/border0/border0.yaml
+++ b/kubernetes/apps/ottawa/border0/border0.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app border0
+  namespace: flux-system
+spec:
+  targetNamespace: border0
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/border0/border0-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/border0/kustomization.yaml
+++ b/kubernetes/apps/ottawa/border0/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./border0.yaml

--- a/kubernetes/apps/ottawa/border0/namespace.yaml
+++ b/kubernetes/apps/ottawa/border0/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: border0
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/cartography/cartography.yaml
+++ b/kubernetes/apps/ottawa/cartography/cartography.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cartography
+  namespace: flux-system
+spec:
+  targetNamespace: cartography
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/cartography/cartography/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/ottawa/cartography/kustomization.yaml
+++ b/kubernetes/apps/ottawa/cartography/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./cartography.yaml

--- a/kubernetes/apps/ottawa/cartography/namespace.yaml
+++ b/kubernetes/apps/ottawa/cartography/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cartography
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/firecrawl/firecrawl.yaml
+++ b/kubernetes/apps/ottawa/firecrawl/firecrawl.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firecrawl
+  namespace: flux-system
+spec:
+  targetNamespace: firecrawl
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./examples/kubernetes/cluster-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: firecrawl
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  patches:
+    - target:
+        kind: Deployment
+        name: nuq-worker
+      patch: |-
+        - op: replace
+          path: /spec/replicas
+          value: 1

--- a/kubernetes/apps/ottawa/firecrawl/kustomization.yaml
+++ b/kubernetes/apps/ottawa/firecrawl/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./firecrawl.yaml

--- a/kubernetes/apps/ottawa/firecrawl/namespace.yaml
+++ b/kubernetes/apps/ottawa/firecrawl/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: firecrawl
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/gatus/gatus.yaml
+++ b/kubernetes/apps/ottawa/gatus/gatus.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gatus
+  namespace: flux-system
+spec:
+  targetNamespace: gatus
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/gatus/gatus-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/gatus/kustomization.yaml
+++ b/kubernetes/apps/ottawa/gatus/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./gatus.yaml

--- a/kubernetes/apps/ottawa/gatus/namespace.yaml
+++ b/kubernetes/apps/ottawa/gatus/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -18,3 +18,8 @@ resources:
   - ./volsync
   - ./zot
   - ./agent-sandbox-system
+  - ./argocd
+  - ./border0
+  - ./cartography
+  - ./firecrawl
+  - ./gatus


### PR DESCRIPTION
## summary

PR-A (adopt) for batch C groups 3+4: 5 apps, 6 CRs total.

**apps:** argocd (2 CRs), border0, cartography, firecrawl, gatus
**old parent:** cluster-apps (all 6 CRs)

## details

- argocd: 2 CRs (argocd, argocd-apps); base at `kubernetes/apps/base/argocd/argocd-ottawa/`; common/argocd is already neutered (comment-only), no collision
- border0, cartography, gatus: single CRs, verbatim copy to base
- firecrawl: sources from external `firecrawl` GitRepository, path stays `./examples/kubernetes/cluster-install` — only CR location moves

## verification

- `make test` green ×3 clusters  
- flate byte-identical: all 6 CRs confirmed