### PR TITLE
migrate(batch-e/g3): adopt border0, zot-cache-egress, tailbench (stpetersburg)

### DIFF
--- a/kubernetes/apps/base/border0/border0/app/helmrelease.yaml
+++ b/kubernetes/apps/base/border0/border0/app/helmrelease.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailzero-connector
+  namespace: border0
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: tailzero-connector
+      version: 0.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: border0
+        namespace: flux-system
+      interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      # multi-arch (amd64/arm64) — stpetersburg is the arm64/GPU site
+      repository: ghcr.io/borderzero/tailzero
+      tag: latest
+      pullPolicy: Always
+    # api-admin grants the connector's ServiceAccount wildcard access to the
+    # kube-apiserver + impersonation. REQUIRED for Kubernetes API proxying
+    # (the Cluster Dashboard / kubectl-over-Border0 path). Per-user authz is
+    # enforced by Border0 policies in the admin portal, not k8s RBAC.
+    rbac:
+      clusterRoleMode: api-admin
+    config:
+      # PLACEHOLDER invite — intentionally NOT a live invite code.
+      #
+      # The chart's validateConfig fails on an empty inviteCode, so this must be
+      # non-empty, but it is NEVER exchanged: the connector's durable credentials
+      # are pre-seeded out-of-band into the chart's credential-cache Secret
+      # "tailzero-connector-credentials" (ns border0). On boot tailzero loads
+      # creds FROM that Secret (-cache-k8s-secret-name) and skips the invite
+      # exchange entirely. This is the Terraform-native pattern: the API/TF
+      # primitive is a CONNECTOR TOKEN (POST /connector/token), not a portal
+      # invite. The Secret's config.yaml = {connector_id, connector_token,
+      # tailscale_auth_key} for the "stpetersburg-tailzero" connector
+      # (id 78ac4dfc-0dbb-4266-9bf8-4182cb82adba). Seeded with Helm ownership
+      # metadata so helm-controller adopts it; .data never in git, preserved by
+      # Flux 3-way merge (manifest declares no .data).
+      inviteCode: "seeded-via-credentials-secret-do-not-edit"
+      hostname: stpetersburg-tailzero

--- a/kubernetes/apps/base/border0/border0/app/kustomization.yaml
+++ b/kubernetes/apps/base/border0/border0/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/tailbench/tailbench/app/deployment.yaml
+++ b/kubernetes/apps/base/tailbench/tailbench/app/deployment.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailbench
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tailbench
+  template:
+    metadata:
+      labels:
+        app: tailbench
+    spec:
+      containers:
+        - name: tailbench
+          image: ghcr.io/rajsinghtech/tailbench:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/kubernetes/apps/base/tailbench/tailbench/app/httproute.yaml
+++ b/kubernetes/apps/base/tailbench/tailbench/app/httproute.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tailbench
+  annotations:
+    item.homer.rajsingh.info/name: "Tailbench"
+    item.homer.rajsingh.info/subtitle: "Tailscale Benchmarks"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/speedtest-tracker.png"
+    item.homer.rajsingh.info/keywords: "tailscale, benchmark, performance"
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "tailbench.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: tailbench
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/tailbench/tailbench/app/kustomization.yaml
+++ b/kubernetes/apps/base/tailbench/tailbench/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tailbench
+resources:
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/base/tailbench/tailbench/app/service.yaml
+++ b/kubernetes/apps/base/tailbench/tailbench/app/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tailbench
+spec:
+  selector:
+    app: tailbench
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80

--- a/kubernetes/apps/base/zot/zot-cache-egress/app/egress.yaml
+++ b/kubernetes/apps/base/zot/zot-cache-egress/app/egress.yaml
@@ -1,0 +1,17 @@
+---
+# Egress to the shared DragonflyDB instance running in Ottawa.
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-cache
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: zot-cache.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: redis
+      port: 6379
+      protocol: TCP

--- a/kubernetes/apps/base/zot/zot-cache-egress/app/kustomization.yaml
+++ b/kubernetes/apps/base/zot/zot-cache-egress/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: zot
+resources:
+  - egress.yaml

--- a/kubernetes/apps/stpetersburg/border0/border0.yaml
+++ b/kubernetes/apps/stpetersburg/border0/border0.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app border0
+  namespace: flux-system
+spec:
+  targetNamespace: border0
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/border0/border0/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/border0/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/border0/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./border0.yaml

--- a/kubernetes/apps/stpetersburg/border0/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/border0/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: border0
+  labels:
+    # privileged: the connector needs a TUN device (NET_ADMIN + /dev/net/tun)
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
   - ./gatus
   - ./home-assistant
   - ./jellyswarrm
+  - ./border0
+  - ./zot
+  - ./tailbench

--- a/kubernetes/apps/stpetersburg/tailbench/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/tailbench/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailbench.yaml

--- a/kubernetes/apps/stpetersburg/tailbench/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/tailbench/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailbench

--- a/kubernetes/apps/stpetersburg/tailbench/tailbench.yaml
+++ b/kubernetes/apps/stpetersburg/tailbench/tailbench.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailbench-app
+  namespace: flux-system
+spec:
+  targetNamespace: tailbench
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailbench/tailbench/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+    namespace: flux-system
+  wait: false
+  interval: 1m
+  retryInterval: 1m
+  timeout: 1m

--- a/kubernetes/apps/stpetersburg/zot/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/zot/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./zot-cache-egress.yaml

--- a/kubernetes/apps/stpetersburg/zot/zot-cache-egress.yaml
+++ b/kubernetes/apps/stpetersburg/zot/zot-cache-egress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zot-cache-egress
+  namespace: flux-system
+spec:
+  targetNamespace: zot
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/zot/zot-cache-egress/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

- verbatim copy of `clusters/talos-stpetersburg/apps/{border0,zot-cache-egress,tailbench}/app` to `kubernetes/apps/base/`
- pointer files with `spec.path` changed to new tree; CR names unchanged
- border0 and tailbench namespace dirs with `namespace.yaml` (prune: disabled)
- zot-cache-egress has no namespace.yaml (zot namespace owned by common zot app)
- old parent: `cluster-apps` (stpetersburg)
- byte-identical flate check: border0 ✓, zot-cache-egress ✓, tailbench-app ✓
- make test: passes (agents-demo failure is pre-existing on main)

Part of #1553 Batch E.