### PR TITLE
migrate(batch-e/g4): adopt blackbox-exporter-stpetersburg and grafana-redirect (stpetersburg)

### DIFF
--- a/kubernetes/apps/base/monitoring/blackbox-exporter-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-stpetersburg/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - probes-cluster-infra.yaml

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-stpetersburg/app/probes-cluster-infra.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-stpetersburg/app/probes-cluster-infra.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-k8s-api-local
+spec:
+  jobName: blackbox
+  module: http_401
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://k8s.stpetersburg.internal:6443/readyz
+      labels:
+        service: kubernetes-api
+        target: cluster-vip
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-cluster-services
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://kube-dns.kube-system:9153/metrics
+        - http://source-controller.flux-system:8080/metrics
+      labels:
+        service: cluster-infra

--- a/kubernetes/apps/base/monitoring/grafana-redirect-stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana-redirect-stpetersburg/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./redirect.yaml

--- a/kubernetes/apps/base/monitoring/grafana-redirect-stpetersburg/redirect.yaml
+++ b/kubernetes/apps/base/monitoring/grafana-redirect-stpetersburg/redirect.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana-redirect
+  namespace: monitoring
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "grafana.${CLUSTER_DOMAIN}"
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            hostname: grafana.killinit.cc
+            port: 443
+            statusCode: 301

--- a/kubernetes/apps/stpetersburg/monitoring/blackbox-exporter-stpetersburg.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/blackbox-exporter-stpetersburg.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: blackbox-exporter-stpetersburg
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: blackbox-exporter
+  dependsOn:
+    - name: blackbox-exporter
+  path: ./kubernetes/apps/base/monitoring/blackbox-exporter-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/monitoring/grafana-redirect.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/grafana-redirect.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-redirect
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  path: ./kubernetes/apps/base/monitoring/grafana-redirect-stpetersburg
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/apps/stpetersburg/monitoring/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./namespace.yaml
   - ./kromgo.yaml
   - ./unpoller.yaml
   - ./blackbox-exporter.yaml
+  - ./blackbox-exporter-stpetersburg.yaml
+  - ./grafana-redirect.yaml

--- a/kubernetes/apps/stpetersburg/monitoring/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary

- verbatim copy of stpetersburg blackbox-exporter/app → `kubernetes/apps/base/monitoring/blackbox-exporter-stpetersburg/app` (name collision with common base → `-stpetersburg` suffix)
- verbatim copy of stpetersburg grafana-redirect dir → `kubernetes/apps/base/monitoring/grafana-redirect-stpetersburg/` (preemptive `-stpetersburg` suffix to avoid future collision with robbinsdale's grafana-redirect)
- pointer files added to `kubernetes/apps/stpetersburg/monitoring/`
- monitoring `namespace.yaml` moved from `clusters/talos-stpetersburg/apps/blackbox-exporter/namespace.yaml` to `kubernetes/apps/stpetersburg/monitoring/namespace.yaml` (prune: disabled)
- old parent: `cluster-apps` (stpetersburg)
- byte-identical check via kustomize build (grafana-redirect not resolvable in flate's kubernetes-apps scope from old tree): blackbox-exporter-stpetersburg ✓, grafana-redirect ✓
- make test: passes (agents-demo/mimir-ruler pre-existing flake unrelated)

Part of #1553 Batch E.