### PR TITLE
migrate(batch-d/g3): adopt border0, gatus, speedtest (robbinsdale)

### DIFF
--- a/kubernetes/apps/base/border0/border0-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/border0/border0-robbinsdale/app/helmrelease.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailzero-connector
+  namespace: border0
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: tailzero-connector
+      version: 0.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: border0
+        namespace: flux-system
+      interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: ghcr.io/borderzero/tailzero
+      tag: latest
+      pullPolicy: Always
+    # api-admin grants the connector's ServiceAccount wildcard access to the
+    # kube-apiserver + impersonation. REQUIRED for Kubernetes API proxying
+    # (the Cluster Dashboard / kubectl-over-Border0 path). Per-user authz is
+    # enforced by Border0 policies in the admin portal, not k8s RBAC.
+    rbac:
+      clusterRoleMode: api-admin
+    config:
+      # PLACEHOLDER invite — intentionally NOT a live invite code.
+      #
+      # The chart's validateConfig fails on an empty inviteCode, so this must be
+      # non-empty, but it is NEVER exchanged: the connector's durable credentials
+      # are pre-seeded out-of-band into the chart's credential-cache Secret
+      # "tailzero-connector-credentials" (ns border0). On boot tailzero loads
+      # creds FROM that Secret (-cache-k8s-secret-name) and skips the invite
+      # exchange entirely. This is the Terraform-native pattern: the API/TF
+      # primitive is a CONNECTOR TOKEN (POST /connector/token), not a portal
+      # invite. The Secret's config.yaml = {connector_id, connector_token,
+      # tailscale_auth_key} for the "robbinsdale-tailzero" connector
+      # (id 7d3cdae5-c530-4865-b3a1-21fe3d050dcd). Seeded with Helm ownership
+      # metadata so helm-controller adopts it; .data never in git, preserved by
+      # Flux 3-way merge (manifest declares no .data).
+      #
+      # NOTE: tailzero (ghcr.io/borderzero/tailzero) REPLACES the legacy
+      # `border0-connector` chart (image ghcr.io/borderzero/border0), which
+      # could not serve the Tailscale-integrated k8s API-proxy data path
+      # (clients connected as WireGuard peers but packets were dropped at the
+      # connector's empty filter trie -> infinite spin in the Cluster Dashboard).
+      inviteCode: "seeded-via-credentials-secret-do-not-edit"
+      hostname: robbinsdale-tailzero

--- a/kubernetes/apps/base/border0/border0-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/border0/border0-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
@@ -1,0 +1,256 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gatus
+      version: "1.5.0"
+      sourceRef:
+        kind: HelmRepository
+        name: twin
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      tag: v5.35.0
+    priorityClassName: "infra-critical"
+    nodeSelector:
+      kubernetes.io/hostname: stone
+    envFrom:
+      - secretRef:
+          name: gatus
+    config:
+      alerting:
+        discord:
+          webhook-url: "$${discord-webhook-url}"
+          failure-threshold: 3
+          success-threshold: 2
+      ui:
+        title: "K8s Robbinsdale Status"
+        description: "GitOps-managed Kubernetes cluster monitoring - Single source of truth for infrastructure health"
+        header: "K8s-Robbinsdale Infrastructure Dashboard"
+        logo: "https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png"
+        link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+        buttons:
+          - name: "GitOps Repository"
+            link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+          - name: "Portfolio"
+            link: "https://www.rajsingh.info"
+      external-endpoints:
+        - name: Heartbeat
+          group: Alertmanager
+          url: "${GATUS_HEARTBEAT_URL}"
+          token: "${GATUS_HEARTBEAT_TOKEN}"
+          heartbeat:
+            interval: 5m
+          alerts:
+            - type: discord
+              send-on-resolved: true
+
+      endpoints:
+        - name: Kubernetes API
+          group: kubernetes
+          url: https://k8s.robbinsdale.local:6443/readyz
+          interval: 60s
+          client:
+            insecure: true
+          conditions:
+            - "[STATUS] == 401"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Tank
+          group: servers
+          url: tcp://tank.local:6443
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Titan
+          group: servers
+          url: tcp://titan.local:6443
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Stone
+          group: servers
+          url: tcp://stone.local:6443
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Ubiquiti UNAS Pro
+          group: servers
+          url: https://nas.local
+          interval: 60s
+          client:
+            insecure: true
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Portfolio - Raj Singh
+          group: website
+          url: https://www.rajsingh.info
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Immich
+          group: home
+          url: http://immich-server.immich:2283/api/server/ping
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 15000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Cloudflared Tunnel
+          group: network
+          url: https://status.rajsingh.info
+          client:
+            dns-resolver: "tcp://1.1.1.1:53"
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Portfolio - Luke Houge
+          group: website
+          url: https://www.lukehouge.com
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Jellyfin
+          group: media
+          url: http://jellyfin.media:8096/health
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Jellystat
+          group: media
+          url: http://jellystat.media:3000
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Jellyseerr
+          group: media
+          url: http://jellyseerr.media:5055
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: PiHole Home DNS
+          group: network
+          url: "ts-pihole-dns.home"
+          dns:
+            query-name: "google.com"
+            query-type: "A"
+          conditions:
+            - "[DNS_RCODE] == NOERROR"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Frigate
+          group: home
+          url: https://frigate.lukehouge.com
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Homeassistant
+          group: home
+          url: https://homeassistant.lukehouge.com
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 3000"
+            - "[CERTIFICATE_EXPIRATION] > 168h"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        # === Storage: Garage Cross-Cluster ===
+        - name: Garage Local (Robbinsdale)
+          group: storage
+          url: tcp://garage.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage Ottawa
+          group: storage
+          url: tcp://ottawa-garage.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
+        - name: Garage StPetersburg
+          group: storage
+          url: tcp://stpetersburg-garage.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/httproute.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/httproute.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gatus
+  namespace: gatus
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+    item.homer.rajsingh.info/name: "Gatus"
+    item.homer.rajsingh.info/subtitle: "Service Monitoring"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/gatus.svg"
+    item.homer.rajsingh.info/keywords: "monitoring, uptime, status"
+    # item.homer.rajsingh.info/type: "Ping"
+    # item.homer.rajsingh.info/endpoint: "http://gatus.gatus.svc.cluster.local"
+    # item.homer.rajsingh.info/method: "GET"
+    # item.homer.rajsingh.info/successCodes: "200, 201"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "status.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: gatus
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: / 

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gatus
+resources:
+  - helmrelease.yaml
+  - httproute.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/postgres.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/postgres.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: gatus-postgres
+spec:
+  inheritedMetadata:
+    labels:
+      app: gatus-postgres
+  instances: 2
+  nodeMaintenanceWindow:
+    reusePVC: false
+  storage:
+    size: 10Gi
+    storageClass: ceph-block-replicated-nvme
+  monitoring:
+    enablePodMonitor: true
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://postgres
+      endpointURL: http://rook-ceph-rgw-object-store.rook-ceph.svc.cluster.local:80
+      serverName: gatus-postgres
+      s3Credentials:
+        accessKeyId:
+          name: postgres-ceph-bucket
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: postgres-ceph-bucket
+          key: AWS_SECRET_ACCESS_KEY
+#  bootstrap:
+#    recovery:
+#      source: gatus-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: gatus-postgres
+spec:
+  schedule: "@weekly"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: gatus-postgres 

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/secret.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatus
+  namespace: gatus
+type: Opaque
+stringData:
+  discord-webhook-url: ${GATUS_DISCORD_WEBHOOK_URL}

--- a/kubernetes/apps/base/speedtest/speedtest/app/helmrelease.yaml
+++ b/kubernetes/apps/base/speedtest/speedtest/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: speedtest
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: openspeedtest
+      version: 0.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: openspeedtest
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  # values: {} # Original valuesFile was empty 

--- a/kubernetes/apps/base/speedtest/speedtest/app/httproute.yaml
+++ b/kubernetes/apps/base/speedtest/speedtest/app/httproute.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: speedtest
+  annotations:
+    item.homer.rajsingh.info/name: "SpeedTest"
+    item.homer.rajsingh.info/subtitle: "Network Speed Test"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/speedtest-tracker.png"
+    item.homer.rajsingh.info/keywords: "network, speed, test"
+
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "speedtest.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: speedtest-openspeedtest
+          port: 3000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: / 

--- a/kubernetes/apps/base/speedtest/speedtest/app/kustomization.yaml
+++ b/kubernetes/apps/base/speedtest/speedtest/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: speedtest
+resources:
+  - helmrelease.yaml
+  - httproute.yaml 

--- a/kubernetes/apps/robbinsdale/border0/border0.yaml
+++ b/kubernetes/apps/robbinsdale/border0/border0.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app border0
+  namespace: flux-system
+spec:
+  targetNamespace: border0
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/border0/border0-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/border0/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/border0/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./border0.yaml

--- a/kubernetes/apps/robbinsdale/border0/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/border0/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: border0
+  labels:
+    # privileged: the connector needs a TUN device (NET_ADMIN + /dev/net/tun)
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/gatus/gatus.yaml
+++ b/kubernetes/apps/robbinsdale/gatus/gatus.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gatus
+  namespace: flux-system
+spec:
+  targetNamespace: gatus
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/gatus/gatus-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/gatus/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/gatus/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./gatus.yaml

--- a/kubernetes/apps/robbinsdale/gatus/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/gatus/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -13,3 +13,6 @@ resources:
   - ./dragonfly-operator-system
   - ./gvisor
   - ./kube-system
+  - ./border0
+  - ./gatus
+  - ./speedtest

--- a/kubernetes/apps/robbinsdale/speedtest/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/speedtest/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./speedtest.yaml

--- a/kubernetes/apps/robbinsdale/speedtest/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/speedtest/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: speedtest
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/speedtest/speedtest.yaml
+++ b/kubernetes/apps/robbinsdale/speedtest/speedtest.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app speedtest
+  namespace: flux-system
+spec:
+  targetNamespace: speedtest
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/speedtest/speedtest/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
PR-A adopt for Batch D Group 3. Verbatim copy of cluster-specific app dirs into kubernetes tree + pointer Kustomization CRs. spec.path only change; CR names unchanged to preserve Flux adoption.

Apps: border0, gatus, speedtest

- border0: cluster-specific (hostname robbinsdale-tailzero, connector ID 7d3cdae5)
- gatus: cluster-specific (nodeSelector stone, postgres, discord webhook, robbinsdale endpoints)
- speedtest: robbinsdale-only app

flate: 236 pass (stable before/after, byte-identical renders for all 3 CRs)

Follows PR-B to release old dirs after live ownership flip verified.