### PR TITLE
migrate(batch-e/g5): adopt ai-inference into kubernetes tree (stpetersburg)

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/README.md
+++ b/kubernetes/apps/base/ai/ai/inference/README.md
@@ -1,0 +1,146 @@
+# AI Inference on DGX Spark (GB10 Blackwell)
+
+## Hardware: NVIDIA DGX Spark / SM120 / GB10
+
+- **GPU**: NVIDIA GB10 Grace Blackwell Superchip (SM_121, compute capability 12.1)
+- **Memory**: 128GB LPDDR5X **unified** (shared between CPU and GPU — no dedicated VRAM)
+- **Bandwidth**: ~273 GB/s (LPDDR5X), ~600 GB/s NVLink-C2C between CPU/GPU dies
+- **Tensor Cores**: 192x 5th-gen (native FP4/FP6/FP8 support)
+- **FP4 Peak**: ~1 PFLOP (1000 TOPS)
+- **CPU**: 10x Cortex-X925 + 10x Cortex-A725 (ARM64)
+- **CUDA**: Requires CUDA 13.0+
+- **OS**: Talos Linux v1.12.2
+
+## Current Setup: llama.cpp (Q4 GGUF)
+
+**Model**: `unsloth/Qwen3-Coder-Next-GGUF` (UD-Q4_K_XL, ~46GB)
+**Image**: `ghcr.io/ardge-labs/llama-cpp-dgx-spark:server`
+**Performance**: ~33 tok/s decode, ~170 tok/s prefill
+
+### Key Config Decisions
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `--n-gpu-layers 99` | Force all layers to GPU | `--fit on` miscalculates unified memory, only offloads 34/49 layers |
+| `--parallel 1` | Single slot | OpenCode sends >32K token prompts; splitting context across slots causes "context exceeded" |
+| `-c 131072` | 131K context | Needed for coding agents with large system prompts + file context |
+| `--seed 3407` | Fixed seed | Unsloth recommended |
+| `--jinja` | Jinja templates | Required for tool calling / chat templates |
+| No `--flash-attn` | Omitted | Not in Unsloth docs; auto mode is default |
+| No `--cache-type-k/v` | Omitted | Not in Unsloth docs; default is fine |
+
+### Sampling (per Unsloth docs)
+- `--temp 1.0`, `--top-p 0.95`, `--top-k 40`, `--min-p 0.01`
+
+## Previous Setup: vLLM (FP8)
+
+**Model**: `Qwen/Qwen3-Coder-Next-FP8` (~85GB)
+**Image**: `scitrera/dgx-spark-vllm:0.15.1-t5`
+**Performance**: ~43 tok/s decode
+
+Config is commented out in `vllm.yaml` for easy rollback.
+
+### vLLM Tuning Notes (for future use)
+- `--gpu-memory-utilization 0.85` (was 0.75 — can safely go higher on Spark)
+- `--enable-prefix-caching` — free throughput for repeated system prompts
+- `--kv-cache-dtype fp8` — halves KV cache memory
+- `--enable-chunked-prefill` — better TTFT
+- `--attention-backend flashinfer` — required for DGX Spark
+- `--load-format fastsafetensors` — faster model loading
+- `unsloth/Qwen3-Coder-Next-FP8-Dynamic` — claims 25%+ throughput over standard FP8
+
+## Comparison: vLLM vs llama.cpp on DGX Spark
+
+| | vLLM (FP8) | llama.cpp (Q4) |
+|---|---|---|
+| Model size | ~85GB | ~46GB |
+| Decode speed | ~43 tok/s | ~33 tok/s |
+| Free memory | ~43GB | ~82GB |
+| Context | 32K (configurable) | 131K (single slot) |
+| Parallel requests | 8 | 1 |
+| Tool calling | Native (qwen3_coder parser) | Jinja templates |
+| OpenAI API | Full compatibility | Compatible (llama-server) |
+| Quantization | FP8 (2x compression) | Q4_K_XL (4x compression) |
+
+**Verdict**: vLLM is faster (~30% more tok/s) and handles concurrent requests better. llama.cpp uses ~40GB less memory and supports longer context per request. Choose based on whether you need speed/concurrency (vLLM) or memory/context (llama.cpp).
+
+## Quantization Options for DGX Spark
+
+### Available for Qwen3-Coder-Next
+| Format | Size | vLLM | llama.cpp | Notes |
+|--------|------|------|-----------|-------|
+| FP8 | ~85GB | Yes | No | Best quality, native Blackwell acceleration |
+| FP8-Dynamic (Unsloth) | ~85GB | Yes | No | 25%+ throughput boost claimed |
+| Q4_K_XL GGUF (Unsloth) | ~46GB | No | Yes | Best for memory constrained |
+| Q3 GGUF | ~30GB | No | Yes | Lower quality, smallest size |
+
+### Broader Quantization Landscape
+- **NVFP4**: Native Blackwell FP4. Best perf/byte but needs SM_121-compiled vLLM (`avarok/vllm-nvfp4-gb10-sm120:v14`). Pre-quantized models: `nvidia/Qwen3-30B-A3B-NVFP4`, `nvidia/DeepSeek-R1-NVFP4`
+- **AWQ INT4** (Marlin): Best general vLLM 4-bit. ~741 tok/s throughput with Marlin kernel. No AWQ version of Qwen3-Coder-Next exists yet.
+- **GPTQ INT4** (Marlin): Slightly behind AWQ quality. ~712 tok/s.
+- **BitsAndBytes 4-bit**: On-the-fly quantization (no pre-quantized checkpoint needed) but ~168 tok/s (slow).
+
+### What Fits in 128GB (model weights only)
+| Model | FP16 | FP8 | INT4 | NVFP4 |
+|-------|------|-----|------|-------|
+| 70B | 140GB (no) | 70GB | 35GB | 40GB |
+| 80B MoE (Qwen3-CN) | ~160GB (no) | ~85GB | ~46GB | ~50GB |
+| 405B | 810GB (no) | 405GB (no) | ~100GB (barely) | ~115GB (barely) |
+
+## DGX Spark Gotchas
+
+1. **Unified memory ≠ VRAM**: `--fit on` in llama.cpp and `--gpu-memory-utilization` in vLLM miscalculate available memory because they see the GPU's allocation separately from total unified pool.
+2. **ARM64 images required**: Standard x86_64 Docker images won't work. Need ARM64+CUDA builds.
+3. **SM_121 kernels**: Stock vLLM is compiled for SM_100 (Hopper). NVFP4 MoE kernels need SM_120+ specific builds.
+4. **No official ARM64+CUDA llama.cpp images**: `ghcr.io/ggml-org/llama.cpp:server-cuda` is amd64 only. Use `ghcr.io/ardge-labs/llama-cpp-dgx-spark:server` or build your own.
+5. **Qwen3-Coder-Next is Gated DeltaNet**: Not standard Transformer or Mamba. Requires llama.cpp b7186+ with Feb 4, 2026 key_gdiff fix (PR #19324).
+6. **Buffer cache on unified memory**: vLLM may OOM even when memory appears available. Flush with `echo 3 > /proc/sys/vm/drop_caches`.
+7. **llama.cpp ~40% slower than vLLM**: Known ARM CPU performance issue (GitHub #19345, #19386). Ongoing.
+
+## Docker Images
+
+| Image | Purpose | Architecture |
+|-------|---------|-------------|
+| `scitrera/dgx-spark-vllm:0.15.1-t5` | vLLM for DGX Spark | ARM64+CUDA |
+| `ghcr.io/ardge-labs/llama-cpp-dgx-spark:server` | llama.cpp for DGX Spark | ARM64+CUDA 13.0+SM_121 |
+| `avarok/vllm-nvfp4-gb10-sm120:v14` | vLLM with NVFP4 for Blackwell | ARM64+CUDA |
+
+## OpenCode Configuration
+
+Config lives at `~/.config/opencode/config.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "llama-cpp/Qwen3-Coder-Next",
+  "provider": {
+    "llama-cpp": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "http://stpetersburg-llama-cpp/v1"
+      },
+      "models": {
+        "Qwen3-Coder-Next": {
+          "name": "Qwen3-Coder-Next",
+          "limit": { "context": 131072, "output": 16384 }
+        }
+      }
+    }
+  }
+}
+```
+
+Tailscale MagicDNS hostnames:
+- `stpetersburg-llama-cpp` → llama.cpp server (port 80 → 8000)
+- `stpetersburg-vllm` → vLLM server (port 80 → 8000) [currently disabled]
+
+## References
+
+- [Unsloth Qwen3-Coder-Next Guide](https://unsloth.ai/docs/models/qwen3-coder-next)
+- [NVIDIA DGX Spark Hardware Docs](https://docs.nvidia.com/dgx/dgx-spark/hardware.html)
+- [vLLM Quantization Docs](https://docs.vllm.ai/en/latest/features/quantization/)
+- [llama.cpp Qwen3-Next PR #16095](https://github.com/ggml-org/llama.cpp/pull/16095)
+- [key_gdiff Fix PR #19324](https://github.com/ggml-org/llama.cpp/pull/19324)
+- [ardge-labs DGX Spark images](https://github.com/ardge-labs/llama-cpp-dgx-spark)
+- [Avarok NVFP4 Blog](https://blog.avarok.net/nvfp4-w4a4-moe-inference-on-nvidia-blackwell-gb10-1a83e85d0f9e)
+- [NVIDIA NVFP4 Blog](https://developer.nvidia.com/blog/introducing-nvfp4-for-efficient-and-accurate-low-precision-inference/)

--- a/kubernetes/apps/base/ai/ai/inference/ai-gateway.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/ai-gateway.yaml
@@ -1,0 +1,64 @@
+# Dedicated Envoy AI Gateway for vLLM. Isolated from the shared `ts` gateway
+# so the ai-gateway-extproc sidecar rollout only churns this proxy. Exposed
+# as its own dedicated Tailscale device via proxy-class (legacy per-svc proxy
+# StatefulSet) — ProxyGroup-shared ingress had reachability issues from some
+# tag:k8s clients.
+#
+# Flow:
+#   client → http://stpetersburg-ai-gateway.keiretsu.ts.net/  (or any host:80)
+#         → Tailscale CGNAT VIP (100.x.y.z, served by dedicated ts-* pod)
+#         → Envoy proxy (this gateway, HTTP/80, any Host)
+#         → AIGatewayRoute → AIServiceBackend → Backend → vllm.ai.svc:8000
+#
+# HTTP only — TLS is the tailnet itself (wireguard). No cert needed.
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: ai-gateway
+  namespace: ai
+spec:
+  telemetry:
+    metrics:
+      prometheus:
+        compression:
+          type: Gzip
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 1
+      envoyService:
+        annotations:
+          tailscale.com/hostname: ${LOCATION}-ai-gateway
+          tailscale.com/proxy-class: common
+          tailscale.com/tags: "tag:singh360,tag:k8s,tag:${LOCATION}"
+        loadBalancerClass: tailscale
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ai-gateway
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: ai-gateway
+    namespace: ai
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ai-gateway
+  namespace: ai
+spec:
+  gatewayClassName: ai-gateway
+  listeners:
+    # No hostname filter — accepts any Host header.
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: © 2025 Raj Singh <raj@keiretsu.cloud>
+# SPDX-License-Identifier: MIT
+#
+# DeepSeek-V4-Flash on 2× DGX Spark — vLLM v1 engine
+#
+# Intent        : Serve the official FP8 DeepSeek-V4-Flash (685B MoE, 46
+#                 shards, ~149 GiB) across 2× DGX Spark nodes, each with a
+#                 single Jetson Thor Blackwell GPU (120 GiB usable).
+#
+# Architecture  : TP=2 across 2 nodes via PyTorch mp backend (no Ray).
+#                 Each pod gets a single GPU; NCCL-RoCEv2 over CX-7 for
+#                 the cross-node tensor-parallel shard.
+#
+# Memory guard  : Control-plane shares the GPU node (spark-0). Without
+#                 drop-caches, the OS page cache from kv2png routinely pushes
+#                 kubelet past the evictionThreshold. Initiaker + sidecar
+#                 echo 3 > /proc/sys/vm/drop_caches pre- and during weight
+#                 load to keep host memory under the evictionHard (6 GiB)
+#                 thresholds. vLLM startup script also drops caches immediately
+#                 before weight load.
+#                 kubelet memory guard: systemReserved 4Gi, kubeReserved 4Gi,
+#                 evictionHard 6Gi.
+#                 Guaranteed QoS at 85Gi (request==limit) to ensure predictable
+#                 accounting.
+#   Current: 0.70 util, 32K ctx, 1 seq, flashinfer ON, MTP ON, B12X MoE.
+#   Step up ctx: 32K → 64K → 128K → 256K as KV cache allows.
+#   NOTE: B12X kernel (VLLM_USE_B12X_MOE=1) does NOT support
+#   --enable-expert-parallel; the two are mutually exclusive on this build.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dsv4-download-script
+  namespace: ai
+data:
+  download-and-validate.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    MODEL_DIR="${MODEL_DIR:-/models/dsv4}"
+    HF_REPO="${HF_REPO:-deepseek-ai/DeepSeek-V4-Flash}"
+    EXPECTED=46
+
+    mkdir -p "$MODEL_DIR"
+    cd "$MODEL_DIR"
+
+    echo "[download] Starting model download with hf CLI…"
+    hf download "$HF_REPO" --local-dir "$MODEL_DIR" 2>&1
+
+    echo "[validate] Checking for ${EXPECTED} shards…"
+    COUNT="$(find . -name '*.safetensors' | wc -l)"
+    echo "[validate] Found ${COUNT} shard(s)"
+
+    if [ "$COUNT" -lt "$EXPECTED" ]; then
+      echo "[ERROR] Expected ${EXPECTED} shards, got ${COUNT}. Redownloading…"
+      rm -rf "$MODEL_DIR"/*
+      hf download "$HF_REPO" --local-dir "$MODEL_DIR" 2>&1
+      COUNT="$(find . -name '*.safetensors' | wc -l)"
+      if [ "$COUNT" -lt "$EXPECTED" ]; then
+        echo "[FATAL] Still only ${COUNT} shards after retry. Aborting."
+        exit 1
+      fi
+    fi
+
+    echo "[validate] Shard validation OK (${COUNT}/${EXPECTED})"
+    echo "[download] Done."
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dsv4-head-models
+  namespace: ai
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 200Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dsv4-worker-models
+  namespace: ai
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 200Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dsv4-head
+  namespace: ai
+  labels: { app: dsv4, role: head }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: dsv4, role: head }
+  template:
+    metadata:
+      labels: { app: dsv4, role: head }
+    spec:
+      hostNetwork: true
+      hostIPC: true
+      nodeSelector: { kubernetes.io/hostname: spark-0 }
+      initContainers:
+      - name: drop-caches
+        image: busybox:1.38
+        command: [sh, -c, "echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true"]
+        securityContext: { privileged: true }
+        resources:
+          requests: { memory: "64Mi", cpu: "100m" }
+          limits: { memory: "256Mi", cpu: "500m" }
+      - name: download-models
+        image: aidendle94/sparkrun-vllm-ds4-gb10:production-ready
+        command:
+        - /bin/bash
+        args:
+        - /scripts/download-and-validate.sh
+        env:
+        - { name: MODEL_DIR, value: "/models/dsv4" }
+        - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
+        - { name: HF_HOME, value: "/models/huggingface" }
+        - { name: HF_HUB_OFFLINE, value: "0" }
+        - { name: TRANSFORMERS_OFFLINE, value: "0" }
+        volumeMounts:
+        - { name: models, mountPath: /models }
+        - { name: download-script, mountPath: /scripts }
+        resources:
+          requests: { memory: "4Gi", cpu: "2000m" }
+          limits: { memory: "8Gi", cpu: "4000m" }
+      containers:
+      - name: drop-caches-loop
+        image: busybox:1.38
+        command: [sh, -c, "while true; do sleep 15; echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true; done"]
+        securityContext: { privileged: true }
+        resources:
+          requests: { memory: "64Mi", cpu: "100m" }
+          limits: { memory: "256Mi", cpu: "500m" }
+      - name: vllm
+        image: aidendle94/sparkrun-vllm-ds4-gb10:production-ready
+        command: [bash, -c]
+        args:
+        - |
+          # Drop page cache immediately before weight load (belt + suspenders
+          # with the drop-caches init container above).
+          echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true
+          exec /usr/local/bin/dsv4-vllm-entrypoint serve /models/dsv4 \
+            --served-model-name deepseek-v4-flash DeepSeek-V4-Flash \
+            --host 0.0.0.0 --port 8000 --trust-remote-code \
+            --tensor-parallel-size 2 --pipeline-parallel-size 1 \
+            --distributed-executor-backend mp \
+            --kv-cache-dtype fp8 --block-size 256 \
+            --max-model-len 262144 \
+            --max-num-seqs 2 --max-num-batched-tokens 8192 \
+            --gpu-memory-utilization 0.75 \
+            --enable-prefix-caching \
+            --enable-flashinfer-autotune \
+            --tokenizer-mode deepseek_v4 \
+            --tool-call-parser deepseek_v4 --enable-auto-tool-choice \
+            --reasoning-parser deepseek_v4 \
+            --speculative-config '{"method":"mtp","num_speculative_tokens":1}' \
+            --nnodes 2 --node-rank 0 \
+            --master-addr 192.168.74.1 --master-port 25000
+        ports:
+        - { containerPort: 8000, name: http, protocol: TCP }
+        env:
+        - { name: NODE_RANK, value: "0" }
+        - { name: VLLM_HOST_IP, value: "192.168.74.1" }
+        - { name: MASTER_ADDR, value: "192.168.74.1" }
+        - { name: VLLM_USE_B12X_MOE, value: "1" }
+        - { name: VLLM_SPARSE_INDEXER_MAX_LOGITS_MB, value: "256" }
+        - { name: VLLM_ALLOW_LONG_MAX_MODEL_LEN, value: "1" }
+        - { name: TRANSFORMERS_OFFLINE, value: "1" }
+        - { name: PYTORCH_CUDA_ALLOC_CONF, value: "expandable_segments:True" }
+        # RoCEv2 over the ConnectX-7 rail.
+        - { name: NCCL_SOCKET_IFNAME, value: "eth2" }
+        - { name: GLOO_SOCKET_IFNAME, value: "eth2" }
+        - { name: NCCL_IB_HCA, value: "mlx5_1" }
+        - { name: NCCL_IB_GID_INDEX, value: "3" }
+        - { name: NCCL_IB_DISABLE, value: "0" }
+        - { name: NCCL_NET_GDR_LEVEL, value: "5" }
+        - { name: NCCL_IB_TIMEOUT, value: "22" }
+        - { name: NCCL_DEBUG, value: "INFO" }
+        - { name: VLLM_PORT, value: "25001" }
+        - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
+        - { name: HF_HOME, value: "/models/huggingface" }
+        - { name: VLLM_COMPILE_CACHE_DIR, value: "/models/compile-cache" }
+        - { name: VLLM_CACHE_ROOT, value: "/models/vllm-cache" }
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["IPC_LOCK", "SYS_RESOURCE"]
+        volumeMounts:
+        - { name: models, mountPath: /models }
+        - { name: shm, mountPath: /dev/shm }
+        - { name: infiniband, mountPath: /dev/infiniband }
+        - { name: sys-ib, mountPath: /sys/class/infiniband }
+        resources:
+          requests: { memory: "85Gi", cpu: "8000m", nvidia.com/gpu: "1" }
+          limits: { memory: "85Gi", nvidia.com/gpu: "1" }
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 900
+          periodSeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 900
+          periodSeconds: 15
+          timeoutSeconds: 10
+      volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: "128Gi"
+      - name: infiniband
+        hostPath: { path: /dev/infiniband, type: "" }
+      - name: sys-ib
+        hostPath: { path: /sys/class/infiniband, type: "" }
+      - name: models
+        persistentVolumeClaim: { claimName: dsv4-head-models }
+      - name: download-script
+        configMap:
+          name: dsv4-download-script
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dsv4-worker
+  namespace: ai
+  labels: { app: dsv4, role: worker }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: dsv4, role: worker }
+  template:
+    metadata:
+      labels: { app: dsv4, role: worker }
+    spec:
+      hostNetwork: true
+      hostIPC: true
+      nodeSelector: { kubernetes.io/hostname: spark-1 }
+      initContainers:
+      - name: drop-caches
+        image: busybox:1.38
+        command: [sh, -c, "echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true"]
+        securityContext: { privileged: true }
+        resources:
+          requests: { memory: "64Mi", cpu: "100m" }
+          limits: { memory: "256Mi", cpu: "500m" }
+      - name: download-models
+        image: aidendle94/sparkrun-vllm-ds4-gb10:production-ready
+        command:
+        - /bin/bash
+        args:
+        - /scripts/download-and-validate.sh
+        env:
+        - { name: MODEL_DIR, value: "/models/dsv4" }
+        - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
+        - { name: HF_HOME, value: "/models/huggingface" }
+        - { name: HF_HUB_OFFLINE, value: "0" }
+        - { name: TRANSFORMERS_OFFLINE, value: "0" }
+        volumeMounts:
+        - { name: models, mountPath: /models }
+        - { name: download-script, mountPath: /scripts }
+        resources:
+          requests: { memory: "4Gi", cpu: "2000m" }
+          limits: { memory: "8Gi", cpu: "4000m" }
+      containers:
+      - name: drop-caches-loop
+        image: busybox:1.38
+        command: [sh, -c, "while true; do sleep 15; echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true; done"]
+        securityContext: { privileged: true }
+        resources:
+          requests: { memory: "64Mi", cpu: "100m" }
+          limits: { memory: "256Mi", cpu: "500m" }
+      - name: vllm
+        image: aidendle94/sparkrun-vllm-ds4-gb10:production-ready
+        command: [bash, -c]
+        args:
+        - |
+          echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true
+          exec /usr/local/bin/dsv4-vllm-entrypoint serve /models/dsv4 \
+            --served-model-name deepseek-v4-flash DeepSeek-V4-Flash \
+            --host 0.0.0.0 --port 8000 --trust-remote-code \
+            --tensor-parallel-size 2 --pipeline-parallel-size 1 \
+            --distributed-executor-backend mp \
+            --kv-cache-dtype fp8 --block-size 256 \
+            --max-model-len 262144 \
+            --max-num-seqs 2 --max-num-batched-tokens 8192 \
+            --gpu-memory-utilization 0.75 \
+            --enable-prefix-caching \
+            --enable-flashinfer-autotune \
+            --tokenizer-mode deepseek_v4 \
+            --tool-call-parser deepseek_v4 --enable-auto-tool-choice \
+            --reasoning-parser deepseek_v4 \
+            --speculative-config '{"method":"mtp","num_speculative_tokens":1}' \
+            --nnodes 2 --node-rank 1 \
+            --master-addr 192.168.74.1 --master-port 25000 \
+            --headless
+        env:
+        - { name: NODE_RANK, value: "1" }
+        - { name: VLLM_HOST_IP, value: "192.168.74.2" }
+        - { name: MASTER_ADDR, value: "192.168.74.1" }
+        - { name: HEADLESS, value: "1" }
+        - { name: VLLM_USE_B12X_MOE, value: "1" }
+        - { name: VLLM_SPARSE_INDEXER_MAX_LOGITS_MB, value: "256" }
+        - { name: VLLM_ALLOW_LONG_MAX_MODEL_LEN, value: "1" }
+        - { name: TRANSFORMERS_OFFLINE, value: "1" }
+        - { name: PYTORCH_CUDA_ALLOC_CONF, value: "expandable_segments:True" }
+        # RoCEv2 over the ConnectX-7 rail.
+        - { name: NCCL_SOCKET_IFNAME, value: "eth2" }
+        - { name: GLOO_SOCKET_IFNAME, value: "eth2" }
+        - { name: NCCL_IB_HCA, value: "mlx5_1" }
+        - { name: NCCL_IB_GID_INDEX, value: "3" }
+        - { name: NCCL_IB_DISABLE, value: "0" }
+        - { name: NCCL_NET_GDR_LEVEL, value: "5" }
+        - { name: NCCL_IB_TIMEOUT, value: "22" }
+        - { name: NCCL_DEBUG, value: "INFO" }
+        - { name: VLLM_PORT, value: "25001" }
+        - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
+        - { name: HF_HOME, value: "/models/huggingface" }
+        - { name: VLLM_COMPILE_CACHE_DIR, value: "/models/compile-cache" }
+        - { name: VLLM_CACHE_ROOT, value: "/models/vllm-cache" }
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["IPC_LOCK", "SYS_RESOURCE"]
+        volumeMounts:
+        - { name: models, mountPath: /models }
+        - { name: shm, mountPath: /dev/shm }
+        - { name: infiniband, mountPath: /dev/infiniband }
+        - { name: sys-ib, mountPath: /class/infiniband }
+        resources:
+          requests: { memory: "85Gi", cpu: "8000m", nvidia.com/gpu: "1" }
+          limits: { memory: "85Gi", nvidia.com/gpu: "1" }
+      volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: "128Gi"
+      - name: infiniband
+        hostPath: { path: /dev/infiniband, type: "" }
+      - name: sys-ib
+        hostPath: { path: /sys/class/infiniband, type: "" }
+      - name: models
+        persistentVolumeClaim: { claimName: dsv4-worker-models }
+      - name: download-script
+        configMap:
+          name: dsv4-download-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dsv4
+  namespace: ai
+  labels: { app: dsv4 }
+spec:
+  type: ClusterIP
+  selector: { app: dsv4, role: head }
+  ports:
+  - { name: http, port: 8000, protocol: TCP, targetPort: 8000 }
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dsv4
+  namespace: ai
+  labels:
+    app: dsv4
+    release: kube-prometheus-stack
+spec:
+  endpoints:
+  - port: http
+    path: /metrics
+    interval: 15s
+    scrapeTimeout: 10s
+    metricRelabelings:
+    - action: replace
+      replacement: talos-stpetersburg
+      targetLabel: cluster
+  selector:
+    matchLabels:
+      app: dsv4
+  namespaceSelector:
+    matchNames:
+    - ai

--- a/kubernetes/apps/base/ai/ai/inference/kustomization.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+
+resources:
+  - namespace.yaml
+  - vllm.yaml
+  - dsv4.yaml
+  - ai-gateway.yaml
+  - vllm-route.yaml
+  - vllm-dnsrecord.yaml
+  - scrapeconfig.yaml
+  - secret.yaml
+  - probes.yaml

--- a/kubernetes/apps/base/ai/ai/inference/namespace.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/base/ai/ai/inference/probes.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/probes.yaml
@@ -1,0 +1,19 @@
+---
+# vLLM OpenAI-compatible inference server.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-vllm
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://vllm.ai:8000/health
+        - http://vllm.ai:8000/v1/models
+      labels:
+        service: ai-inference
+        target: vllm

--- a/kubernetes/apps/base/ai/ai/inference/scrapeconfig.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/scrapeconfig.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: vllm
+  namespace: ai
+  labels:
+    release: kube-prometheus-stack
+spec:
+  staticConfigs:
+  - targets:
+    - vllm.ai.svc.cluster.local:8000
+  metricsPath: /metrics
+  scrapeInterval: 15s

--- a/kubernetes/apps/base/ai/ai/inference/secret.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-secret
+  namespace: ai
+stringData:
+  HF_TOKEN: ${HF_TOKEN}

--- a/kubernetes/apps/base/ai/ai/inference/vllm-dnsrecord.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/vllm-dnsrecord.yaml
@@ -1,0 +1,21 @@
+# Public DNS for the AI Gateway. 100.119.119.145 is the Tailscale CGNAT VIP
+# of the dedicated ai-gateway service (loadBalancerClass: tailscale, hostname
+# stpetersburg-ai-gateway). Only reachable from tailnet-connected machines —
+# Cloudflare proxy must stay disabled for CGNAT targets.
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: ai-gateway
+  namespace: ai
+  labels:
+    dns-target: cloudflare
+spec:
+  endpoints:
+    - dnsName: "${LOCATION}-ai-gateway.${COMMON_DOMAIN}"
+      recordType: A
+      targets:
+        - "100.119.119.145"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/base/ai/ai/inference/vllm-route.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/vllm-route.yaml
@@ -1,0 +1,88 @@
+# vLLM routing on the dedicated ai-gateway. Token-aware metrics, model-aware
+# routing, streaming-aware LB via Envoy AI Gateway. Using LeastRequest so
+# both DGX Sparks are used efficiently (routes to the Spark with fewer active
+# connections, correlating with KV cache utilization).
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: vllm
+  namespace: ai
+spec:
+  endpoints:
+    - fqdn:
+        # Repointed from the Qwen `vllm` Service to the DeepSeek-V4-Flash head pod (dsv4.yaml).
+        hostname: dsv4.ai.svc.cluster.local
+        port: 8000
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: vllm
+  namespace: ai
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    group: gateway.envoyproxy.io
+    kind: Backend
+    name: vllm
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIGatewayRoute
+metadata:
+  name: vllm
+  namespace: ai
+spec:
+  parentRefs:
+    - name: ai-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  # Token-aware metrics exported via Envoy dynamic metadata for Prometheus.
+  llmRequestCosts:
+    - metadataKey: llm_input_token
+      type: InputToken
+    - metadataKey: llm_output_token
+      type: OutputToken
+    - metadataKey: llm_total_token
+      type: TotalToken
+    - metadataKey: llm_cached_input_token
+      type: CachedInputToken
+  rules:
+    # Dedicated gateway, single listener for *-ai-gateway.${COMMON_DOMAIN}.
+    # No Host filter needed — all traffic on this gateway is AI.
+    - backendRefs:
+        - name: vllm
+      timeouts:
+        # vLLM streaming completions can run for minutes on long generations.
+        request: 0s
+        backendRequest: 0s
+---
+# ConsistentHash on X-Session-Id pins each chat session to a single Spark so
+# the warm prefix cache (system prompt + conversation context) keeps hitting.
+# Clients without the header fall back to source-IP hashing — still sticky
+# per-client, just coarser. Tradeoff vs LeastRequest: gives up active-connection
+# balancing in exchange for KV-cache locality.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: vllm
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: vllm
+  loadBalancer:
+    type: ConsistentHash
+    consistentHash:
+      type: Header
+      header:
+        name: X-Session-Id
+  timeout:
+    http:
+      requestTimeout: 0s
+      connectionIdleTimeout: 600s
+      maxConnectionDuration: 0s
+  connection:
+    bufferLimit: 65536

--- a/kubernetes/apps/base/ai/ai/inference/vllm.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/vllm.yaml
@@ -1,0 +1,291 @@
+# vLLM Deployment for DGX Spark (GB10/ARM/Blackwell) — OPTIMIZED DATA-PARALLEL
+# Model: AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS + DFlash speculative decoding
+# Image: ghcr.io/aeon-7/vllm-aeon-ultimate-dflash:qwen36-v4 (ARM64/SBSA, patched vLLM)
+# Reference: https://github.com/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-DFlash
+#
+# PERFORMANCE TUNING (2026-05-12):
+#   - Full GB10 per replica (no time-slicing: 128GB unified memory, all compute units)
+#   - gpu-memory-utilization: 0.80 → more KV cache headroom on unified memory
+#   - /dev/shm: 16Gi → multimodal + DFlash shared memory
+#   - VLLM_CPU_KV_TRANSFER_CHUNK_SIZE=16, VLLM_BLOCK_SIZE=32 → CPU/KV cache tuning
+#   - max-num-seqs=64 per replica (128 cluster-wide concurrent streams)
+#   - max-num-batched-tokens 65536 → chunked prefill budget (500000 OOMed on 96Gi container limit)
+#   - --block-size 32 → PagedAttention block size
+#   - CPU freq governance via cpu_freq_scale sysctl (spark-0/1 nodes)
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vllm
+  namespace: ai
+  labels:
+    app: vllm
+spec:
+  serviceName: vllm-headless
+  # Scaled to 0: both DGX Spark GPUs are now claimed by the DeepSeek-V4-Flash TP=2
+  # instance (dsv4.yaml). Kept in-repo for rollback — set back to 2 to restore Qwen.
+  replicas: 0
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      enableServiceLinks: false
+      # One replica per spark (DGX Spark only — no time-sliced GPUs elsewhere)
+      nodeSelector:
+        node.kubernetes.io/instance-type: dgx-spark
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: vllm
+      terminationGracePeriodSeconds: 120
+      initContainers:
+      - name: download-models
+        image: ghcr.io/aeon-7/vllm-aeon-ultimate-dflash:qwen36-v4
+        command: [python3, /scripts/download.py]
+        env:
+        - name: HUGGING_FACE_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: HF_TOKEN
+        - name: HF_HOME
+          value: "/models/huggingface"
+        volumeMounts:
+        - name: models
+          mountPath: /models
+        - name: download-script
+          mountPath: /scripts
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "2000m"
+          limits:
+            memory: "8Gi"
+      - name: drop-caches
+        image: busybox:1.38
+        command: [sh, -c, "sync && echo 3 > /proc/sys/vm/drop_caches && echo 'page cache dropped'"]
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "100m"
+          limits:
+            memory: "32Mi"
+      containers:
+      - name: vllm
+        image: ghcr.io/aeon-7/vllm-aeon-ultimate-dflash:qwen36-v4
+        command: [bash, -c]
+        args:
+        - |
+          exec vllm serve /models/aeon-ultimate-xs \
+            --served-model-name Qwen3.6-27B aeon-ultimate qwen36-ultimate aeon-fast aeon-deep aeon-ultimate-xs \
+            --host 0.0.0.0 \
+            --port 8000 \
+            --tensor-parallel-size 1 \
+            --dtype auto \
+            --quantization modelopt \
+            --max-model-len 200000 \
+            --max-num-seqs 64 \
+            --max-num-batched-tokens 65536 \
+            --gpu-memory-utilization 0.60 \
+            --enable-chunked-prefill \
+            --enable-prefix-caching \
+            --block-size 32 \
+            --load-format safetensors \
+            --trust-remote-code \
+            --enable-auto-tool-choice \
+            --tool-call-parser qwen3_coder \
+            --reasoning-parser qwen3 \
+            --default-chat-template-kwargs '{"enable_thinking": true, "thinking_budget": 2048}' \
+            --limit-mm-per-prompt '{"image": 4, "video": 2}' \
+            --mm-encoder-tp-mode data \
+            --mm-processor-cache-type shm \
+            --speculative-config '{"method":"dflash","model":"/models/aeon-ultimate-dflash","num_speculative_tokens":15}' \
+            --attention-backend flash_attn
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        env:
+        - name: VLLM_TEST_FORCE_FP8_MARLIN
+          value: "0"
+        - name: TORCH_MATMUL_PRECISION
+          value: "high"
+        - name: PYTORCH_CUDA_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: NVIDIA_FORWARD_COMPAT
+          value: "1"
+        - name: NCCL_IGNORE_CPU_AFFINITY
+          value: "1"
+        - name: ENABLE_NVFP4_SM100
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_MOE_FP4
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_SAMPLER
+          value: "1"
+        - name: VLLM_NVFP4_GEMM_BACKEND
+          value: "flashinfer-cutlass"
+        - name: HUGGING_FACE_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: HF_TOKEN
+        - name: HF_HOME
+          value: "/models/huggingface"
+        - name: VLLM_COMPILE_CACHE_DIR
+          value: "/models/compile-cache"
+        - name: VLLM_CACHE_ROOT
+          value: "/models/vllm-cache"
+        - name: VLLM_CPU_KV_TRANSFER_CHUNK_SIZE
+          value: "16"
+        - name: VLLM_BLOCK_SIZE
+          value: "32"
+        securityContext:
+          capabilities:
+            add: ["IPC_LOCK"]
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "4000m"
+            nvidia.com/gpu: "1"
+          limits:
+            memory: "96Gi"
+            nvidia.com/gpu: "1"
+        volumeMounts:
+        - name: models
+          mountPath: /models
+        - name: shm
+          mountPath: /dev/shm
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 300
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          timeoutSeconds: 5
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 60
+      volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 16Gi
+      - name: download-script
+        configMap:
+          name: vllm-download-script
+  volumeClaimTemplates:
+  - metadata:
+      name: models
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 200Gi
+---
+# Headless service for StatefulSet pod discovery (vllm-0, vllm-1)
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-headless
+  namespace: ai
+spec:
+  clusterIP: None
+  selector:
+    app: vllm
+  ports:
+  - name: http
+    port: 8000
+    targetPort: http
+---
+# Cluster-internal Service — round-robins across both replicas
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm
+  namespace: ai
+  labels:
+    app: vllm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8000
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: vllm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-download-script
+  namespace: ai
+data:
+  download.py: |
+    import glob
+    import os
+    from huggingface_hub import snapshot_download
+
+    token = os.environ.get('HUGGING_FACE_HUB_TOKEN')
+    models = [
+        ('AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS', '/models/aeon-ultimate-xs'),
+        ('z-lab/Qwen3.6-27B-DFlash', '/models/aeon-ultimate-dflash'),
+    ]
+    for repo, path in models:
+        # Verify both config.json AND at least one .safetensors weight file exist.
+        # The previous check (config.json only) missed partial downloads where
+        # the small files landed but the weights got interrupted, causing vLLM
+        # to fail later with "Cannot find any model weights".
+        has_config = os.path.exists(os.path.join(path, 'config.json'))
+        has_weights = bool(glob.glob(os.path.join(path, '*.safetensors')))
+        if not (has_config and has_weights):
+            print(f'Downloading {repo} (config={has_config}, weights={has_weights})...', flush=True)
+            snapshot_download(repo_id=repo, local_dir=path, token=token, max_workers=4)
+            print(f'Done: {repo}', flush=True)
+        else:
+            print(f'Already cached: {repo}', flush=True)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-ts
+  namespace: ai
+  annotations:
+    tailscale.com/hostname: "${LOCATION}-vllm"
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:singh360,tag:k8s,tag:${LOCATION}"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: dsv4
+    role: head

--- a/kubernetes/apps/stpetersburg/ai/ai.yaml
+++ b/kubernetes/apps/stpetersburg/ai/ai.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ai-inference
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/ai/ai/inference
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  dependsOn:
+    - name: envoy-gateway-system-install
+  wait: false
+  interval: 1m
+  retryInterval: 1m
+  timeout: 1m

--- a/kubernetes/apps/stpetersburg/ai/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/ai/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ai.yaml

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - ./dragonfly-operator-system
   - ./gvisor
   - ./kube-system
+  - ./ai


### PR DESCRIPTION
## Summary

- verbatim copy of `clusters/talos-stpetersburg/apps/ai/inference` to `kubernetes/apps/base/ai/ai/inference`
- pointer file `kubernetes/apps/stpetersburg/ai/ai.yaml` with `spec.path` changed to new tree; CR name `ai-inference` unchanged
- ai namespace is inside inference/namespace.yaml (prune: disabled); no separate namespace.yaml needed at location level
- `chat-input.json` is not part of the Kustomization CR path and is not moved (cluster-specific data file)
- old parent: `cluster-apps` (stpetersburg)
- byte-identical flate check: ai-inference ✓ (1083 lines)
- make test ×3: all passed
- GPU pod hard gate: dsv4-head and dsv4-worker start time 2026-06-10T20:11:23Z — will verify unchanged after merge

Part of #1553 Batch E.