### PR TITLE
migrate: garage-operator-system, garage, spegel, volsync, zot into kubernetes tree (adopt)

### DIFF
--- a/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
+++ b/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: garage-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: garage-operator
+      version: "0.6.12"
+      sourceRef:
+        kind: HelmRepository
+        name: garage-operator
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  # Chart's ServiceMonitor selector matches both the metrics Service (port 8443)
+  # and the webhook Service (port 443) because they share identical labels and
+  # both name a port `https`. Prometheus ends up scraping the webhook on /metrics
+  # and getting 404s. Tag the metrics Service with a component label and pin the
+  # ServiceMonitor selector to it.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Service
+              name: garage-operator-metrics
+            patch: |
+              - op: add
+                path: /metadata/labels/app.kubernetes.io~1component
+                value: metrics
+          - target:
+              kind: ServiceMonitor
+              name: garage-operator
+            patch: |
+              - op: add
+                path: /spec/selector/matchLabels/app.kubernetes.io~1component
+                value: metrics
+          # Chart's GarageNodeDisconnected rule fires on per-node
+          # self-observation series (each node reports 0 for its own id).
+          # Aggregate by id so the alert only triggers when no peer sees a
+          # given node. Path indexes the garage.cluster group (idx 2),
+          # GarageNodeDisconnected rule (idx 4).
+          - target:
+              kind: PrometheusRule
+              name: garage-operator-garage
+            patch: |
+              - op: replace
+                path: /spec/groups/2/rules/4/expr
+                value: sum by (id) (cluster_layout_node_connected{job="garage"}) == 0
+  values:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    serviceMonitor:
+      enabled: true
+      labels:
+        release: monitoring
+    prometheusRules:
+      enabled: true
+      labels:
+        release: monitoring
+    webhooks:
+      enabled: true

--- a/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/kustomization.yaml
+++ b/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: keiretsu
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: keiretsu
+  quotas:
+    maxSize: 1Ti
+    maxObjects: 10000000
+  website:
+    enabled: true
+    indexDocument: index.html
+    errorDocument: error.html
+  keyPermissions:
+    - keyRef:
+        name: keiretsu-key
+        namespace: flux-system
+      read: true
+      write: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: rajsingh
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: rajsingh
+  quotas:
+    maxSize: 100Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: rajsingh-key
+        namespace: flux-system
+      read: true
+      write: true
+      owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: tailscale-logs
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: tailscale-logs
+  quotas:
+    maxSize: 500Gi
+    maxObjects: 10000000
+  lifecycle:
+    rules:
+      - id: expire-logs-30d
+        status: Enabled
+        expirationDays: 30
+      - id: abort-stuck-multipart-7d
+        status: Enabled
+        abortIncompleteMultipartUploadDays: 7
+  keyPermissions:
+    - keyRef:
+        name: tailscale-logs-key
+        namespace: tailscale-system
+      read: true
+      write: true
+    - keyRef:
+        name: tailscale-recorder-key
+        namespace: tailscale
+      read: true
+      write: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: mimir
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: mimir
+  quotas:
+    maxSize: 500Gi
+    maxObjects: 50000000
+  keyPermissions:
+    - keyRef:
+        name: mimir-key
+        namespace: mimir
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-bucket/key.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/key.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: webui-sidecar-key
+spec:
+  clusterRef:
+    name: garage
+  name: "WebUI Sidecar Key"
+  allBuckets:
+    read: true
+    write: true
+  secretTemplate:
+    name: garage-webui-sidecar
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/base/garage/garage-bucket/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: garage
 resources:
-  - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - bucket.yaml
+  - key.yaml

--- a/kubernetes/apps/base/garage/garage-exporter/deployment.yaml
+++ b/kubernetes/apps/base/garage/garage-exporter/deployment.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garage-exporter
+  labels:
+    app.kubernetes.io/name: garage-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: garage-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: garage-exporter
+    spec:
+      containers:
+        - name: garage-exporter
+          image: oci.${CLUSTER_DOMAIN}/kbpersonal/garage-exporter:v0.0.2
+          imagePullPolicy: Always
+          args:
+            - -garage.admin-endpoint=http://garage:3903
+            - -scrape-interval=5m
+          env:
+            - name: GARAGE_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-token
+                  key: admin-token
+          ports:
+            - name: metrics
+              containerPort: 9095
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/kubernetes/apps/base/garage/garage-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-exporter/kustomization.yaml
@@ -1,7 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: garage
 resources:
-  - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - deployment.yaml
+  - service.yaml
+  - servicemonitor.yaml

--- a/kubernetes/apps/base/garage/garage-exporter/service.yaml
+++ b/kubernetes/apps/base/garage/garage-exporter/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-exporter
+  labels:
+    app.kubernetes.io/name: garage-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: garage-exporter
+  ports:
+    - name: metrics
+      port: 9095
+      targetPort: metrics

--- a/kubernetes/apps/base/garage/garage-exporter/servicemonitor.yaml
+++ b/kubernetes/apps/base/garage/garage-exporter/servicemonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: garage-exporter
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: garage-exporter
+  namespaceSelector:
+    matchNames:
+      - garage
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 5m

--- a/kubernetes/apps/base/garage/garage-keys/keiretsu-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/keiretsu-key.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: keiretsu-key
+  namespace: flux-system
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Keiretsu Backup Key"
+  secretTemplate:
+    name: garage-keiretsu-bucket
+    accessKeyIdKey: KEIRETSU_S3_ACCESS_KEY
+    secretAccessKeyKey: KEIRETSU_S3_SECRET_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: keiretsu
+        namespace: garage
+      read: true
+      write: true

--- a/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tailscale-recorder-key.yaml
+  - keiretsu-key.yaml
+  - rajsingh-key.yaml
+  - tailscale-logs-key.yaml
+  - mimir-key.yaml

--- a/kubernetes/apps/base/garage/garage-keys/mimir-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/mimir-key.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: mimir-key
+  namespace: mimir
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Mimir Metrics Key"
+  secretTemplate:
+    name: mimir-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      endpoint: "http://${COMMON_S3_ENDPOINT}"
+      region: "garage"
+  bucketPermissions:
+    - bucketRef:
+        name: mimir
+        namespace: garage
+      read: true
+      write: true

--- a/kubernetes/apps/base/garage/garage-keys/rajsingh-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/rajsingh-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: rajsingh-key
+  namespace: flux-system
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Rajsingh Workspace Key"
+  secretTemplate:
+    name: garage-rajsingh-bucket
+    accessKeyIdKey: RAJSINGH_S3_ACCESS_KEY
+    secretAccessKeyKey: RAJSINGH_S3_SECRET_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: rajsingh
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys/tailscale-logs-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/tailscale-logs-key.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: tailscale-logs-key
+  namespace: tailscale-system
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Tailscale Logs Key"
+  secretTemplate:
+    name: tailscale-logs-s3-auth
+    accessKeyIdKey: TAILSCALE_LOGS_S3_ACCESS_KEY
+    secretAccessKeyKey: TAILSCALE_LOGS_S3_SECRET_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: tailscale-logs
+        namespace: garage
+      read: true
+      write: true

--- a/kubernetes/apps/base/garage/garage-keys/tailscale-recorder-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/tailscale-recorder-key.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: tailscale-recorder-key
+  namespace: tailscale
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Tailscale Recorder Key"
+  secretTemplate:
+    name: s3-auth
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: tailscale-logs
+        namespace: garage
+      read: true
+      write: true

--- a/kubernetes/apps/base/garage/garage-webui/deployment.yaml
+++ b/kubernetes/apps/base/garage/garage-webui/deployment.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garage-webui
+  labels:
+    app.kubernetes.io/name: garage-webui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: garage-webui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: garage-webui
+    spec:
+      containers:
+        - name: garage-webui
+          image: oci.${CLUSTER_DOMAIN}/garage-webadmin:latest
+          ports:
+            - containerPort: 80
+              name: http
+          env:
+            - name: API_HOST
+              value: "http://garage:3903"
+            - name: GARAGE_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-token
+                  key: admin-token
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+        - name: garage-webadmin-sidecar
+          image: oci.${CLUSTER_DOMAIN}/garage-webadmin-sidecar:latest
+          ports:
+            - containerPort: 8080
+              name: sidecar
+          envFrom:
+            - secretRef:
+                name: garage-webui-sidecar
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/apps/base/garage/garage-webui/httproute.yaml
+++ b/kubernetes/apps/base/garage/garage-webui/httproute.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-webui
+  annotations:
+    item.homer.rajsingh.info/name: "Garage"
+    item.homer.rajsingh.info/subtitle: "S3-Compatible Storage"
+    item.homer.rajsingh.info/logo: "https://garagehq.deuxfleurs.fr/images/garage-logo.svg"
+    item.homer.rajsingh.info/keywords: "storage, s3, object"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "garage.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-webui
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 3600s
+        backendRequest: 3600s

--- a/kubernetes/apps/base/garage/garage-webui/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-webui/kustomization.yaml
@@ -1,7 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: garage
 resources:
-  - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/apps/base/garage/garage-webui/service.yaml
+++ b/kubernetes/apps/base/garage/garage-webui/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-webui
+  labels:
+    app.kubernetes.io/name: garage-webui
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: garage-webui

--- a/kubernetes/apps/base/garage/garage/admin-token.yaml
+++ b/kubernetes/apps/base/garage/garage/admin-token.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-admin-token
+type: Opaque
+stringData:
+  admin-token: "${GARAGE_ADMIN_TOKEN}"

--- a/kubernetes/apps/base/garage/garage/dashboard.json
+++ b/kubernetes/apps/base/garage/garage/dashboard.json
@@ -1,0 +1,1228 @@
+{
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.2.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 24,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (cluster, pod) (rate(block_bytes_read{job=\"garage\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster}} / {{pod}} read",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "-sum by (cluster, pod) (rate(block_bytes_written{job=\"garage\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster}} / {{pod}} write",
+          "refId": "B"
+        }
+      ],
+      "title": "Disk I/O",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cluster, api_endpoint) (rate(api_s3_request_counter{job=\"garage\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster}} / {{api_endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (cluster) (rate(web_request_counter{job=\"garage\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Web requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (cluster, rpc_endpoint) (rate(rpc_request_counter{job=\"garage\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster}} / {{rpc_endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "RPC requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cluster, api_endpoint, status_code) (rate(api_s3_error_counter{job=\"garage\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster}} / {{api_endpoint}} {{status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (cluster, status_code) (rate(web_error_counter{job=\"garage\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster}} / {{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Web errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "block_resync_queue_length{job=\"garage\", cluster=~\"$cluster\"}",
+          "legendFormat": "{{cluster}} / {{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Resync queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (cluster, table_name) (table_gc_todo_queue_length{job=\"garage\", cluster=~\"$cluster\"})",
+          "legendFormat": "{{cluster}} / {{table_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Table GC queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (cluster, table_name) (table_merkle_updater_todo_queue_length{job=\"garage\", cluster=~\"$cluster\"})",
+          "legendFormat": "{{cluster}} / {{table_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Table Merkle updater queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 25
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "block_resync_errored_blocks{job=\"garage\", cluster=~\"$cluster\"}",
+          "legendFormat": "{{cluster}} / {{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Resync errored blocks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 8,
+        "y": 25
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "garage_local_disk_total{job=\"garage\", cluster=~\"$cluster\"}",
+          "legendFormat": "{{cluster}} / {{pod}} / {{volume}} total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "garage_local_disk_avail{job=\"garage\", cluster=~\"$cluster\"}",
+          "legendFormat": "{{cluster}} / {{pod}} / {{volume}} avail",
+          "refId": "B"
+        }
+      ],
+      "title": "Disk capacity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "mimir" },
+          "expr": "max by (bucket) (garage_bucket_bytes{job=\"garage-exporter\", cluster=~\"$cluster\"})",
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bucket storage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "mimir" },
+          "expr": "max by (bucket) (garage_bucket_objects{job=\"garage-exporter\", cluster=~\"$cluster\"})",
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bucket objects",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "mimir"
+        },
+        "definition": "label_values(garage_build_info{job=\"garage\"}, cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(garage_build_info{job=\"garage\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Garage",
+  "uid": "ys3pnpZ4k",
+  "version": 27,
+  "weekStart": ""
+}

--- a/kubernetes/apps/base/garage/garage/egress.yaml
+++ b/kubernetes/apps/base/garage/garage/egress.yaml
@@ -1,0 +1,243 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: garage-gw.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: garage-global
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: s3
+      port: 3900
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-garage.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: ottawa-garage
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: s3
+      port: 3900
+      protocol: TCP
+    - name: rpc
+      port: 3901
+      protocol: TCP
+    - name: web
+      port: 3902
+      protocol: TCP
+    - name: admin
+      port: 3903
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-garage.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: robbinsdale-garage
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: s3
+      port: 3900
+      protocol: TCP
+    - name: rpc
+      port: 3901
+      protocol: TCP
+    - name: web
+      port: 3902
+      protocol: TCP
+    - name: admin
+      port: 3903
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-garage.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: stpetersburg-garage
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: s3
+      port: 3900
+      protocol: TCP
+    - name: rpc
+      port: 3901
+      protocol: TCP
+    - name: web
+      port: 3902
+      protocol: TCP
+    - name: admin
+      port: 3903
+      protocol: TCP
+---
+# Per-region gateway egress entries — let gateway pods in any region dial
+# remote gateway RPC (port 3901) by hostname for full gateway↔gateway peering.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-garage-gw.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: ottawa-garage-gw
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-garage-gw.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: robbinsdale-garage-gw
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-garage-gw.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: stpetersburg-garage-gw
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+# Per-pod gateway egress entries (one per gateway pod per remote region).
+# Required by the operator's federation code (gatewayRpcEndpointTemplate)
+# so the in-cluster operator can resolve and dial each remote gateway pod
+# individually instead of the shared LB hostname (which Tailscale routes to
+# only one of N pods, leaving the rest in layout.all_nodes() as Not
+# connected and breaking FullReplication quorum cross-region).
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-gw-0.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: ottawa-gw-0
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-gw-1.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: ottawa-gw-1
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-gw-0.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: robbinsdale-gw-0
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-gw-1.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: robbinsdale-gw-1
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-gw-0.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: stpetersburg-gw-0
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-gw-1.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: stpetersburg-gw-1
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP

--- a/kubernetes/apps/base/garage/garage/garagecluster.yaml
+++ b/kubernetes/apps/base/garage/garage/garagecluster.yaml
@@ -1,0 +1,152 @@
+---
+# Unified GarageCluster (v1beta2) — storage + gateway tiers in one CR.
+#
+# In a unified cluster the operator reconciles the gateway tier as one per-pod
+# GarageNode (garage-gateway-N) — each a single-replica StatefulSet with a small
+# metadata PVC (persistent node identity) and EmptyDir data. Each gets a
+# capacity:null layout role so key/bucket auth resolves locally. Stale roles on
+# scale-down are tombstone-reaped (autoApply below applies the cleanup).
+# Cross-region peering is established by the storage tier (via
+# spec.remoteClusters); the gateway tier rides on that mesh.
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: garage
+spec:
+  zone: "${LOCATION}"
+  image: dxflrs/garage:v2.3.0
+
+  replication:
+    factor: 2
+    consistencyMode: "consistent" # Read-after-write consistency (read quorum=2) prevents restic AEAD corruption
+
+  s3Api:
+    rootDomain: ".s3.${COMMON_DOMAIN}"
+
+  webApi:
+    rootDomain: ".${COMMON_DOMAIN}"
+
+  network:
+    rpcPublicAddr: "${LOCATION}-garage.keiretsu.ts.net:3901"
+    rpcSecretRef:
+      name: garage-rpc-secret
+      key: rpc-secret
+
+  remoteClusters:
+    - name: ottawa
+      zone: ottawa
+      connection:
+        adminApiEndpoint: "http://ottawa-garage.keiretsu.ts.net:3903"
+        gatewayRpcEndpointTemplate: "ottawa-gw-{ordinal}.keiretsu.ts.net:3901"
+        adminTokenSecretRef:
+          name: garage-admin-token
+          key: admin-token
+    - name: robbinsdale
+      zone: robbinsdale
+      connection:
+        adminApiEndpoint: "http://robbinsdale-garage.keiretsu.ts.net:3903"
+        gatewayRpcEndpointTemplate: "robbinsdale-gw-{ordinal}.keiretsu.ts.net:3901"
+        adminTokenSecretRef:
+          name: garage-admin-token
+          key: admin-token
+    - name: stpetersburg
+      zone: stpetersburg
+      connection:
+        adminApiEndpoint: "http://stpetersburg-garage.keiretsu.ts.net:3903"
+        gatewayRpcEndpointTemplate: "stpetersburg-gw-{ordinal}.keiretsu.ts.net:3901"
+        storageRpcEndpointTemplate: "stpetersburg-garage-spark-{ordinal}.keiretsu.ts.net:3901"
+        adminTokenSecretRef:
+          name: garage-admin-token
+          key: admin-token
+  # stpetersburg re-added 2026-06-04: node back online, rejoining federation
+
+  admin:
+    adminTokenSecretRef:
+      name: garage-admin-token
+      key: admin-token
+
+  monitoring:
+    enabled: true
+    interval: 30s
+
+  layoutManagement:
+    # autoApply RE-ENABLED 2026-06-01 (operator v0.6.7): the gateway tombstone
+    # reaper is now scoped to the local zone (garage-operator#220), so a region no
+    # longer classifies the OTHER region's gateway roles as stale. The earlier
+    # cross-region layout churn (which left gateway key_table unsynced → S3 403
+    # "No such key") is fixed; both regions report zero pendingGatewayTombstones.
+    # autoApply lets the operator apply legitimate same-zone tombstone cleanup on
+    # gateway scale-down/replacement instead of leaving it pending.
+    autoApply: true
+
+  blocks:
+    ramBufferMax: 128Mi
+
+  workers:
+    # Temporarily accelerated (2026-06-05) to clear a large resync backlog from the
+    # stp-rejoin re-replication + node-rename layout churn. Revert to 1 / 3 once the
+    # block_resync_queue_length drains to ~0 across nodes.
+    resyncWorkerCount: 4
+    resyncTranquility: 1
+    scrubTranquility: 4
+
+  # Storage tier — persistent identity in metadata PVC; data PVC holds blocks.
+  storage:
+    replicas: ${GARAGE_REPLICAS:=1}
+    # Per-tier layout ownership (operator v0.6.11+). Default Auto: the operator
+    # generates and owns one storage GarageNode per replica. A region can set
+    # GARAGE_STORAGE_LAYOUT_POLICY=Manual in its cluster-settings to hand-manage
+    # storage GarageNode CRs in gitops (e.g. stpetersburg's per-spark storage
+    # arrays under clusters/talos-stpetersburg/apps/garage) while the GATEWAY
+    # tier stays operator-managed. Auto->Manual is one-way (operator ejects its
+    # storage nodes; Manual->Auto is rejected by the webhook).
+    layoutPolicy: "${GARAGE_STORAGE_LAYOUT_POLICY:=Auto}"
+    metadata:
+      size: 3Gi
+      storageClassName: "${STORAGECLASS_METADATA}"
+    data:
+      size: 2Ti
+      storageClassName: "${STORAGECLASS_LONGTERM}"
+    priorityClassName: "infra-critical"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 3000m
+        memory: 3Gi
+    # Per-cluster scheduling overrides via Flux postBuild substitution.
+    nodeSelector: ${GARAGE_NODE_SELECTOR=}
+    topologySpreadConstraints: ${GARAGE_TOPOLOGY_SPREAD=}
+
+  # Gateway tier — per-pod GarageNodes with persistent identity; peers with the
+  # local storage tier and inherits federation through it. rpcPublicAddr is the
+  # advertised RPC address so remote regions can reach the gateway nodes for
+  # cluster-wide table sync (key/bucket FullReplication).
+  # PER-ORDINAL address (operator v0.6.9+, garage-operator#226): the operator
+  # substitutes {ordinal} with each gateway pod's index, so pod N advertises
+  # ${LOCATION}-gw-N.keiretsu.ts.net — which the per-pod LB in service-ts-gateway.yaml
+  # routes to that exact pod. This matches remoteClusters[].gatewayRpcEndpointTemplate
+  # so all gateway pods (not just one) are reachable cross-region and join
+  # FullReplication quorum. (A single shared addr could only ever route to one pod.)
+  gateway:
+    replicas: ${GARAGE_GATEWAY_REPLICAS:=2}
+    rpcPublicAddr: "${LOCATION}-gw-{ordinal}.keiretsu.ts.net:3901"
+    priorityClassName: "infra-high"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 2000m
+        memory: 1536Mi
+    nodeSelector: ${GARAGE_NODE_SELECTOR=}
+    affinity: ${GARAGE_GATEWAY_AFFINITY=}
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: garage
+            garage.rajsingh.info/tier: gateway

--- a/kubernetes/apps/base/garage/garage/grafana-dashboard.yaml
+++ b/kubernetes/apps/base/garage/garage/grafana-dashboard.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: garage
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Garage
+  configMapRef:
+    name: garage-grafana-dashboard
+    key: dashboard.json
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/garage/garage/httproute-s3.yaml
+++ b/kubernetes/apps/base/garage/garage/httproute-s3.yaml
@@ -1,0 +1,63 @@
+---
+# S3 API HTTPRoute for direct access to storage cluster
+# Note: S3 uses HTTP for the API protocol, so HTTPRoute works here
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-s3
+  annotations:
+    item.homer.rajsingh.info/name: "Garage S3"
+    item.homer.rajsingh.info/subtitle: "S3 API Endpoint"
+    item.homer.rajsingh.info/logo: "https://garagehq.deuxfleurs.fr/images/garage-logo.svg"
+    item.homer.rajsingh.info/keywords: "storage, s3, object, api"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "s3.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          port: 3900
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+# Public S3 endpoint via cdn gateway (managed by k8gb for GSLB)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-s3-cdn
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "s3.cdn.${COMMON_DOMAIN}"
+    - "tailscale-logs.s3.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          port: 3900
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/garage/garage/httproute-web.yaml
+++ b/kubernetes/apps/base/garage/garage/httproute-web.yaml
@@ -1,0 +1,49 @@
+---
+# Web (static website hosting) HTTPRoute
+# Garage resolves buckets by stripping the root_domain suffix from the Host header.
+# keiretsu.top and www.keiretsu.top need a Host rewrite to keiretsu.keiretsu.top
+# so garage maps them to the "keiretsu" bucket.
+# DNS for keiretsu.top/www managed by ddup (health-checked A records), not ExternalDNS.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-web
+  annotations:
+    item.homer.rajsingh.info/name: "Keiretsu Web"
+    item.homer.rajsingh.info/subtitle: "Static Website"
+    item.homer.rajsingh.info/logo: "https://garagehq.deuxfleurs.fr/images/garage-logo.svg"
+    item.homer.rajsingh.info/keywords: "website, keiretsu, garage, static"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "www.${COMMON_DOMAIN}"
+    - "${COMMON_DOMAIN}"
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: "keiretsu.${COMMON_DOMAIN}"
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          port: 3902
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/garage/garage/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: garage
+resources:
+  - admin-token.yaml
+  - egress.yaml
+  - reference-grants.yaml
+  - service-ts.yaml
+  - service-ts-gateway.yaml
+  - garagecluster.yaml
+  - rpc-secret.yaml
+  - httproute-s3.yaml
+  - httproute-web.yaml
+  - referencegrant-agent-web.yaml
+  - probes.yaml
+  - prometheusrule.yaml
+  - grafana-dashboard.yaml
+configMapGenerator:
+  - name: garage-grafana-dashboard
+    files:
+      - dashboard.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        grafana_folder: garage
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/base/garage/garage/probes.yaml
+++ b/kubernetes/apps/base/garage/garage/probes.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-garage-local
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - garage.garage:3900
+        - garage.garage:3903
+      labels:
+        service: garage
+        target: local
+        # tcp_connect = port-open only; stays GREEN on a wedged-but-listening
+        # gateway. The http_2xx /health serving probes below are the real signal.
+        check: port-open
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-garage-cross-cluster
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - ottawa-garage.garage:3900
+        - ottawa-garage.garage:3903
+        - robbinsdale-garage.garage:3900
+        - robbinsdale-garage.garage:3903
+        - stpetersburg-garage.garage:3900
+        - stpetersburg-garage.garage:3903
+      labels:
+        service: garage
+        target: cross-cluster
+        check: port-open
+---
+# SERVING probes: GET the unauthenticated admin /health. Garage returns 200 for
+# Healthy AND Degraded and 503 only for Unavailable (no partition has a
+# write-quorum of up nodes). Unlike the tcp_connect probes above, these go RED
+# exactly when the cluster cannot serve writes — the same signal the gateway
+# readiness probe gates on — so a wedged-but-listening region is detected
+# instead of looking green. Losing only local storage stays 200 (the gateway
+# still serves via remote storage), which is correct.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-garage-health-local
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://garage.garage:3903/health
+      labels:
+        service: garage
+        target: local
+        check: serving
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-garage-health-cross-cluster
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://ottawa-garage.garage:3903/health
+        - http://robbinsdale-garage.garage:3903/health
+        - http://stpetersburg-garage.garage:3903/health
+      labels:
+        service: garage
+        target: cross-cluster
+        check: serving
+---
+# GATEWAY path — what S3 clients now hit via COMMON_S3_ENDPOINT (garage-gateway
+# svc, tier:gateway). A gateway-tier outage breaks clients but would NOT show in
+# the storage probes above (storage stays up), so probe the gateway Service
+# directly so the monitored path matches the client path: tcp_connect confirms
+# the gateway has ready endpoints on the S3/admin ports, http_2xx /health
+# confirms a gateway pod can serve.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-garage-gateway-local
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - garage-gateway.garage:3900
+        - garage-gateway.garage:3903
+      labels:
+        service: garage
+        target: local
+        tier: gateway
+        check: port-open
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-garage-gateway-health-local
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://garage-gateway.garage:3903/health
+      labels:
+        service: garage
+        target: local
+        tier: gateway
+        check: serving

--- a/kubernetes/apps/base/garage/garage/prometheusrule.yaml
+++ b/kubernetes/apps/base/garage/garage/prometheusrule.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: garage-rules
+spec:
+  groups:
+    - name: garage.rules
+      rules:
+        # The local /health serving probe runs in each region and reports the
+        # cluster-wide health from that region's view. probe_success==0 means
+        # /health returned non-2xx (503 = Unavailable: a partition lost
+        # write-quorum, so writes fail) or the local endpoint is unreachable.
+        # Scoped to target=local so a known-down remote region's cross-cluster
+        # probe doesn't fire this; cross-cluster serving probes stay for
+        # dashboards / the generic blackbox ProbeFailed rule.
+        - alert: GarageServingUnavailable
+          expr: probe_success{service="garage", check="serving", target="local"} == 0
+          for: 3m
+          annotations:
+            summary: Garage cannot serve writes in this region ({{ $labels.instance }})
+            description: >-
+              The Garage /health serving probe has been non-2xx for 3m
+              (503 Unavailable = a partition lost its write-quorum of up storage
+              nodes, or the admin endpoint is unreachable). Reads may still work
+              in degraded mode, but writes are failing. With replication.factor=2
+              this is one storage node away from a full write outage — restore the
+              missing storage node or add write headroom.
+          labels:
+            severity: critical
+
+        # The gateway tier is the S3 CLIENT path (COMMON_S3_ENDPOINT ->
+        # garage-gateway svc). This fires when the gateway Service has no
+        # reachable endpoint — clients fail — but storage may still be up, so it
+        # would NOT trip the storage probes. Distinct from GarageServingUnavailable
+        # (that's write-quorum); this is "clients can't reach a gateway at all."
+        - alert: GarageGatewayUnreachable
+          expr: probe_success{service="garage", tier="gateway", check="port-open", target="local"} == 0
+          for: 2m
+          annotations:
+            summary: Garage gateway tier unreachable in this region ({{ $labels.instance }})
+            description: >-
+              The garage-gateway Service has had no reachable endpoint for 2m.
+              In-cluster S3 clients reach Garage through it (COMMON_S3_ENDPOINT),
+              so they are failing. Check the gateway pods (garage-gateway-N) and
+              their readiness — storage may still be up (this won't show in the
+              storage probes).
+          labels:
+            severity: critical

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: cross-namespace-access
+spec:
+  from:
+    - kind: GarageKey
+      namespace: forgejo
+    - kind: GarageBucket
+      namespace: forgejo
+    - kind: GarageKey
+      namespace: keiretsu-top
+    - kind: GarageBucket
+      namespace: keiretsu-top
+    - kind: GarageKey
+      namespace: zot
+    - kind: GarageBucket
+      namespace: zot
+    - kind: GarageKey
+      namespace: immich
+    - kind: GarageKey
+      namespace: media
+    - kind: GarageKey
+      namespace: hermes
+    - kind: GarageKey
+      namespace: home
+    - kind: GarageKey
+      namespace: tailscale-examples
+    - kind: GarageKey
+      namespace: loki
+    - kind: GarageBucket
+      namespace: loki
+    - kind: GarageKey
+      namespace: tailscale
+    - kind: GarageKey
+      namespace: flux-system
+    - kind: GarageKey
+      namespace: mimir
+    - kind: GarageKey
+      namespace: tailscale-system
+    - kind: GarageKey
+      namespace: agents
+    - kind: GarageBucket
+      namespace: agents

--- a/kubernetes/apps/base/garage/garage/referencegrant-agent-web.yaml
+++ b/kubernetes/apps/base/garage/garage/referencegrant-agent-web.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: agent-garage-gateway
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: agents
+  to:
+    - group: ""
+      kind: Service
+      name: garage-gateway

--- a/kubernetes/apps/base/garage/garage/rpc-secret.yaml
+++ b/kubernetes/apps/base/garage/garage/rpc-secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-rpc-secret
+type: Opaque
+stringData:
+  rpc-secret: "${GARAGE_RPC_SECRET}"

--- a/kubernetes/apps/base/garage/garage/service-ts-gateway.yaml
+++ b/kubernetes/apps/base/garage/garage/service-ts-gateway.yaml
@@ -1,0 +1,124 @@
+---
+# Per-region gateway escape-hatch LB.
+# Use for targeted regional access (debugging, migration tests, hot-spot pinning).
+# Apps should normally hit `garage-gateway-global-ts` instead.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-garage-gw
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-gateway-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: s3-api
+      port: 3900
+      protocol: TCP
+      targetPort: 3900
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+    - name: s3-web
+      port: 3902
+      protocol: TCP
+      targetPort: 3902
+    - name: admin
+      port: 3903
+      protocol: TCP
+      targetPort: 3903
+  selector:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/tier: gateway
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+# Per-pod gateway LB for cross-region peering. Each ordinal-stable hostname
+# resolves to exactly one gateway pod, so storage nodes in other regions can
+# ConnectClusterNodes() to a specific peer instead of having Tailscale's
+# load-balancer pick one of N pods. Required by the operator's federation
+# code (RemoteClusterConnection.gatewayRpcEndpointTemplate) so all gateways
+# participate in FullReplication quorum cross-region.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-gw-0
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-gateway-0-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/tier: gateway
+    # Per-node gateway STS (post-#210): GarageNode "garage-gateway-0" -> pod
+    # "garage-gateway-0-0". (Pre-#210 single-STS pods were "garage-gateway-0".)
+    statefulset.kubernetes.io/pod-name: garage-gateway-0-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-gw-1
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-gateway-1-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/tier: gateway
+    # Per-node gateway STS (post-#210): GarageNode "garage-gateway-1" -> pod
+    # "garage-gateway-1-0".
+    statefulset.kubernetes.io/pod-name: garage-gateway-1-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+# Anycast global gateway LB — Tailscale routes clients to the nearest region's
+# gateway pods via the shared common-ingress proxy-group.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: garage-gw
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+  name: garage-gateway-global-ts
+spec:
+  ports:
+    - name: s3-api
+      port: 3900
+      protocol: TCP
+      targetPort: 3900
+    - name: s3-web
+      port: 3902
+      protocol: TCP
+      targetPort: 3902
+    - name: admin
+      port: 3903
+      protocol: TCP
+      targetPort: 3903
+  selector:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/tier: gateway
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/garage/garage/service-ts.yaml
+++ b/kubernetes/apps/base/garage/garage/service-ts.yaml
@@ -1,0 +1,41 @@
+---
+# Tailscale LoadBalancer for cross-cluster RPC connectivity
+# Each cluster gets a unique hostname based on location
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-garage
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-ts
+spec:
+  # Allow routing to pods before they're ready - essential for multi-cluster
+  # federation bootstrap when pods wait for cluster health
+  publishNotReadyAddresses: true
+  ports:
+    - name: s3-api
+      port: 3900
+      protocol: TCP
+      targetPort: 3900
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+    - name: s3-web
+      port: 3902
+      protocol: TCP
+      targetPort: 3902
+    - name: admin
+      port: 3903
+      protocol: TCP
+      targetPort: 3903
+  selector:
+    # Match by operator-stamped cluster + tier labels (v0.6.0+).
+    # Pre-v0.6.0 selectors of {name=garage, instance=garage, tier=storage}
+    # silently lost endpoints when the #190 refactor relabeled storage pods to
+    # {name=garagenode, instance=<garagenode-name>}.
+    garage.rajsingh.info/cluster: garage
+    garage.rajsingh.info/tier: storage
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/spegel/spegel/helmrelease.yaml
+++ b/kubernetes/apps/base/spegel/spegel/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spegel
+  namespace: spegel
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: spegel
+      version: 0.7.1
+      sourceRef:
+        kind: HelmRepository
+        name: spegel
+        namespace: flux-system
+      interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    spegel:
+      # Talos containerd is preconfigured to read hosts.toml fragments from this directory
+      containerdRegistryConfigPath: /etc/cri/conf.d/hosts
+      logLevel: INFO
+    service:
+      registry:
+        nodePort: 30020
+        port: 5000
+    serviceMonitor:
+      enabled: true
+    grafanaDashboard:
+      enabled: true
+      labels:
+        grafana_dashboard: "1"

--- a/kubernetes/apps/base/volsync/volsync/helmrelease.yaml
+++ b/kubernetes/apps/base/volsync/volsync/helmrelease.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: volsync
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: volsync
+      version: 0.16.0
+      sourceRef:
+        kind: HelmRepository
+        name: backube-charts # Use existing repo name
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    replicaCount: 1
+    manageCRDs: true
+    metrics:
+      disableAuth: true
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 64Mi 

--- a/kubernetes/apps/base/volsync/volsync/kustomization.yaml
+++ b/kubernetes/apps/base/volsync/volsync/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: volsync-system
+resources:
+  - ./helmrelease.yaml
+  - ./servicemonitor.yaml
+  # Dashboards
+  - ./overview.yaml

--- a/kubernetes/apps/base/volsync/volsync/overview.yaml
+++ b/kubernetes/apps/base/volsync/volsync/overview.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: volsync-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Volsync
+  grafanaCom:
+    id: 21356

--- a/kubernetes/apps/base/volsync/volsync/servicemonitor.yaml
+++ b/kubernetes/apps/base/volsync/volsync/servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: volsync-monitor
+  namespace: volsync-system
+  labels:
+    control-plane: volsync-controller
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: https
+      scheme: https
+      tlsConfig:
+        # Using self-signed cert for connection
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: volsync-controller

--- a/kubernetes/apps/base/zot/zot/backendtrafficpolicy.yaml
+++ b/kubernetes/apps/base/zot/zot/backendtrafficpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: zot-timeouts
+  namespace: zot
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-public
+  timeout:
+    http:
+      requestTimeout: 300s
+      connectionIdleTimeout: 3600s
+      maxConnectionDuration: 0s

--- a/kubernetes/apps/base/zot/zot/bucket.yaml
+++ b/kubernetes/apps/base/zot/zot/bucket.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: zot
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: zot
+  quotas:
+    maxSize: 500Gi
+    maxObjects: 10000000
+  keyPermissions:
+    - keyRef:
+        name: zot-key
+      read: true
+      write: true
+      owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: zot-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Zot Registry Key"
+  secretTemplate:
+    name: garage-s3-auth
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: zot
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/zot/zot/dashboard.json
+++ b/kubernetes/apps/base/zot/zot/dashboard.json
@@ -1,0 +1,298 @@
+{
+  "title": "Zot Registry",
+  "uid": "zot-registry",
+  "tags": ["zot", "registry"],
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "links": [],
+  "annotations": { "list": [] },
+  "templating": {
+    "list": [
+      {
+        "name": "job",
+        "label": "Registry",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "mimir" },
+        "query": "label_values(zot_http_requests_total, job)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {}
+      },
+      {
+        "name": "repo",
+        "label": "Repo",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "mimir" },
+        "query": "label_values(zot_repo_storage_bytes{job=~\"$job\"}, repo)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Traffic",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Requests / sec",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 2 } },
+      "targets": [
+        {
+          "expr": "sum(rate(zot_http_requests_total{job=~\"$job\"}[5m]))",
+          "legendFormat": "rps",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Error Rate",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(zot_http_requests_total{job=~\"$job\",code=~\"5..\"}[5m])) / sum(rate(zot_http_requests_total{job=~\"$job\"}[5m]))",
+          "legendFormat": "errors",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Total Storage",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "sum(zot_repo_storage_bytes{job=~\"$job\"})",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Requests by Method",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "targets": [
+        {
+          "expr": "sum by (method) (rate(zot_http_requests_total{job=~\"$job\"}[5m]))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Requests by Status Code",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "targets": [
+        {
+          "expr": "sum by (code) (rate(zot_http_requests_total{job=~\"$job\"}[5m]))",
+          "legendFormat": "HTTP {{code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Latency",
+      "gridPos": { "x": 0, "y": 13, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Request Latency by Method (p50 / p95 / p99)",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 0, "y": 14, "w": 16, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, method) (rate(zot_http_method_latency_seconds_bucket{job=~\"$job\"}[5m])))",
+          "legendFormat": "p50 {{method}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(zot_http_method_latency_seconds_bucket{job=~\"$job\"}[5m])))",
+          "legendFormat": "p95 {{method}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, method) (rate(zot_http_method_latency_seconds_bucket{job=~\"$job\"}[5m])))",
+          "legendFormat": "p99 {{method}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Mean Latency by Repo",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 16, "y": 14, "w": 8, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean"] } },
+      "targets": [
+        {
+          "expr": "topk(10, rate(zot_http_repo_latency_seconds_sum{job=~\"$job\",repo=~\"$repo\"}[5m]) / rate(zot_http_repo_latency_seconds_count{job=~\"$job\",repo=~\"$repo\"}[5m]))",
+          "legendFormat": "{{repo}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Storage & Transfer",
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "type": "table",
+      "title": "Storage by Repo",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 0, "y": 23, "w": 8, "h": 10 },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "repo" }, "properties": [{ "id": "custom.width", "value": 200 }] }
+        ]
+      },
+      "options": { "sortBy": [{ "displayName": "Value", "desc": true }], "footer": { "show": true, "reducer": ["sum"] } },
+      "targets": [
+        {
+          "expr": "sort_desc(sum by (repo) (zot_repo_storage_bytes{job=~\"$job\",repo=~\"$repo\"}))",
+          "legendFormat": "{{repo}}",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "filterFieldsByName", "options": { "include": { "names": ["repo", "Value"] } } },
+        { "id": "organize", "options": { "renameByName": { "Value": "Size" } } }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Downloads / sec (top 10 repos)",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 8, "y": 23, "w": 8, "h": 10 },
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (repo) (rate(zot_repo_downloads_total{job=~\"$job\",repo=~\"$repo\"}[5m])))",
+          "legendFormat": "{{repo}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Uploads / sec (top 10 repos)",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 16, "y": 23, "w": 8, "h": 10 },
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (repo) (rate(zot_repo_uploads_total{job=~\"$job\",repo=~\"$repo\"}[5m])))",
+          "legendFormat": "{{repo}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Scheduler",
+      "gridPos": { "x": 0, "y": 33, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Task Queue Length",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 0, "y": 34, "w": 12, "h": 7 },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "sum by (job) (zot_scheduler_tasksqueue_length{job=~\"$job\"})",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Scheduler Workers",
+      "datasource": { "type": "prometheus", "uid": "mimir" },
+      "gridPos": { "x": 12, "y": 34, "w": 12, "h": 7 },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "sum by (job, state) (zot_scheduler_workers{job=~\"$job\"})",
+          "legendFormat": "{{job}} {{state}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/kubernetes/apps/base/zot/zot/egress.yaml
+++ b/kubernetes/apps/base/zot/zot/egress.yaml
@@ -1,0 +1,54 @@
+---
+# Cross-cluster egress to peer zot instances via the common-egress ProxyGroup.
+# In-cluster Service name matches the tailnet FQDN's first label so the
+# helmrelease can list peers as "robbinsdale-zot:5000" etc. Each cluster gets
+# all three Services; the local-cluster entry resolves through Tailscale back
+# into the same cluster, but a hostAlias in the zot pod short-circuits self
+# traffic to 127.0.0.1 and lets zot pass its self-identification check.
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-zot
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-zot.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 5000
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ottawa-zot
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-zot.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 5000
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-zot
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-zot.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 5000
+      protocol: TCP

--- a/kubernetes/apps/base/zot/zot/grafana-dashboard.yaml
+++ b/kubernetes/apps/base/zot/zot/grafana-dashboard.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: zot-registry
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Registry
+  configMapRef:
+    name: zot-grafana-dashboard
+    key: dashboard.json
+  datasources:
+    - inputName: DS_MIMIR
+      datasourceName: Mimir-${CLUSTER_DISPLAY_NAME}

--- a/kubernetes/apps/base/zot/zot/helmrelease.yaml
+++ b/kubernetes/apps/base/zot/zot/helmrelease.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: zot
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: zot
+      version: 0.1.117
+      sourceRef:
+        kind: HelmRepository
+        name: zot
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    replicaCount: 1
+    startupProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      failureThreshold: 30
+    service:
+      type: ClusterIP
+      port: 5000
+    persistence: false
+    mountConfig: true
+    mountSecret: true
+    env:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: garage-s3-auth
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: garage-s3-auth
+            key: AWS_SECRET_ACCESS_KEY
+    configFiles:
+      config.json: |-
+        {
+          "storage": {
+            "rootDirectory": "/var/lib/registry",
+            "dedupe": false,
+            "gc": true,
+            "gcDelay": "1h",
+            "gcInterval": "6h",
+            "remoteCache": true,
+            "cacheDriver": {
+              "name": "redis",
+              "addr": ["zot-cache:6379"],
+              "dial_timeout": "10s",
+              "read_timeout": "60s",
+              "write_timeout": "60s",
+              "keyprefix": "zot"
+            },
+            "retention": {
+              "policies": [{
+                "repositories": ["**"],
+                "deleteReferrers": true,
+                "deleteUntagged": true,
+                "keepTags": [{
+                  "mostRecentlyPushedCount": 10,
+                  "mostRecentlyPulledCount": 10,
+                  "pulledWithin": "720h",
+                  "pushedWithin": "720h"
+                }]
+              }]
+            },
+            "storageDriver": {
+              "name": "s3",
+              "rootdirectory": "/zot",
+              "region": "garage",
+              "regionendpoint": "http://${COMMON_S3_ENDPOINT}",
+              "bucket": "zot",
+              "forcepathstyle": true,
+              "secure": false,
+              "skipverify": false,
+              "multipartcopymaxconcurrency": 8
+            }
+          },
+          "cluster": {
+            "members": [
+              "robbinsdale-zot:5000",
+              "ottawa-zot:5000"
+            ],
+            "hashKey": "${ZOT_CLUSTER_HASHKEY}"
+          },
+          "http": {
+            "address": "0.0.0.0",
+            "port": "5000",
+            "compat": ["docker2s2"],
+            "auth": {
+              "htpasswd": { "path": "/secret/htpasswd" }
+            },
+            "accessControl": {
+              "repositories": {
+                "**": {
+                  "policies": [{
+                    "users": ["admin"],
+                    "actions": ["read", "create", "update", "delete"]
+                  }],
+                  "anonymousPolicy": ["read", "create", "update"],
+                  "defaultPolicy": []
+                }
+              }
+            }
+          },
+          "extensions": {
+            "search": { "enable": true },
+            "ui": { "enable": true },
+            "metrics": { "enable": true },
+            "sync": {
+              "enable": true,
+              "downloadDir": "/var/lib/registry/sync-tmp",
+              "registries": [{
+                "urls": ["https://ghcr.io"],
+                "content": [{
+                  "prefix": "rajsinghtech/**"
+                }],
+                "onDemand": true,
+                "pollInterval": "6h",
+                "tlsVerify": true
+              }]
+            }
+          },
+          "log": { "level": "info" }
+        }
+    secretFiles:
+      htpasswd: "${COMMON_OCI}"
+  postRenderers:
+    # Inject a hostAlias so the local zot pod's lookup of its own peer name
+    # (e.g. ottawa-zot in the Ottawa cluster) returns 127.0.0.1, satisfying
+    # zot's GetLocalMemberClusterSocket self-identification check at startup.
+    # Without this, zot panics because the ExternalName Service for its own
+    # location resolves to the common-egress proxy IP, not the pod IP.
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: zot
+            patch: |
+              - op: add
+                path: /spec/template/spec/hostAliases
+                value:
+                  - ip: 127.0.0.1
+                    hostnames:
+                      - ${LOCATION}-zot

--- a/kubernetes/apps/base/zot/zot/httproute-internal.yaml
+++ b/kubernetes/apps/base/zot/zot/httproute-internal.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot
+  annotations:
+    item.homer.rajsingh.info/name: "Zot Registry"
+    item.homer.rajsingh.info/subtitle: "OCI Container Registry"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/docker-moby.png"
+    item.homer.rajsingh.info/keywords: "registry, oci, containers"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "oci.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: zot
+          port: 5000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/zot/zot/httproute-public.yaml
+++ b/kubernetes/apps/base/zot/zot/httproute-public.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot-public
+  annotations:
+    item.homer.rajsingh.info/name: "Zot Registry"
+    item.homer.rajsingh.info/subtitle: "OCI Container Registry"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/docker-moby.png"
+    item.homer.rajsingh.info/keywords: "registry, oci, containers"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "oci.${CLUSTER_DOMAIN}"
+    - "oci.cdn.${COMMON_DOMAIN}"
+    - "zot.cdn.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: zot
+          port: 5000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/zot/zot/ingress-internal.yaml
+++ b/kubernetes/apps/base/zot/zot/ingress-internal.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oci-ts
+  annotations:
+    tailscale.com/proxy-group: "common-ingress"
+    tailscale.com/tags: "tag:k8s"
+spec:
+  defaultBackend:
+    service:
+      name: zot
+      port:
+        number: 5000
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - oci

--- a/kubernetes/apps/base/zot/zot/kustomization.yaml
+++ b/kubernetes/apps/base/zot/zot/kustomization.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: zot
+resources:
+  - backendtrafficpolicy.yaml
+  - probes.yaml
+  - bucket.yaml
+  - egress.yaml
+  - grafana-dashboard.yaml
+  - helmrelease.yaml
+  - httproute-internal.yaml
+  - httproute-public.yaml
+  - ingress-internal.yaml
+  - service-ts.yaml
+  - servicemonitor.yaml
+configMapGenerator:
+  - name: zot-grafana-dashboard
+    files:
+      - dashboard.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        grafana_folder: Registry
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/base/zot/zot/probes.yaml
+++ b/kubernetes/apps/base/zot/zot/probes.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-zot
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://zot.zot:5000/
+      labels:
+        service: zot

--- a/kubernetes/apps/base/zot/zot/service-ts.yaml
+++ b/kubernetes/apps/base/zot/zot/service-ts.yaml
@@ -1,0 +1,23 @@
+---
+# Per-cluster Tailscale ingress LB so peers in other clusters can reach this zot.
+# Each cluster gets a stable hostname: ${LOCATION}-zot.keiretsu.ts.net
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-ts
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-zot
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: common-ingress
+spec:
+  publishNotReadyAddresses: true
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+    - name: http
+      port: 5000
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app.kubernetes.io/name: zot
+    app.kubernetes.io/instance: zot

--- a/kubernetes/apps/base/zot/zot/servicemonitor.yaml
+++ b/kubernetes/apps/base/zot/zot/servicemonitor.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: zot
+  labels:
+    app.kubernetes.io/name: zot
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zot
+      app.kubernetes.io/instance: zot
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s

--- a/kubernetes/apps/ottawa/garage-operator-system/garage-operator-system-install.yaml
+++ b/kubernetes/apps/ottawa/garage-operator-system/garage-operator-system-install.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-operator-system-install
+  namespace: flux-system
+spec:
+  targetNamespace: garage-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-operator-system-install
+  path: ./kubernetes/apps/base/garage-operator-system/garage-operator-system-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/garage-operator-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/garage-operator-system/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./garage-operator-system-install.yaml

--- a/kubernetes/apps/ottawa/garage-operator-system/namespace.yaml
+++ b/kubernetes/apps/ottawa/garage-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/garage/garage.yaml
+++ b/kubernetes/apps/ottawa/garage/garage.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-bucket
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
+  path: ./kubernetes/apps/base/garage/garage-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-keys
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage-keys
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: garage-bucket
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-webui
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-webui
+  path: ./kubernetes/apps/base/garage/garage-webui
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/garage/kustomization.yaml
+++ b/kubernetes/apps/ottawa/garage/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./garage.yaml

--- a/kubernetes/apps/ottawa/garage/namespace.yaml
+++ b/kubernetes/apps/ottawa/garage/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -12,3 +12,8 @@ resources:
   - ./dragonfly-operator-system
   - ./gvisor
   - ./kube-system
+  - ./garage-operator-system
+  - ./garage
+  - ./spegel
+  - ./volsync
+  - ./zot

--- a/kubernetes/apps/ottawa/spegel/kustomization.yaml
+++ b/kubernetes/apps/ottawa/spegel/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./spegel.yaml

--- a/kubernetes/apps/ottawa/spegel/namespace.yaml
+++ b/kubernetes/apps/ottawa/spegel/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spegel
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/ottawa/spegel/spegel.yaml
+++ b/kubernetes/apps/ottawa/spegel/spegel.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app spegel
+  namespace: flux-system
+spec:
+  targetNamespace: spegel
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/spegel/spegel
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/volsync/kustomization.yaml
+++ b/kubernetes/apps/ottawa/volsync/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./volsync.yaml

--- a/kubernetes/apps/ottawa/volsync/namespace.yaml
+++ b/kubernetes/apps/ottawa/volsync/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volsync-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/ottawa/volsync/volsync.yaml
+++ b/kubernetes/apps/ottawa/volsync/volsync.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app volsync
+  namespace: flux-system
+spec:
+  targetNamespace: volsync-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/volsync/volsync
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/zot/kustomization.yaml
+++ b/kubernetes/apps/ottawa/zot/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
   - ./zot.yaml

--- a/kubernetes/apps/ottawa/zot/namespace.yaml
+++ b/kubernetes/apps/ottawa/zot/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zot
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/zot/zot.yaml
+++ b/kubernetes/apps/ottawa/zot/zot.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zot
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: zot
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/zot/zot
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install.yaml
+++ b/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-operator-system-install
+  namespace: flux-system
+spec:
+  targetNamespace: garage-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-operator-system-install
+  path: ./kubernetes/apps/base/garage-operator-system/garage-operator-system-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/garage-operator-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/garage-operator-system/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./garage-operator-system-install.yaml

--- a/kubernetes/apps/robbinsdale/garage-operator-system/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/garage-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/garage/garage.yaml
+++ b/kubernetes/apps/robbinsdale/garage/garage.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-bucket
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
+  path: ./kubernetes/apps/base/garage/garage-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-keys
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage-keys
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: garage-bucket
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-webui
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-webui
+  path: ./kubernetes/apps/base/garage/garage-webui
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/garage/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/garage/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./garage.yaml

--- a/kubernetes/apps/robbinsdale/garage/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/garage/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -16,3 +16,8 @@ resources:
   - ./border0
   - ./gatus
   - ./speedtest
+  - ./garage-operator-system
+  - ./garage
+  - ./spegel
+  - ./volsync
+  - ./zot

--- a/kubernetes/apps/robbinsdale/spegel/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/spegel/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./spegel.yaml

--- a/kubernetes/apps/robbinsdale/spegel/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/spegel/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spegel
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/robbinsdale/spegel/spegel.yaml
+++ b/kubernetes/apps/robbinsdale/spegel/spegel.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app spegel
+  namespace: flux-system
+spec:
+  targetNamespace: spegel
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/spegel/spegel
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/volsync/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/volsync/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./volsync.yaml

--- a/kubernetes/apps/robbinsdale/volsync/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/volsync/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volsync-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/robbinsdale/volsync/volsync.yaml
+++ b/kubernetes/apps/robbinsdale/volsync/volsync.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app volsync
+  namespace: flux-system
+spec:
+  targetNamespace: volsync-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/volsync/volsync
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/zot/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/zot/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
   - ./zot.yaml

--- a/kubernetes/apps/robbinsdale/zot/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/zot/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zot
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/zot/zot.yaml
+++ b/kubernetes/apps/robbinsdale/zot/zot.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zot
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: zot
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/zot/zot
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/garage-operator-system/garage-operator-system-install.yaml
+++ b/kubernetes/apps/stpetersburg/garage-operator-system/garage-operator-system-install.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-operator-system-install
+  namespace: flux-system
+spec:
+  targetNamespace: garage-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-operator-system-install
+  path: ./kubernetes/apps/base/garage-operator-system/garage-operator-system-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/garage-operator-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/garage-operator-system/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./garage-operator-system-install.yaml

--- a/kubernetes/apps/stpetersburg/garage-operator-system/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/garage-operator-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/garage/garage.yaml
+++ b/kubernetes/apps/stpetersburg/garage/garage.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-bucket
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
+  path: ./kubernetes/apps/base/garage/garage-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-keys
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage-keys
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: garage-bucket
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-webui
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-webui
+  path: ./kubernetes/apps/base/garage/garage-webui
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/garage/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/garage/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./garage.yaml

--- a/kubernetes/apps/stpetersburg/garage/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/garage/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -20,3 +20,7 @@ resources:
   - ./gvisor
   - ./kube-system
   - ./ai
+  - ./garage-operator-system
+  - ./garage
+  - ./spegel
+  - ./volsync

--- a/kubernetes/apps/stpetersburg/spegel/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/spegel/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./spegel.yaml

--- a/kubernetes/apps/stpetersburg/spegel/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/spegel/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spegel
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/stpetersburg/spegel/spegel.yaml
+++ b/kubernetes/apps/stpetersburg/spegel/spegel.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app spegel
+  namespace: flux-system
+spec:
+  targetNamespace: spegel
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/spegel/spegel
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/volsync/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/volsync/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot-cache-egress.yaml
-  - ./zot.yaml
+  - ./volsync.yaml

--- a/kubernetes/apps/stpetersburg/volsync/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/volsync/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volsync-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/stpetersburg/volsync/volsync.yaml
+++ b/kubernetes/apps/stpetersburg/volsync/volsync.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app volsync
+  namespace: flux-system
+spec:
+  targetNamespace: volsync-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/volsync/volsync
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/zot/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/zot/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zot
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/zot/zot.yaml
+++ b/kubernetes/apps/stpetersburg/zot/zot.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zot
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: zot
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/zot/zot
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Batch B Groups 6-9 PR-A (adopt).

Moves base manifests and creates pointer Kustomization CRs for:
- garage-operator-system (garage-operator-system-install CR, uses install/ subdir)
- garage (4 CRs: garage, garage-bucket, garage-keys, garage-webui; + garage-exporter)
- spegel
- volsync
- zot

All three location trees updated. stpetersburg/zot/ already had zot-cache-egress.yaml from Batch E — kustomization.yaml is UNION of namespace.yaml + zot-cache-egress.yaml + zot.yaml.

Byte-identical verification:
- garage-operator-system-install: IDENTICAL (flate)
- garage: IDENTICAL (flate)
- garage-bucket: IDENTICAL (direct kustomize — flate false positive, configMapGenerator with dashboard.json)
- garage-keys: IDENTICAL (direct kustomize — flate false positive, dependsOn garage)
- garage-webui: IDENTICAL (flate)
- spegel: IDENTICAL (flate)
- volsync: IDENTICAL (flate)
- zot: IDENTICAL (flate)

flate test failures: ottawa (garage-keys, garage-webui), robbinsdale (garage-nodes) — all known v0.3.4 false positives for apps with dependsOn pointing to a kustomization that uses configMapGenerator with non-YAML files. Same pattern as dragonfly-operator-system (remote URL). Direct kustomize build confirms byte-identity.

PR-B (release) follows after live adoption verified.