### PR TITLE
migrate(batch-d/g4): adopt garage-config, garage-nodes, immich, tailgate-operator, zot-cache-egress (robbinsdale)

### DIFF
--- a/kubernetes/apps/base/garage/garage-config-robbinsdale/config/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-config-robbinsdale/config/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: garage
 resources:
-  - ./namespace.yaml
-  - ./zot.yaml
-  - ./zot-cache-egress.yaml
+  - pv.yaml

--- a/kubernetes/apps/base/garage/garage-config-robbinsdale/config/pv.yaml
+++ b/kubernetes/apps/base/garage/garage-config-robbinsdale/config/pv.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: smb.csi.k8s.io
+  name: data-garage-0
+spec:
+  capacity:
+    storage: 2Ti
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+    - vers=3.0
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: smb-server.default.svc.cluster.local/k8s_shortsnap/garage
+    volumeAttributes:
+      source: //192.168.50.115/k8s_shortsnap/garage
+    nodeStageSecretRef:
+      name: csi-smbcreds
+      namespace: kube-system

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: garage
+resources:
+  - robbinsdale-garage-smb.yaml
+  - robbinsdale-garage-localpath-tank.yaml
+  - robbinsdale-garage-localpath-titan.yaml
+  - robbinsdale-garage-localpath-stone.yaml
+  - service-ts-storage.yaml

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-localpath-stone.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-localpath-stone.yaml
@@ -1,0 +1,23 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: robbinsdale-garage-localpath-stone
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 700Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "robbinsdale-garage-stone.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 700Gi
+      storageClassName: local-path
+  nodeSelector:
+    kubernetes.io/hostname: stone

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-localpath-tank.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-localpath-tank.yaml
@@ -1,0 +1,33 @@
+---
+# Tank storage node — 2nd storage node for Robbinsdale, adding LocalPath
+# capacity alongside the existing SMB-backed node.
+#
+# Backend = local-path, pinned to tank (control-plane node, ~1Ti SSD).
+# Dynamic PVCs via spec.storage.{metadata,data}.size — no existingClaim needed
+# since this is a fresh node with no prior data to migrate.
+#
+# NodeSelector pins directly to tank. The operator auto-discovers the nodeId
+# from the pod's Garage admin API on first connect, so nodeId is omitted here.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: robbinsdale-garage-localpath-tank
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 700Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "robbinsdale-garage-tank.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 700Gi
+      storageClassName: local-path
+  nodeSelector:
+    kubernetes.io/hostname: tank

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-localpath-titan.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-localpath-titan.yaml
@@ -1,0 +1,23 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: robbinsdale-garage-localpath-titan
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 700Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "robbinsdale-garage-titan.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 700Gi
+      storageClassName: local-path
+  nodeSelector:
+    kubernetes.io/hostname: titan

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-smb.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-smb.yaml
@@ -1,0 +1,34 @@
+---
+# Robbinsdale storage node, hand-managed (Manual). Data lives on SMB; metadata
+# on ceph RBD (ceph-block-replicated-nvme) — so the pod is schedulable and
+# node-fault-tolerant (no local-path node pin). Named by the data backend (smb).
+# Binds the existing PVCs via existingClaim so node_key identity (Garage NodeID
+# 62b5e2dd…) and all data are preserved.
+#
+# spec.tags keep the EXACT existing layout-role tags (including the legacy
+# pod-name tag). To move the data array off SMB later, add a new node
+# (e.g. robbinsdale-garage-cephrbd), sync, then drain.
+#
+# History: migrated 2026-06-04 from operator-owned garage-storage-0 via
+# existingClaim; metadata then cold-copied from local-path -> ceph RBD
+# (node_key preserved byte-for-byte, layout unchanged) so the node is no longer
+# pinned to one host.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: robbinsdale-garage-smb
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: 62b5e2ddcba5261e9b6ce201039d93bc4411d53810869bcc55ab1f267e505bb4
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-0-0
+  storage:
+    metadata:
+      existingClaim: metadata-garage-ceph
+    data:
+      existingClaim: data-garage-0

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/service-ts-storage.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: robbinsdale-garage-tank
+    tailscale.com/tags: "tag:k8s,tag:robbinsdale"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-tank-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: robbinsdale-garage-localpath-tank-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: robbinsdale-garage-titan
+    tailscale.com/tags: "tag:k8s,tag:robbinsdale"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-titan-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: robbinsdale-garage-localpath-titan-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: robbinsdale-garage-stone
+    tailscale.com/tags: "tag:k8s,tag:robbinsdale"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-stone-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: robbinsdale-garage-localpath-stone-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: immich
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: immich
+      version: 0.12.0
+      sourceRef:
+        kind: HelmRepository
+        name: immich
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: false
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              repository: ghcr.io/immich-app/immich-server
+              tag: v2.7.5
+            env:
+              DB_DATABASE_NAME: immich
+              DB_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-postgres-app
+                    key: username
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-postgres-app
+                    key: password
+              DB_HOSTNAME: immich-postgres-rw
+              REDIS_HOSTNAME: dragonfly-immich
+              REDIS_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-dragonfly-secret
+                    key: password
+    immich:
+      metrics:
+        enabled: true
+      persistence:
+        library:
+          existingClaim: immich-library
+    valkey:
+      enabled: false
+    server:
+      persistence:
+        pics:
+          enabled: true
+          existingClaim: immich-pics
+          globalMounts:
+            - path: /pics
+              readOnly: true
+      controllers:
+        main:
+          strategy: Recreate
+          containers:
+            main:
+              env:
+                DB_DATABASE_NAME: immich
+                DB_USERNAME:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: username
+                DB_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: password
+                DB_HOSTNAME: immich-postgres-rw
+                REDIS_HOSTNAME: dragonfly-immich
+                REDIS_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-dragonfly-secret
+                      key: password
+    machine-learning:
+      controllers:
+        main:
+          containers:
+            main:
+              env:
+                DB_DATABASE_NAME: immich
+                DB_USERNAME:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: username
+                DB_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: password
+                DB_HOSTNAME: immich-postgres-rw
+                REDIS_HOSTNAME: dragonfly-immich
+                REDIS_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-dragonfly-secret
+                      key: password

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/httproute.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/httproute.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: immich-server
+  namespace: immich
+  annotations:
+    item.homer.rajsingh.info/name: "Immich"
+    item.homer.rajsingh.info/subtitle: "Photo & Video Management"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/immich.svg"
+    item.homer.rajsingh.info/keywords: "photos, videos, backup"
+
+    service.homer.rajsingh.info/name: "Media"
+    service.homer.rajsingh.info/icon: "fas fa-tv"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "immich.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: immich-server
+          port: 2283
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: immich
+resources:
+  - helmrelease.yaml
+  - probes.yaml
+  - pvc-library.yaml
+  - httproute.yaml
+  - secret.sops.yaml
+  - pg.yaml
+  - redis.yaml
+  - s3-backup.yaml

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/pg.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/pg.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-postgres
+  namespace: immich
+spec:
+  instances: 2
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:15-0.3.0
+  postgresql:
+    shared_preload_libraries:
+      - "vchord.so"
+  bootstrap:
+    initdb:
+      database: immich
+      owner: immich
+      dataChecksums: true
+      postInitApplicationSQL:
+        - ALTER USER immich WITH SUPERUSER;
+        - CREATE EXTENSION IF NOT EXISTS vchord CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "cube";
+        - CREATE EXTENSION IF NOT EXISTS "earthdistance";
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 16Gi
+  # Enable Barman Cloud plugin for S3 backups
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: immich-s3-store
+        serverName: immich-postgres
+
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: keiretsu
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: immich-s3-store
+          serverName: immich-postgres
+---
+# S3 backup schedule using Barman Cloud
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: immich-postgres-s3
+  namespace: immich
+spec:
+  schedule: "0 0 23 * * *"  # Daily at 11 PM
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: immich-postgres

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/probes.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/probes.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-immich
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://immich-server.immich:2283/api/server/ping
+      labels:
+        service: immich

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/pvc-library.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/pvc-library.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: smb.csi.k8s.io
+  name: immich-library
+spec:
+  capacity:
+    storage: 4Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: smb-server.default.svc.cluster.local/k8s_shortsnap/immich
+    volumeAttributes:
+      source: //192.168.50.115/k8s_shortsnap/immich
+    nodeStageSecretRef:
+      name: csi-smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-library
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 4Ti
+  volumeName: immich-library
+  storageClassName: smb
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: smb.csi.k8s.io
+  name: immich-pics
+spec:
+  capacity:
+    storage: 4Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: smb-server.default.svc.cluster.local/k8s_shortsnap/pics
+    volumeAttributes:
+      source: //192.168.50.115/k8s_shortsnap/pics
+    nodeStageSecretRef:
+      name: csi-smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-pics
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 4Ti
+  volumeName: immich-pics
+  storageClassName: smb

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/redis.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/redis.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly-immich
+spec:
+  replicas: 2
+  args:
+    - --maxmemory=1000M
+    - --proactor_threads=2
+    - --default_lua_flags=allow-undeclared-keys
+  authentication:
+    passwordFromSecret:
+      name: immich-dragonfly-secret
+      key: password
+  resources:
+    requests:
+      cpu: 25m
+      memory: 1000Mi
+    limits:
+      memory: 1500Mi

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/s3-backup.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/s3-backup.yaml
@@ -1,0 +1,33 @@
+# S3 credentials secret for Immich backups
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: immich-s3-backup
+  namespace: immich
+stringData:
+  AWS_ACCESS_KEY_ID: ${KEIRETSU_S3_ACCESS_KEY}
+  AWS_SECRET_ACCESS_KEY: ${KEIRETSU_S3_SECRET_KEY}
+---
+# ObjectStore for Barman Cloud backups
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: immich-s3-store
+  namespace: immich
+spec:
+  configuration:
+    destinationPath: s3://keiretsu/${LOCATION}/immich/postgres/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: immich-s3-backup
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: immich-s3-backup
+        key: AWS_SECRET_ACCESS_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/secret.sops.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/secret.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: immich-dragonfly-secret
+type: Opaque
+stringData:
+    password: ENC[AES256_GCM,data:eZCGQUd8EDG4E6DuvH0pN+/BjF2YsMeuL5yv5FDZqri9c8WTSWdiiKCUcAU=,iv:JH4PNft18KPC/pNhPjTVi1c4QlMvYh5oJw2TgQdKt1o=,tag:KMCVIB9ZReooP6En5jXpTA==,type:str]
+sops:
+    lastmodified: "2026-04-11T21:32:30Z"
+    mac: ENC[AES256_GCM,data:TFIrOfpytSzK6H2bkGlagLcobopkpHHxwcrVLmXol1HsrwK6b2gVCUGYvbP+LGb8Hra9gBQtZN8BFgKZBBbmQQAam5j8B5bPILTxYo2hGjPCXslpXMHL2zKpgfELuEEVYhOeV6Vw0U5f+oV7CoTF28LyyZ0dfDM4Ex9oxgwJA44=,iv:bB/65xxr3IeFiWFvP7C1z5HduCnZMwOnzA+ng/BHTDI=,tag:RedFU8JMsLQiztH3TtuB7Q==,type:str]
+    pgp:
+        - created_at: "2026-04-11T21:32:30Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveAQ//Vy4nCJqa+cSZnXdwaE3TRZpwGuIcpXNTNAlnk1wzpC8Q
+            BK96YugvKaL1Z9+SI+Fm4MBnQAiQXfvchVeqEUA1P/w/HllmDI8RdDd9YimT9/4h
+            Og5IXC3uUY2mzKilgF6/truVGPN6wK1kog2cTgkQThdlW9qklJvmYk0KQJM8foYm
+            zw3zYFjObE8bZ8osgf29Yx19c/W7t32OVb+Rbvg+aX7Qz2NYaqt2JNlZ0+IJMMwA
+            vWiW6POA0BZji90p9Dr5UqGxqIvlTniSSrpAribiot9E9/R1G0lczysgQeaQpqMQ
+            aU496zSvU6o+zl7D/os3dOkirXyHw6XtTCvIXFz7zGnuugiMYpBMA40KUTDuxC7z
+            O/9Fwd57mjZUwI5E9WGYRR+9qJEjsl6CN0EdbtkWhmn9p9DdVeLUNgInFYPj/TUS
+            D5QXPF/2yAwxZ9LJBH+yE24/WerREcWeApryZXsmlycG8q5JtXCqBb21zga00BV2
+            9TLvaRIpd1+VyDv33d10P3yayDIsDjq/DUFqTUQYakJKvvGlNbNPlsSccpTqvfl+
+            QKvt/xk0YZLF9Y+AVELdWZedl/lpyprqhLIjIRgHvnO6RZ9K9AM2rlio1yOW44Ye
+            JsjAkZhoGMErEOjfJkuLW96t1NG48wMXMvpUde3G6PxmUBgOuQglyHMk8EuddKvU
+            aAEJAhDEHtbGTA+Yj6go6wOzj8c6J3NhzEzBGmBQwIO3YJVj12PNXykhZYtYwRDN
+            t6zd60Zc/cSEy/rXFfHJnlmdkfLUk0raMCdcRP2K3ers5b0JSNxhsai03tWzJcYw
+            maCJKLURKX/z
+            =TcTO
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/helmrelease.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailgate-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: tailgate-operator
+      version: "0.0.4"
+      sourceRef:
+        kind: HelmRepository
+        name: tailgate-operator
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  values:
+    fullnameOverride: tailgate-operator
+    crds:
+      install: true
+      keep: true
+    tailnet:
+      # Reference secret.yaml (creds substituted from common-secrets) instead of templating one.
+      create: false
+      secretName: tailgate-tailnet-creds
+    agent:
+      enabled: true
+      # robbinsdale pod CIDR,service CIDR — kept on the primary CNI for exit-node
+      # members so kube-dns / the API server never blackhole through the tunnel.
+      clusterCIDRs: "10.1.0.0/16,10.0.0.0/16"
+      image:
+        tag: v0.0.4
+    operator:
+      image:
+        tag: v0.0.4
+    gateway:
+      image:
+        tag: v0.0.4

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/kustomization.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./zot.yaml
-  - ./zot-cache-egress.yaml
+  - secret.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/secret.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/secret.yaml
@@ -1,0 +1,15 @@
+---
+# Reuses the same Tailscale OAuth client the tailscale operator uses: TS_OAUTH_CLIENT_ID /
+# TS_OAUTH_CLIENT_SECRET come from common-secrets, substituted by Flux (the cluster-apps
+# patch injects postBuild.substituteFrom into every child Kustomization). No new client,
+# no per-app SOPS. tag:k8s-operator owns tag:k8s + tag:robbinsdale, so this client can mint
+# the gateway authkey. TS_TAILNET "-" = the client's default tailnet.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailgate-tailnet-creds
+type: Opaque
+stringData:
+  TS_TAILNET: "-"
+  TS_OAUTH_CLIENT_ID: ${TS_OAUTH_CLIENT_ID}
+  TS_OAUTH_CLIENT_SECRET: ${TS_OAUTH_CLIENT_SECRET}

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/egress/egressgroup.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/egress/egressgroup.yaml
@@ -1,0 +1,22 @@
+---
+# Canary group (cluster-scoped). The operator stands up one shared gateway tagged
+# tag:k8s + tag:robbinsdale (both owned by tag:k8s-operator in tailscale/policy.hujson).
+# Cross-site test: members reach the ottawa LAN (192.168.169.0/24) through the gateway —
+# policy grants tag:robbinsdale -> ipset:ottawa via tag:ottawa, and the ottawa subnet
+# router advertises 192.168.169.0/24 (autoApprover). Ping 192.168.169.1 (ottawa router)
+# from a selected pod to confirm the full path.
+apiVersion: tailscale.rajsingh.info/v1alpha1
+kind: EgressGroup
+metadata:
+  name: robbinsdale-egress
+spec:
+  selector:
+    podSelector:
+      matchLabels:
+        tailgate.rajsingh.info/egress: robbinsdale
+  tags:
+    - "tag:k8s"
+    - "tag:robbinsdale"
+  routes:
+    - 192.168.169.0/24    # ottawa LAN (advertised by tag:ottawa subnet router)
+  acceptRoutes: true      # gateway accepts the ottawa advertised route (default)

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/egress/kustomization.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/egress/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./zot.yaml
-  - ./zot-cache-egress.yaml
+  - egressgroup.yaml
+  - probe.yaml

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/egress/probe.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/egress/probe.yaml
@@ -1,0 +1,34 @@
+---
+# Connectivity probe for the canary: a busybox the EgressGroup selects (label
+# tailgate.rajsingh.info/egress=robbinsdale). Lives in default (NOT the gateway namespace —
+# the agent skips its own namespace). Verify the cross-site path with:
+#   kubectl exec deploy/tailgate-canary-probe -- ping -c3 192.168.169.1
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailgate-canary-probe
+  namespace: default
+  labels:
+    app.kubernetes.io/name: tailgate-canary-probe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailgate-canary-probe
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailgate-canary-probe
+        tailgate.rajsingh.info/egress: robbinsdale
+    spec:
+      containers:
+        - name: probe
+          image: busybox:1.38
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi

--- a/kubernetes/apps/robbinsdale/garage/garage.yaml
+++ b/kubernetes/apps/robbinsdale/garage/garage.yaml
@@ -83,3 +83,45 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-config
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage-config-robbinsdale/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-nodes
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/immich/immich.yaml
+++ b/kubernetes/apps/robbinsdale/immich/immich.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app immich
+  namespace: flux-system
+spec:
+  targetNamespace: immich
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-system
+    - name: dragonfly-operator-system
+    - name: volsync
+  path: ./kubernetes/apps/base/immich/immich-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/immich/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/immich/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot.yaml
-  - ./zot-cache-egress.yaml
+  - ./immich.yaml

--- a/kubernetes/apps/robbinsdale/immich/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/immich/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: immich
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -22,3 +22,5 @@ resources:
   - ./volsync
   - ./zot
   - ./agent-sandbox-system
+  - ./immich
+  - ./tailgate-operator-system

--- a/kubernetes/apps/robbinsdale/tailgate-operator-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/tailgate-operator-system/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./zot.yaml
-  - ./zot-cache-egress.yaml
+  - ./tailgate-operator.yaml

--- a/kubernetes/apps/robbinsdale/tailgate-operator-system/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/tailgate-operator-system/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailgate-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    # agent DaemonSet runs privileged + hostNetwork + hostPID
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/robbinsdale/tailgate-operator-system/tailgate-operator.yaml
+++ b/kubernetes/apps/robbinsdale/tailgate-operator-system/tailgate-operator.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailgate-operator
+  namespace: flux-system
+spec:
+  targetNamespace: tailgate-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tailgate-operator-egress
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: tailgate-operator
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: tailgate-operator-egress
+  path: ./kubernetes/apps/base/tailgate-operator-system/tailgate-operator/egress
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/zot/zot-cache-egress.yaml
+++ b/kubernetes/apps/robbinsdale/zot/zot-cache-egress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zot-cache-egress
+  namespace: flux-system
+spec:
+  targetNamespace: zot
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/zot/zot-cache-egress/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
PR-A adopt for Batch D Group 4. Verbatim copy of cluster-specific app dirs into kubernetes tree + pointer Kustomization CRs. CR names unchanged to preserve Flux adoption.

Apps:
- garage-config: cluster-specific PVs (`/data/tank/`, `/data/titan/`, `/data/stone/` paths). Base: `garage-config-robbinsdale`
- garage-nodes: cluster-specific GarageNode CRs (stone/tank/titan localpath + SMB). Base: `garage-nodes-robbinsdale`
- immich: cluster-specific (SMB PVC, different helmrelease values). Base: `immich-robbinsdale`
- tailgate-operator + tailgate-operator-egress: robbinsdale-only app (EgressGroup CRs). Base: `tailgate-operator-system/tailgate-operator`
- zot-cache-egress: uses shared `base/zot/zot-cache-egress/app` (byte-identical with stpetersburg, already in tree)

Note: flate test `all` shows pre-existing garage-* failures from the flate 0.3.4 sequential-state contamination bug (garage CR path check corruption). Each cluster passes individually. CI runs clusters in isolation and passes.

Follows PR-B to release old dirs after live ownership flip.