### PR TITLE
migrate(batch-c/g5): adopt forgejo, hermes, immich, kener into kubernetes tree (ottawa)

### DIFF
--- a/kubernetes/apps/base/forgejo/forgejo/app/bucket.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/bucket.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: forgejo
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: forgejo
+  quotas:
+    maxSize: 100Gi
+    maxObjects: 5000000
+  keyPermissions:
+    - keyRef:
+        name: forgejo-key
+      read: true
+      write: true
+      owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: forgejo-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Forgejo Key"
+  secretTemplate:
+    name: garage-s3-auth
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: forgejo
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/forgejo/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/helmrelease.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: forgejo
+      version: 17.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: forgejo
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    service:
+      http:
+        type: ClusterIP
+        port: 3000
+      ssh:
+        type: ClusterIP
+        port: 22
+    persistence:
+      enabled: true
+      storageClass: ${STORAGECLASS_DEFAULT}
+      size: 10Gi
+    gitea:
+      additionalConfigFromEnvs:
+        - name: FORGEJO__database__PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: forgejo-postgres-app
+              key: password
+        - name: FORGEJO__storage__MINIO_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: garage-s3-auth
+              key: AWS_ACCESS_KEY_ID
+        - name: FORGEJO__storage__MINIO_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: garage-s3-auth
+              key: AWS_SECRET_ACCESS_KEY
+      config:
+        server:
+          DOMAIN: forgejo.${COMMON_DOMAIN}
+          ROOT_URL: https://forgejo.${COMMON_DOMAIN}
+          SSH_DOMAIN: forgejo.${COMMON_DOMAIN}
+        database:
+          DB_TYPE: postgres
+          HOST: forgejo-postgres-rw:5432
+          NAME: forgejo
+          USER: forgejo
+          SSL_MODE: require
+        cache:
+          ADAPTER: memory
+        session:
+          PROVIDER: db
+        service:
+          DISABLE_REGISTRATION: "true"
+        storage:
+          STORAGE_TYPE: minio
+          MINIO_ENDPOINT: ${COMMON_S3_ENDPOINT}
+          MINIO_BUCKET: forgejo
+          MINIO_LOCATION: garage
+          MINIO_USE_SSL: "false"
+        security:
+          REVERSE_PROXY_TRUSTED_PROXIES: "127.0.0.0/8,::1/128,10.2.0.0/16,10.3.0.0/16"
+        actions:
+          ENABLED: "true"

--- a/kubernetes/apps/base/forgejo/forgejo/app/httproute.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/httproute.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: forgejo
+  annotations:
+    item.homer.rajsingh.info/name: "Forgejo"
+    item.homer.rajsingh.info/subtitle: "Git Forge"
+    item.homer.rajsingh.info/logo: "https://forgejo.org/favicon.svg"
+    item.homer.rajsingh.info/keywords: "git, forge, code, repository"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-code-branch"
+spec:
+  hostnames:
+    - forgejo.${CLUSTER_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  rules:
+    - backendRefs:
+        - name: forgejo-http
+          port: 3000
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/forgejo/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: forgejo
+resources:
+  - bucket.yaml
+  - pg.yaml
+  - helmrelease.yaml
+  - httproute.yaml
+  - tcproute.yaml
+  - referencegrant.yaml
+  - runner-config.yaml
+  - runner-secret.yaml
+  - runner.yaml

--- a/kubernetes/apps/base/forgejo/forgejo/app/pg.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/pg.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: forgejo-postgres
+spec:
+  inheritedMetadata:
+    labels:
+      app: forgejo-postgres
+  instances: 2
+  bootstrap:
+    initdb:
+      database: forgejo
+      owner: forgejo
+      dataChecksums: true
+  storage:
+    size: 10Gi
+    storageClass: ceph-block-replicated
+  monitoring:
+    enablePodMonitor: true

--- a/kubernetes/apps/base/forgejo/forgejo/app/referencegrant.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/referencegrant.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: forgejo-cdn
+  namespace: forgejo
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: keiretsu-top
+  to:
+    - group: ""
+      kind: Service
+      name: forgejo-http

--- a/kubernetes/apps/base/forgejo/forgejo/app/runner-config.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/runner-config.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forgejo-runner-config
+data:
+  config.yaml: |
+    log:
+      level: info
+    runner:
+      file: /data/.runner
+      capacity: 4
+      labels:
+        - "ubuntu-latest:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest"
+        - "ubuntu-22.04:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest"
+        - "ubuntu-20.04:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest"
+    cache:
+      enabled: true
+      dir: /data/cache
+    container:
+      network: bridge
+      privileged: true
+      docker_host: tcp://127.0.0.1:2375

--- a/kubernetes/apps/base/forgejo/forgejo/app/runner-secret.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/runner-secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: forgejo-runner-token
+type: Opaque
+stringData:
+  token: "${FORGEJO_RUNNER_TOKEN}"

--- a/kubernetes/apps/base/forgejo/forgejo/app/runner.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/runner.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: forgejo-runner
+spec:
+  replicas: 6
+  serviceName: forgejo-runner
+  selector:
+    matchLabels:
+      app: forgejo-runner
+  template:
+    metadata:
+      labels:
+        app: forgejo-runner
+    spec:
+      initContainers:
+        - name: chown-data
+          image: busybox:latest
+          command: [sh, -c, chown -R 1000:1000 /data]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+        - name: register
+          image: code.forgejo.org/forgejo/runner:12.10.2
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ ! -f /data/.runner ]; then
+                forgejo-runner register \
+                  --config /config/config.yaml \
+                  --instance http://forgejo-http:3000 \
+                  --token "$(cat /secrets/token)" \
+                  --name "$(hostname)" \
+                  --labels ubuntu-latest:docker://node:20-bookworm,ubuntu-22.04:docker://node:20-bookworm \
+                  --no-interactive
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: token
+              mountPath: /secrets
+            - name: config
+              mountPath: /config
+      containers:
+        - name: runner
+          image: code.forgejo.org/forgejo/runner:12.10.2
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until nc -z 127.0.0.1 2375 2>/dev/null; do
+                echo "waiting for docker..."; sleep 2
+              done
+              forgejo-runner daemon --config /config/config.yaml
+          env:
+            - name: DOCKER_HOST
+              value: tcp://127.0.0.1:2375
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config
+        - name: dind
+          image: docker:dind
+          securityContext:
+            privileged: true
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          volumeMounts:
+            - name: docker-storage
+              mountPath: /var/lib/docker
+      volumes:
+        - name: token
+          secret:
+            secretName: forgejo-runner-token
+        - name: config
+          configMap:
+            name: forgejo-runner-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: ${STORAGECLASS_DEFAULT}
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: docker-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: ${STORAGECLASS_DEFAULT}
+        resources:
+          requests:
+            storage: 10Gi

--- a/kubernetes/apps/base/forgejo/forgejo/app/tcproute.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/tcproute.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: forgejo-ssh
+spec:
+  parentRefs:
+    - name: public
+      namespace: home
+      sectionName: forgejo-ssh
+    - name: private
+      namespace: home
+      sectionName: forgejo-ssh
+    - name: ts
+      namespace: home
+      sectionName: forgejo-ssh
+  rules:
+    - backendRefs:
+        - name: forgejo-ssh
+          port: 22

--- a/kubernetes/apps/base/hermes/hermes/app/app.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/app.yaml
@@ -1,0 +1,161 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes
+spec:
+  # Scaled to 0: migrated to the templated agent `teaspoon` in ns `agents`
+  # (Discord bot + tag:k8s). Only one gateway may hold the Discord token at a
+  # time, so this old non-templated app is retired. Kept in git (not deleted)
+  # as a rollback anchor until teaspoon is confirmed stable.
+  replicas: 0
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hermes
+    spec:
+      initContainers:
+        - name: seed-aws-credentials
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /opt/data/.aws
+              umask 077
+              cat >/opt/data/.aws/credentials <<EOF
+              [default]
+              aws_access_key_id = $${AWS_ACCESS_KEY_ID}
+              aws_secret_access_key = $${AWS_SECRET_ACCESS_KEY}
+              EOF
+              cat >/opt/data/.aws/config <<EOF
+              [default]
+              region = $${AWS_REGION}
+              endpoint_url = $${AWS_ENDPOINT_URL}
+              s3 =
+                  endpoint_url = $${AWS_ENDPOINT_URL_S3}
+                  addressing_style = path
+              EOF
+          envFrom:
+            - secretRef:
+                name: hermes-s3
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      containers:
+        - name: hermes
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["gateway", "run"]
+          env:
+            - name: OPENAI_API_KEY
+              value: "unused"
+            - name: ANTHROPIC_API_KEY
+              value: "unused"
+            - name: GATEWAY_ALLOW_ALL_USERS
+              value: "true"
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: "0.0.0.0"
+            - name: API_SERVER_PORT
+              value: "8642"
+            - name: DISCORD_REQUIRE_MENTION
+              value: "false"
+            - name: DISCORD_AUTO_THREAD
+              value: "true"
+            - name: DISCORD_REACTIONS
+              value: "true"
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/data/.aws/credentials
+            - name: AWS_CONFIG_FILE
+              value: /opt/data/.aws/config
+            # v2026.5.29 introduced s6 supervision — dashboard runs in the same
+            # container as the gateway. HERMES_DASHBOARD=1 spawns it; TUI=1
+            # enables the embedded chat tab; HOST=0.0.0.0 exposes it.
+            # HERMES_DASHBOARD_INSECURE=1 skips the dashboard's OAuth gate;
+            # network access is already gated by the Tailscale `ts` gateway ACL.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_TUI
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          envFrom:
+            - secretRef:
+                name: hermes-secrets
+            - secretRef:
+                name: hermes-s3
+          ports:
+            - name: gateway
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 4Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-data
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes
+spec:
+  selector:
+    app.kubernetes.io/name: hermes
+  ports:
+    - name: gateway
+      port: 8642
+      targetPort: 8642
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: 9119
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-ts
+  annotations:
+    tailscale.com/hostname: "hermes"
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8642
+  selector:
+    app.kubernetes.io/name: hermes

--- a/kubernetes/apps/base/hermes/hermes/app/egress.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/egress.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-vllm
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-vllm.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aperture
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: aperture.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: searxng
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-searxng.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP

--- a/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: hermes-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Hermes S3 Reader Key"
+  allBuckets:
+    read: true
+  secretTemplate:
+    name: hermes-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://${COMMON_S3_ENDPOINT}"
+      AWS_ENDPOINT_URL_S3: "http://${COMMON_S3_ENDPOINT}"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/hermes/hermes/app/httproute.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/httproute.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hermes
+  annotations:
+    item.homer.rajsingh.info/name: "Hermes"
+    item.homer.rajsingh.info/subtitle: "AI Agent"
+    item.homer.rajsingh.info/logo: "https://hermes-agent.nousresearch.com/docs/img/logo.png"
+    item.homer.rajsingh.info/keywords: "ai, agent, assistant, discord"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-robot"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "hermes.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: hermes
+          port: 9119
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/hermes/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hermes
+resources:
+  - app.yaml
+  - storagestack.yaml
+  - httproute.yaml
+  - egress.yaml
+  - garagekey.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/base/hermes/hermes/app/secret.sops.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/secret.sops.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hermes-secrets
+type: Opaque
+stringData:
+    DISCORD_BOT_TOKEN: ENC[AES256_GCM,data:xz/aE7Q1Vo5RYI+o5+DB4B/ZvfkJ/KzXgjoYR5seygWwVwlg6iTQV95SbHNVSVBpoRcbd9Bu26Uc9AdyAWbaNUH/pviJjI7o,iv:lj5d9S2KCT1cjHg/hqkcpeU6+3ywCNCzkoppxACL4v4=,tag:zz/F5FlsRsuyc+kK9myvUA==,type:str]
+    GH_TOKEN: ENC[AES256_GCM,data:WBU20jTNGHSdBOMkjB2eZx23BrGqrJA/qqt1hXGlAeaXbswY38Ce+w==,iv:4WGtrbaFREwRWVfJY7Hl+1bFUsvYrcOjZDv+fwMMwL0=,tag:WP++J3tBkDhB/aPBxREZLA==,type:str]
+    API_SERVER_KEY: ENC[AES256_GCM,data:p/93ut96iYk/wiqP1MHddp/xCNclhc3kX5DyHP3SpqZuVMis3ujsMBrGuoKu4Ybrp/VrhgyldIjg6KYceKidHw==,iv:LKAGNP7KywEz5NFgnLuNFOH8J86O1TLofRPiPcQNiOo=,tag:YK9mvhp8uqfIIRTo4WygKQ==,type:str]
+sops:
+    lastmodified: "2026-04-18T08:12:57Z"
+    mac: ENC[AES256_GCM,data:dxM8wA/FkZKITB5TmLg/5FqOjfslPNdEJxwC+JGS7tQy+qOjVa5K22sFLK8AdiLhpRh2WuOBHyWqA6UISFWPR8gmzbfdNnUzCzjNQStUYFMKp/FGbPq8vIUKasOzymFFD3BsqerGRmmJUlfCxHJQyH+ac4wdhMwsuhLYfqPc5Vo=,iv:SqvW1Q0fnEYFExf9INpsLTITl8ArlScWRK3w13Y7jGk=,tag:NRVpDWZN6nRb1E0XbpsInQ==,type:str]
+    pgp:
+        - created_at: "2026-04-18T08:12:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveAQ//RSqeqvy5ut5lmzZKQcu5eHRCZU49WOgK1mIMACcjo/XH
+            W57QjCmR5rTti31s9/NHljVvycLFV/hwV7D6ZAfcZAqh+s2/VoHLC5bmim3DsQzp
+            Np+zmBQcD8Mvj+wi2azgZcJeG2QnYaagyMhX53gKdd6zAqUVYrsq1wcGh792N+WZ
+            QaSI7UO+QW9HJK3irtzmlqib5sXz8Ms48tLOoN+GzbBI1FNfivX5Rs7GwFSGZDjQ
+            Mp3wZBikZ6LG3bc/ph8zLH4yCAEZcOzbde2fKQ4zifdRjw5QJB/rasFNrQTABDUX
+            nDNs8MXAEW2UhQ7E+OEnFeTRnX6NJmvTYCHnyH25KLjgniA+hiq5+Dema3M4BvwN
+            LFMjUvQ4ph/Q/d9SpFzH7XyHO8kOF0giCl3tf4CwPF6IYgY4aiC9cbHdOXAB2pNq
+            8GOWFDFvMFoMP+9u99U6vAX2e7iIEyOc7rFh/Ehd492E1NNaMZG3o5gZPLpISgr8
+            TwpQAYlFKNAL22jEu3sB2XFQpDUN5CirJ4iXYq5jbvsFqE51N6+gkviKAcnhejBS
+            ZJqA7qB7C3yTq0E17OS4wp1kqF1dHDaLaAEAVZAyXOAzcKG5aGTaWXysr6z4kAvG
+            BQjHOZysZvpBlXd/EQD4+/iLG7QPPB8XODg23iUECXyOnNIMaBFvYKl7Rx9zG23U
+            aAEJAhBfGm2/En7Cx3Rjlek6hmttvNeCsFCEE6bS2QMDd4PJLA1kxE81B2djVZIG
+            J/hvVODyCp9NRXkayMqicxldIUiqxDNmTQRn3lmHjtRZHOdJ/dRtkHLUdCK3GWCd
+            Jz1zXAMyV8q1
+            =SJFR
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/kubernetes/apps/base/hermes/hermes/app/storagestack.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/storagestack.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: hermes-data
+  labels:
+    keiretsu.ts.net/location: ottawa
+spec:
+  name: hermes-data
+  size: 10Gi
+  storageClass: ceph-block-replicated
+  s3Path: hermes/hermes-data-v2
+  schedule: 0 4 * * *
+  copyMethod: Snapshot
+  restorePaused: false

--- a/kubernetes/apps/base/immich/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/base/immich/immich/app/helmrelease.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: immich
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: immich
+      version: 0.12.0
+      sourceRef:
+        kind: HelmRepository
+        name: immich
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: false
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              repository: ghcr.io/immich-app/immich-server
+              tag: v2.7.5
+            env:
+              DB_DATABASE_NAME: immich
+              DB_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-postgres-app
+                    key: username
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-postgres-app
+                    key: password
+              DB_HOSTNAME: immich-postgres-rw
+              REDIS_HOSTNAME: dragonfly-immich
+              REDIS_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-dragonfly-secret
+                    key: password
+    immich:
+      metrics:
+        enabled: true
+      persistence:
+        library:
+          existingClaim: immich-library
+    valkey:
+      enabled: false
+    server:
+      controllers:
+        main:
+          strategy: Recreate
+          containers:
+            main:
+              env:
+                DB_DATABASE_NAME: immich
+                DB_USERNAME:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: username
+                DB_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: password
+                DB_HOSTNAME: immich-postgres-rw
+                REDIS_HOSTNAME: dragonfly-immich
+                REDIS_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-dragonfly-secret
+                      key: password
+    machine-learning:
+      controllers:
+        main:
+          containers:
+            main:
+              env:
+                DB_DATABASE_NAME: immich
+                DB_USERNAME:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: username
+                DB_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-app
+                      key: password
+                DB_HOSTNAME: immich-postgres-rw
+                REDIS_HOSTNAME: dragonfly-immich
+                REDIS_PASSWORD:
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-dragonfly-secret
+                      key: password

--- a/kubernetes/apps/base/immich/immich/app/httproute.yaml
+++ b/kubernetes/apps/base/immich/immich/app/httproute.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: immich-server
+  namespace: immich
+  annotations:
+    item.homer.rajsingh.info/name: "Immich"
+    item.homer.rajsingh.info/subtitle: "Photo & Video Management"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/immich.svg"
+    item.homer.rajsingh.info/keywords: "photos, videos, backup"
+
+    service.homer.rajsingh.info/name: "Media"
+    service.homer.rajsingh.info/icon: "fas fa-tv"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "immich.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: immich-server
+          port: 2283
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/immich/immich/app/kustomization.yaml
+++ b/kubernetes/apps/base/immich/immich/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: immich
+resources:
+  - helmrelease.yaml
+  - probes.yaml
+  - pvc-library.yaml
+  - httproute.yaml
+  - secret.sops.yaml
+  - pg.yaml
+  - redis.yaml
+  - s3-backup.yaml

--- a/kubernetes/apps/base/immich/immich/app/pg.yaml
+++ b/kubernetes/apps/base/immich/immich/app/pg.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-postgres
+  namespace: immich
+spec:
+  instances: 2
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:15-0.3.0
+  postgresql:
+    shared_preload_libraries:
+      - "vchord.so"
+  bootstrap:
+    initdb:
+      database: immich
+      owner: immich
+      dataChecksums: true
+      postInitApplicationSQL:
+        - ALTER USER immich WITH SUPERUSER;
+        - CREATE EXTENSION IF NOT EXISTS vchord CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "cube";
+        - CREATE EXTENSION IF NOT EXISTS "earthdistance";
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 16Gi
+  # Enable Barman Cloud plugin for S3 backups
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: immich-s3-store
+        serverName: immich-postgres
+
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: keiretsu
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: immich-s3-store
+          serverName: immich-postgres
+---
+# S3 backup schedule using Barman Cloud
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: immich-postgres-s3
+  namespace: immich
+spec:
+  schedule: "0 0 23 * * *"  # Daily at 11 PM
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: immich-postgres

--- a/kubernetes/apps/base/immich/immich/app/probes.yaml
+++ b/kubernetes/apps/base/immich/immich/app/probes.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-immich
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://immich-server.immich:2283/api/server/ping
+      labels:
+        service: immich

--- a/kubernetes/apps/base/immich/immich/app/pvc-library.yaml
+++ b/kubernetes/apps/base/immich/immich/app/pvc-library.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-library
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: ceph-block-replicated
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: immich-library
+spec:
+  sourcePVC: immich-library
+  trigger:
+    schedule: "0 3 * * *"
+  restic:
+    pruneIntervalDays: 14
+    repository: restic-immich-library
+    retain:
+      hourly: 1
+      daily: 3
+      weekly: 4
+      monthly: 2
+      yearly: 1
+    copyMethod: Direct
+    cacheAccessModes: [ReadWriteOnce]
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: immich-library
+spec:
+  trigger:
+    manual: first
+  restic:
+    repository: restic-immich-library
+    destinationPVC: immich-library
+    copyMethod: Direct
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: volsync-immich-library-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Immich Library Volsync Key"
+  secretTemplate:
+    name: restic-immich-library
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    includeEndpoint: false
+    includeRegion: false
+    additionalData:
+      RESTIC_REPOSITORY: "s3:http://${COMMON_S3_ENDPOINT}/keiretsu/${LOCATION}/immich/library"
+      RESTIC_PASSWORD: "${COMMON_RESTIC_SECRET}"
+  bucketPermissions:
+    - globalAlias: keiretsu
+      read: true
+      write: true

--- a/kubernetes/apps/base/immich/immich/app/redis.yaml
+++ b/kubernetes/apps/base/immich/immich/app/redis.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly-immich
+spec:
+  replicas: 2
+  args:
+    - --maxmemory=1000M
+    - --proactor_threads=2
+    - --default_lua_flags=allow-undeclared-keys
+  authentication:
+    passwordFromSecret:
+      name: immich-dragonfly-secret
+      key: password
+  resources:
+    requests:
+      cpu: 25m
+      memory: 1000Mi
+    limits:
+      memory: 1500Mi

--- a/kubernetes/apps/base/immich/immich/app/s3-backup.yaml
+++ b/kubernetes/apps/base/immich/immich/app/s3-backup.yaml
@@ -1,0 +1,33 @@
+# S3 credentials secret for Immich backups
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: immich-s3-backup
+  namespace: immich
+stringData:
+  AWS_ACCESS_KEY_ID: ${KEIRETSU_S3_ACCESS_KEY}
+  AWS_SECRET_ACCESS_KEY: ${KEIRETSU_S3_SECRET_KEY}
+---
+# ObjectStore for Barman Cloud backups
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: immich-s3-store
+  namespace: immich
+spec:
+  configuration:
+    destinationPath: s3://keiretsu/${LOCATION}/immich/postgres/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: immich-s3-backup
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: immich-s3-backup
+        key: AWS_SECRET_ACCESS_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"

--- a/kubernetes/apps/base/immich/immich/app/secret.sops.yaml
+++ b/kubernetes/apps/base/immich/immich/app/secret.sops.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: immich-dragonfly-secret
+type: Opaque
+stringData:
+    password: ENC[AES256_GCM,data:wEXLYO+LcoViibzogsd1v6SNAzmLNyofG8k=,iv:eYfK/24ARql3Sodzl7mLo1R07GyTFjXgDdh8T3rDxPs=,tag:xiWJq+ihzC4Nk+MvPFNlNQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-01-31T04:26:12Z"
+    mac: ENC[AES256_GCM,data:mM5zMcNE5pOFu++27NtJ5Lxlg9ImvM6gVEnfxUKtvrFnricJdkhbhenUci7XsSBUTArmuRx2cOgXrP4GjXlX0YnTCYQMOFU9Tv+OugUdCeMJEb8aBlmju6VIn8xZwlzSgajc9O3Q0t63zgP2FWJMNYAQNgkPxDhWxBbLlx0m0gU=,iv:4pJqWTN9loCFSs2JzKQxJNCL5NIh9xQeGU/p3AE4JQQ=,tag:5bfU5v0U7hBQq/6tDPXnww==,type:str]
+    pgp:
+        - created_at: "2026-01-31T04:26:12Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveARAAiah4gdjK0vHbezffBbWOx8bNF7m1K2yuH8Ta6ZNrSmit
+            2tc0y9F3UcOTwO3n71fm/simzvMhAF66P0hNWqQwUsQbfEQhqKGh2j+q0Dd2z6u3
+            P+nzN/lTtvg/ttf+v/+f9ksNXbt3/ZDM1sNI5hyvPXQqThs3mZFL5w8xTknpMJte
+            GfL/Ejr4xYgtUKJ/8P0ei0/GPe+MwJJPGzWqCoE0t/r8B/UMf4/I6nKbyc4C2ODF
+            T4aqZS0aczDq/mNVlRw+Gzdyrhxz5ioRnqURPReysUC+6OldDUUa3sbpdqk+vdvB
+            kjwa2yqJS4rLC8lnOfpkmmZPb/jAWBIK+eGvkA0cDyMmCwpQoVrPRSnCOns44Det
+            tnwUopsrNFLBVEQOUFiGIMFa4hvFh8pOkDzY7DBfCNk6AuT70u8jZ65HKOBS6n6N
+            rw0zhVFD78S+vr3s726C/CFf85IdYFMwaQVGTQtfyiHKfSmxzSq2G0bOoynRhZsE
+            jF1hyVpFe76UyRVqxJBIFXfNYYxfbQ0wiPMCfAgRIBZ/CSep6vHG82az/HsIu+Xw
+            9gZK8wglAH6fFoEAG6GYlE/sjQU6ztyG4Wsq1fCYXsLOQ1k5+cAofb6ORDVogFN/
+            LBRp43tSJqhjdF84q+RFSc0R8x5WMgxmML0q52zCKTNXUvB+FIOUKxQvk9XzoXDU
+            aAEJAhANp/cRWMHewGlxB9lqxEoH8sKDMiAZJgtUYFgj1gHoXXKIljtVjRN6MpcC
+            7jZvzJ0+u80r2zfUt2FCbtqyeUnpte//QOq31EwKPyn8QJUKiGn+Z/bvNSQCa1a9
+            uVSltw4+HmNG
+            =GXJW
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/kubernetes/apps/base/kener/kener/app/deployment.yaml
+++ b/kubernetes/apps/base/kener/kener/app/deployment.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kener
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kener
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kener
+    spec:
+      containers:
+        - name: kener
+          image: ghcr.io/rajnandan1/kener:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: PORT
+              value: "3000"
+            - name: ORIGIN
+              value: "https://kener.${CLUSTER_DOMAIN}"
+            - name: REDIS_URL
+              value: redis://localhost:6379
+            - name: KENER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kener
+                  key: KENER_SECRET_KEY
+          volumeMounts:
+            - name: database
+              mountPath: /app/database
+            - name: uploads
+              mountPath: /app/uploads
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+        - name: redis
+          image: redis:8-alpine
+          imagePullPolicy: IfNotPresent
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: database
+          persistentVolumeClaim:
+            claimName: kener
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: kener-uploads

--- a/kubernetes/apps/base/kener/kener/app/httproute.yaml
+++ b/kubernetes/apps/base/kener/kener/app/httproute.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kener
+  annotations:
+    item.homer.rajsingh.info/name: "Kener"
+    item.homer.rajsingh.info/subtitle: "Public Status Page"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/gatus.svg"
+    item.homer.rajsingh.info/keywords: "status, uptime, public"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "kener.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: kener
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/kener/kener/app/kustomization.yaml
+++ b/kubernetes/apps/base/kener/kener/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kener
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/apps/base/kener/kener/app/pvc.yaml
+++ b/kubernetes/apps/base/kener/kener/app/pvc.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kener
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block-replicated
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kener-uploads
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block-replicated
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/base/kener/kener/app/service.yaml
+++ b/kubernetes/apps/base/kener/kener/app/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kener
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: kener
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/apps/ottawa/forgejo/forgejo.yaml
+++ b/kubernetes/apps/ottawa/forgejo/forgejo.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app forgejo
+  namespace: flux-system
+spec:
+  targetNamespace: forgejo
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
+    - name: cnpg-system
+  path: ./kubernetes/apps/base/forgejo/forgejo/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/ottawa/forgejo/kustomization.yaml
+++ b/kubernetes/apps/ottawa/forgejo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - forgejo.yaml

--- a/kubernetes/apps/ottawa/forgejo/namespace.yaml
+++ b/kubernetes/apps/ottawa/forgejo/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/ottawa/hermes/hermes.yaml
+++ b/kubernetes/apps/ottawa/hermes/hermes.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes
+  namespace: flux-system
+spec:
+  targetNamespace: hermes
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/hermes/hermes/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg

--- a/kubernetes/apps/ottawa/hermes/kustomization.yaml
+++ b/kubernetes/apps/ottawa/hermes/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - hermes.yaml

--- a/kubernetes/apps/ottawa/hermes/namespace.yaml
+++ b/kubernetes/apps/ottawa/hermes/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  annotations:
+    volsync.backube/privileged-movers: "true"
+    # argocd.argoproj.io/sync-options: Prune=false

--- a/kubernetes/apps/ottawa/immich/immich.yaml
+++ b/kubernetes/apps/ottawa/immich/immich.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app immich
+  namespace: flux-system
+spec:
+  targetNamespace: immich
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-system
+    - name: dragonfly-operator-system
+    - name: volsync
+    - name: garage
+  path: ./kubernetes/apps/base/immich/immich/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/immich/kustomization.yaml
+++ b/kubernetes/apps/ottawa/immich/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - immich.yaml

--- a/kubernetes/apps/ottawa/immich/namespace.yaml
+++ b/kubernetes/apps/ottawa/immich/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: immich
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kener/kener.yaml
+++ b/kubernetes/apps/ottawa/kener/kener.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kener
+  namespace: flux-system
+spec:
+  targetNamespace: kener
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kener/kener/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/kener/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kener/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - kener.yaml

--- a/kubernetes/apps/ottawa/kener/namespace.yaml
+++ b/kubernetes/apps/ottawa/kener/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kener
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -15,10 +16,14 @@ resources:
   - ./dragonfly-operator-system
   - ./firecrawl
   - ./fluent-bit
+  - ./forgejo
   - ./garage-operator-system
   - ./garage
   - ./gatus
   - ./gvisor
+  - ./hermes
+  - ./immich
+  - ./kener
   - ./kube-system
   - ./spegel
   - ./volsync


### PR DESCRIPTION
## Summary

- Adopt forgejo, hermes, immich, kener into `kubernetes/apps/` tree for ottawa cluster
- 4 CRs total (1 per app): verbatim copy to `kubernetes/apps/base/{forgejo,hermes,immich,kener}/`
- Ottawa pointers in `kubernetes/apps/ottawa/{forgejo,hermes,immich,kener}/`
- All 4 old parents: `cluster-apps`

## Test plan
- [x] `make test` passes (all clusters)
- [ ] After merge: reconcile kubernetes-apps, verify CRs show `kubernetes-apps` owner label
- [ ] PR-B: remove `clusters/talos-ottawa/apps/{forgejo,hermes,immich,kener}`, reconcile cluster-apps, verify CRs survive