### PR TITLE
migrate(batch-d/g5): adopt grafana-redirect into kubernetes tree (robbinsdale)

### DIFF
--- a/kubernetes/apps/base/home/grafana-redirect/app/kustomization.yaml
+++ b/kubernetes/apps/base/home/grafana-redirect/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./redirect.yaml

--- a/kubernetes/apps/base/home/grafana-redirect/app/redirect.yaml
+++ b/kubernetes/apps/base/home/grafana-redirect/app/redirect.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana-redirect
+  namespace: home
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "grafana.${CLUSTER_DOMAIN}"
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            hostname: grafana.killinit.cc
+            port: 443
+            statusCode: 301

--- a/kubernetes/apps/robbinsdale/home/grafana-redirect.yaml
+++ b/kubernetes/apps/robbinsdale/home/grafana-redirect.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-redirect
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  path: ./kubernetes/apps/base/home/grafana-redirect/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/apps/robbinsdale/home/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/home/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./grafana-redirect.yaml

--- a/kubernetes/apps/robbinsdale/home/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/home/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: home
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   - ./agent-sandbox-system
   - ./immich
   - ./tailgate-operator-system
+  - ./home


### PR DESCRIPTION
PR-A adopt for Batch D Group 5 (anomaly case).

grafana-redirect is special: the ks.yaml CR was never applied by cluster-apps (kustomization.yaml only included redirect.yaml, not ks.yaml). The HTTPRoute was applied directly by cluster-apps without a Flux Kustomization CR wrapper.

This PR creates a new Flux CR `grafana-redirect` in the kubernetes tree. After merge, Flux creates and owns the HTTPRoute. PR-B removes the old dir to stop cluster-apps from also applying the HTTPRoute directly.

Note: flate emits an orphan warning for grafana-redirect (flate 0.3.4 bug) but the CR passes (✓) in test output. No new failures vs pre-existing baseline.