### PR TITLE
feat: deploy authtest whoami with tinyauth extAuth SecurityPolicy (PR 2/3 for #1547)

### DIFF
--- a/kubernetes/apps/base/authtest/deployment.yaml
+++ b/kubernetes/apps/base/authtest/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authtest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authtest
+  template:
+    metadata:
+      labels:
+        app: authtest
+    spec:
+      containers:
+        - name: whoami
+          image: docker.io/traefik/whoami:v1.10.7
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534

--- a/kubernetes/apps/base/authtest/httproute.yaml
+++ b/kubernetes/apps/base/authtest/httproute.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authtest
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "authtest.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: authtest
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/authtest/kustomization.yaml
+++ b/kubernetes/apps/base/authtest/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - securitypolicy.yaml

--- a/kubernetes/apps/base/authtest/securitypolicy.yaml
+++ b/kubernetes/apps/base/authtest/securitypolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Envoy Gateway SecurityPolicy: forward-auth via tinyauth extAuth
+# Every request to authtest.keiretsu.top is checked by tinyauth.
+# On deny, tinyauth returns 302 -> login; on allow, headers are forwarded.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: authtest-tinyauth
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: authtest
+  extAuth:
+    http:
+      backendRefs:
+        - name: tinyauth
+          namespace: tinyauth
+          port: 3000
+      path: /api/auth/envoy
+      headersToBackend:
+        - remote-user
+        - remote-email
+      # Send the upstream Host so tinyauth can do per-FQDN ACL matching
+      headersToExtAuth:
+        - X-Forwarded-Host
+        - X-Forwarded-Proto

--- a/kubernetes/apps/base/authtest/service.yaml
+++ b/kubernetes/apps/base/authtest/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: authtest
+spec:
+  selector:
+    app: authtest
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/kubernetes/apps/ottawa/authtest/authtest.yaml
+++ b/kubernetes/apps/ottawa/authtest/authtest.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app authtest
+  namespace: flux-system
+spec:
+  targetNamespace: authtest
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/authtest
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/authtest/kustomization.yaml
+++ b/kubernetes/apps/ottawa/authtest/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./authtest.yaml

--- a/kubernetes/apps/ottawa/authtest/namespace.yaml
+++ b/kubernetes/apps/ottawa/authtest/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authtest
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ./monitoring
   - ./auth
+  - ./authtest
   - ./agent-sandbox-system
   - ./agents
   - ./argocd

--- a/kubernetes/apps/robbinsdale/authtest/authtest.yaml
+++ b/kubernetes/apps/robbinsdale/authtest/authtest.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app authtest
+  namespace: flux-system
+spec:
+  targetNamespace: authtest
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/authtest
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/authtest/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/authtest/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./authtest.yaml

--- a/kubernetes/apps/robbinsdale/authtest/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/authtest/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authtest
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ./monitoring
   - ./auth
+  - ./authtest
   - ./agent-sandbox-system
   - ./border0
   - ./clickhouse-operator-system

--- a/kubernetes/apps/stpetersburg/authtest/authtest.yaml
+++ b/kubernetes/apps/stpetersburg/authtest/authtest.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app authtest
+  namespace: flux-system
+spec:
+  targetNamespace: authtest
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/authtest
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/authtest/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/authtest/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./authtest.yaml

--- a/kubernetes/apps/stpetersburg/authtest/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/authtest/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authtest
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ./monitoring
   - ./auth
+  - ./authtest
   - ./agent-sandbox-system
   - ./ai
   - ./border0


### PR DESCRIPTION
## What

Second PR for #1547 — deploys a whoami test pod (`authtest.${COMMON_DOMAIN}`) behind Envoy Gateway with a SecurityPolicy that uses **tinyauth as ext_auth** to validate the forward-auth redirect flow.

## Structure

| Path | Purpose |
|------|---------|
| `kubernetes/apps/base/authtest/` | Deployment (traefik/whoami), Service, HTTPRoute, SecurityPolicy |
| `kubernetes/apps/{ottawa,robbinsdale,stpetersburg}/authtest/` | Per-cluster pointer files |

## What this proves

1. **Redirect flow through EG's extAuth wrapper** — SecurityPolicy targets `/api/auth/envoy` on tinyauth; on deny, Envoy forwards tinyauth's 302 + Set-Cookie to the client
2. **`X-Forwarded-Host` passes through** so tinyauth can do per-FQDN ACL matching
3. **HeadersToBackend** — `remote-user` and `remote-email` are injected into the upstream request

## Testing

Once deployed and tinyauth has an OAuth config (PR 3), hitting `https://authtest.keiretsu.top` should:
- Redirect to GitHub login (no session) → show whoami response headers incl. remote-user/remote-email (authenticated + whitelisted)
- Return 403 for non-whitelisted users (acls.policy: deny)

Refs: #1547