### PR TITLE
feat: add tinyauth secrets (gh OAuth client, signing key) — PR 3/3 for #1547

### DIFF
--- a/kubernetes/apps/base/auth/tinyauth/kustomization.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/auth/tinyauth/secret.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/secret.yaml
@@ -1,0 +1,18 @@
+# To encrypt:
+#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
+#
+# Then add secret.sops.yaml to the kustomization and remove secret.yaml.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tinyauth-secret
+type: Opaque
+stringData:
+  # GitHub OAuth client ID (create at https://github.com/settings/developers)
+  # Callback URL: https://auth.keiretsu.top/api/oauth/callback/github
+  github-client-id: ""
+  # GitHub OAuth client secret
+  github-client-secret: ""
+  # Internal signing/encryption secret
+  tinyauth-secret: "X36TF0olWAj6gB46kmade0b38UbvxntBpXSuqOYW4Hk="


### PR DESCRIPTION
## What

PR 3/3 for #1547 — creates the `tinyauth-secret` Secret with GitHub OAuth credentials and the internal signing key.

## Secret keys

| Key | Env var | Required |
|-----|---------|----------|
| `github-client-id` | `TINYAUTH_OAUTH_PROVIDERS_GITHUB_CLIENTID` | Placeholder — needs real value |
| `github-client-secret` | `TINYAUTH_OAUTH_PROVIDERS_GITHUB_CLIENTSECRET` | Placeholder — needs real value |
| `tinyauth-secret` | `TINYAUTH_SECRET` | ✅ Generated |

## Next steps (Raj needed)

1. Create a GitHub OAuth app at https://github.com/settings/developers
   - Callback URL: `https://auth.keiretsu.top/api/oauth/callback/github`
2. Fill in the client ID and secret in `secret.yaml`
3. Encrypt: `sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml`
4. Update kustomization to reference `secret.sops.yaml` instead

## Safety

All three keys are `optional: true` in the deployment, so the app deploys and runs without them (auth redirect won't work until secrets are populated).

Refs: #1547