### PR TITLE
migrate(batch-c/g6): adopt searxng into kubernetes tree (ottawa)

### DIFF
--- a/kubernetes/apps/base/searxng/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/base/searxng/searxng/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: searxng
+
+resources:
+  - namespace.yaml
+  - valkey.yaml
+  - searxng.yaml
+  - probes.yaml

--- a/kubernetes/apps/base/searxng/searxng/app/namespace.yaml
+++ b/kubernetes/apps/base/searxng/searxng/app/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: searxng
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/base/searxng/searxng/app/probes.yaml
+++ b/kubernetes/apps/base/searxng/searxng/app/probes.yaml
@@ -1,0 +1,38 @@
+---
+# SearXNG meta-search backend used by AI agents.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-searxng
+  namespace: searxng
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://searxng.searxng:8080/healthz
+      labels:
+        service: searxng
+        target: searxng
+---
+# Valkey (Redis-compat) backing store for SearXNG.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-valkey
+  namespace: searxng
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - valkey.searxng:6379
+      labels:
+        service: searxng
+        target: valkey

--- a/kubernetes/apps/base/searxng/searxng/app/searxng.yaml
+++ b/kubernetes/apps/base/searxng/searxng/app/searxng.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: searxng-config
+  namespace: searxng
+data:
+  settings.yml: |
+    use_default_settings: true
+    general:
+      instance_name: "SearXNG"
+      donation_url: false
+      contact_url: false
+    server:
+      secret_key: "changeme"
+      limiter: false
+      image_proxy: true
+      bind_address: "0.0.0.0"
+      port: 8080
+      method: "GET"
+      default_http_headers:
+        X-Content-Type-Options: nosniff
+        X-Robots-Tag: noindex, nofollow
+    ui:
+      static_use_hash: true
+      default_locale: en
+      default_theme: simple
+      center_alignment: true
+      infinite_scroll: false
+      search_on_category_select: true
+      hotkeys: default
+    valkey:
+      url: valkey://valkey:6379/0
+    search:
+      safe_search: 0
+      autocomplete: ""
+      default_lang: "auto"
+      ban_time_on_fail: 5
+      max_ban_time_on_fail: 120
+      formats:
+        - html
+        - json
+    outgoing:
+      request_timeout: 3.0
+      max_request_timeout: 15.0
+      pool_connections: 100
+      pool_maxsize: 20
+      retry_on_http_error: true
+  limiter.toml: |
+    [botdetection]
+    trusted_proxies = []
+    [botdetection.ip_limit]
+    filter_link_local = false
+    link_token = false
+    [botdetection.ip_lists]
+    block_ip = []
+    pass_ip = ["0.0.0.0/0", "::/0"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: searxng
+  namespace: searxng
+  labels:
+    app: searxng
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: searxng
+  template:
+    metadata:
+      labels:
+        app: searxng
+      annotations:
+        config/version: "20260418-4"
+    spec:
+      enableServiceLinks: false
+      initContainers:
+      - name: copy-settings
+        image: busybox:latest
+        command: ["sh", "-c", "cp /config/settings.yml /etc/searxng/settings.yml && cp /config/limiter.toml /etc/searxng/limiter.toml"]
+        volumeMounts:
+        - name: settings-config
+          mountPath: /config
+        - name: settings-writable
+          mountPath: /etc/searxng
+      containers:
+      - name: searxng
+        image: docker.io/searxng/searxng:latest
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        env:
+        - name: PORT
+          value: "8080"
+        volumeMounts:
+        - name: settings-writable
+          mountPath: /etc/searxng
+        - name: cache
+          mountPath: /var/cache/searxng
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: settings-config
+        configMap:
+          name: searxng-config
+      - name: settings-writable
+        emptyDir: {}
+      - name: cache
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: searxng
+  namespace: searxng
+  labels:
+    app: searxng
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: searxng
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: searxng-ts
+  namespace: searxng
+  annotations:
+    tailscale.com/hostname: "${LOCATION}-searxng"
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:singh360,tag:k8s,tag:${LOCATION}"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: searxng

--- a/kubernetes/apps/base/searxng/searxng/app/valkey.yaml
+++ b/kubernetes/apps/base/searxng/searxng/app/valkey.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: valkey
+  namespace: searxng
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: ./valkey
+      sourceRef:
+        kind: GitRepository
+        name: valkey-helm
+        namespace: flux-system
+      interval: 30m
+  releaseName: valkey
+  values:
+    replicaCount: 1
+    auth:
+      enabled: false
+    dataStorage:
+      enabled: false
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 50m
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - ./immich
   - ./kener
   - ./kube-system
+  - ./searxng
   - ./spegel
   - ./volsync
   - ./zot

--- a/kubernetes/apps/ottawa/searxng/kustomization.yaml
+++ b/kubernetes/apps/ottawa/searxng/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./searxng.yaml

--- a/kubernetes/apps/ottawa/searxng/searxng.yaml
+++ b/kubernetes/apps/ottawa/searxng/searxng.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app searxng
+  namespace: flux-system
+spec:
+  targetNamespace: searxng
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/searxng/searxng/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

- Adopt searxng into `kubernetes/apps/` tree for ottawa cluster
- 1 CR (searxng): verbatim copy to `kubernetes/apps/base/searxng/searxng/`
- Ottawa pointer in `kubernetes/apps/ottawa/searxng/`
- Old parent: `cluster-apps`

## Test plan
- [x] `make test` passes (all clusters)
- [ ] After merge: reconcile kubernetes-apps, verify searxng shows `kubernetes-apps` owner label
- [ ] PR-B: remove `clusters/talos-ottawa/apps/{searxng,fleet,keiretsu}`, reconcile cluster-apps, verify searxng CR survives