### PR TITLE
agents: expose Garage-backed trading.rajsingh.info site

### DIFF
--- a/clusters/common/apps/home/local-gateway/certificate-rajsingh.yaml
+++ b/clusters/common/apps/home/local-gateway/certificate-rajsingh.yaml
@@ -1,0 +1,18 @@
+---
+# Wildcard cert for *.rajsingh.info — needed to serve trading.rajsingh.info
+# and any future rajsingh.info subdomains from Garage via the public gateway.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-rajsingh-info
+spec:
+  dnsNames:
+    - '*.rajsingh.info'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: rajsingh-info
+  secretName: wildcard-rajsingh-info
+  usages:
+    - digital signature
+    - key encipherment

--- a/clusters/common/apps/home/local-gateway/kustomization.yaml
+++ b/clusters/common/apps/home/local-gateway/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - clienttrafficpolicy.yaml
   - certificate-s3.yaml
   - certificate-agents.yaml
+  - certificate-rajsingh.yaml

--- a/kubernetes/apps/base/agents/agents/app/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - kartik
   - teaspoon
   - camofox
+  - trading
 # NOTE: hermes groups (groups/<name>) are NOT listed here. Each is reconciled by
 # its own Flux Kustomization (ks-<name>.yaml) so tenants build independently —
 # no shared kustomize accumulation (group-meta would collide) and one group's

--- a/kubernetes/apps/base/agents/agents/app/trading/bucket.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/bucket.yaml
@@ -1,0 +1,23 @@
+---
+# Garage bucket for the trading.rajsingh.info static website (served via Garage Web API)
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: trading-web
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: trading-web
+  quotas:
+    maxSize: 1Gi
+    maxObjects: 10000
+  website:
+    indexDocument: "index.html"
+    errorDocument: "error.html"
+  keyPermissions:
+    - keyRef:
+        name: trading-web-s3-key
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/agents/agents/app/trading/garagekey.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/garagekey.yaml
@@ -1,0 +1,24 @@
+---
+# S3 key for the trading site to write to its Garage bucket (trading-web).
+# Used by the trading-dashboard cron job to upload HTML to Garage.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: trading-web-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "trading web S3 key"
+  allBuckets:
+    read: true
+    write: true
+  secretTemplate:
+    name: trading-web-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://${COMMON_S3_ENDPOINT}"
+      AWS_ENDPOINT_URL_S3: "http://${COMMON_S3_ENDPOINT}"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/agents/agents/app/trading/httproute-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/httproute-web.yaml
@@ -1,0 +1,43 @@
+---
+# trading.rajsingh.info static site served from Garage S3 via web API (port 3902).
+# OIDC-gated through the public gateway using the shared envoy Gateway OIDC client.
+# Garage resolves buckets by stripping the root_domain suffix from the Host
+# header, so we rewrite hostname → trading-web.keiretsu.top (bucket's globalAlias).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: trading-web
+  annotations:
+    item.homer.rajsingh.info/name: "Trading Dashboard"
+    item.homer.rajsingh.info/subtitle: "Robinhood Portfolio"
+    item.homer.rajsingh.info/keywords: "trading, portfolio, robinhood, rajsingh"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-chart-line"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "trading.rajsingh.info"
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: "trading-web.${COMMON_DOMAIN}"
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          namespace: garage
+          port: 3902
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/trading/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - garagekey.yaml
+  - bucket.yaml
+  - httproute-web.yaml
+  - securitypolicy-web.yaml
+  - oidc-secret.yaml

--- a/kubernetes/apps/base/agents/agents/app/trading/oidc-secret.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/oidc-secret.yaml
@@ -1,0 +1,10 @@
+---
+# Shared envoy Gateway OIDC client secret — same creds used by grafana, frigate, etc.
+# ${ENVOY_GATEWAY_OIDC_CLIENT_SECRET} from common-secrets via Flux postBuild substitution.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trading-web-oidc
+type: Opaque
+stringData:
+  client-secret: "${ENVOY_GATEWAY_OIDC_CLIENT_SECRET}"

--- a/kubernetes/apps/base/agents/agents/app/trading/securitypolicy-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/securitypolicy-web.yaml
@@ -1,0 +1,22 @@
+---
+# OIDC gate for trading.rajsingh.info — uses the shared envoy gateway OIDC client
+# (the same one grafana, frigate, etc. use) so users don't need a separate
+# Pocket ID client per agent web app.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: trading-web-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: trading-web
+  oidc:
+    provider:
+      issuer: "https://pocket-id.${COMMON_DOMAIN}"
+    clientID: "${ENVOY_GATEWAY_OIDC_CLIENT_ID}"
+    clientSecret:
+      name: trading-web-oidc
+    redirectURL: "https://trading.rajsingh.info/oauth2/callback"
+    logoutPath: "/logout"
+    cookieDomain: "rajsingh.info"


### PR DESCRIPTION
## What

Exposes a Garage-backed static website at **trading.rajsingh.info** for the trading/portfolio dashboard.

### Infrastructure changes

**Gateway (clusters/common/apps/home/local-gateway/)**
- Add  — cert-manager Certificate for `*.rajsingh.info` (uses existing `rajsingh-info` ClusterIssuer)
  - Note: the `wildcard-rajsingh-info-https` listener was already added to `gateway-public.yaml` — this just wires the cert
- Wire the new certificate into the kustomization

**Agent site resources (kubernetes/apps/base/agents/agents/app/trading/)**
- `GarageBucket (trading-web)` — 1Gi bucket with website mode (index.html/error.html)
- `GarageKey (trading-web-s3-key)` — write-capable S3 key for the upload cron
- `HTTPRoute` — routes `trading.rajsingh.info` → `garage-gateway:3902` with hostname rewrite to `trading-web.keiretsu.top`
- `SecurityPolicy` — OIDC gate via the shared envoy Gateway client (same pattern as `raj.agents.keiretsu.top`)

### New file structure
```
kubernetes/apps/base/agents/agents/app/trading/
├── bucket.yaml              # Garage bucket
├── garagekey.yaml           # S3 write key
├── httproute-web.yaml       # HTTPRoute → garage-gateway:3902
├── oidc-secret.yaml         # Shared OIDC client secret
├── securitypolicy-web.yaml  # OIDC gate
└── kustomization.yaml
```

### DNS
external-dns for `rajsingh.info` already watches the `public` gateway and will auto-create a DNS A record for `trading.rajsingh.info` pointing to the cluster load balancer.

**Note:** External DNS already exists for `rajsingh.info` (`external-dns-rajsingh-info.yaml`). Adding a Cloudflare DDNS record (`trading.rajsingh.info → ottawa.rajsingh.info`) is not needed as external-dns handles this from the HTTPRoute.

## Next steps after merge
1. Create a cron job or script to generate and upload the trading dashboard HTML to Garage S3
2. Verify at https://trading.rajsingh.info (OIDC login, page renders correctly)

Closes: N/A