### PR TITLE
agents: expose shared agents bucket at trades.rajsingh.info

### DIFF
--- a/clusters/common/apps/home/local-gateway/certificate-rajsingh.yaml
+++ b/clusters/common/apps/home/local-gateway/certificate-rajsingh.yaml
@@ -1,0 +1,18 @@
+---
+# Wildcard cert for *.rajsingh.info — needed to serve trading.rajsingh.info
+# and any future rajsingh.info subdomains from the public gateway.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-rajsingh-info
+spec:
+  dnsNames:
+    - '*.rajsingh.info'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: rajsingh-info
+  secretName: wildcard-rajsingh-info
+  usages:
+    - digital signature
+    - key encipherment

--- a/clusters/common/apps/home/local-gateway/kustomization.yaml
+++ b/clusters/common/apps/home/local-gateway/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - clienttrafficpolicy.yaml
   - certificate-s3.yaml
   - certificate-agents.yaml
+  - certificate-rajsingh.yaml

--- a/kubernetes/apps/base/agents/agents/app/bucket.yaml
+++ b/kubernetes/apps/base/agents/agents/app/bucket.yaml
@@ -11,6 +11,9 @@ spec:
   quotas:
     maxSize: 100Gi
     maxObjects: 10000000
+  website:
+    indexDocument: "index.html"
+    errorDocument: "error.html"
   keyPermissions:
     - keyRef:
         name: assistant-raj-s3-key
@@ -29,6 +32,11 @@ spec:
       owner: true
     - keyRef:
         name: teaspoon-s3-key
+      read: true
+      write: true
+      owner: true
+    - keyRef:
+        name: trading-web-s3-key
       read: true
       write: true
       owner: true

--- a/kubernetes/apps/base/agents/agents/app/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - kartik
   - teaspoon
   - camofox
+  - trading
 # NOTE: hermes groups (groups/<name>) are NOT listed here. Each is reconciled by
 # its own Flux Kustomization (ks-<name>.yaml) so tenants build independently —
 # no shared kustomize accumulation (group-meta would collide) and one group's

--- a/kubernetes/apps/base/agents/agents/app/trading/garagekey.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/garagekey.yaml
@@ -1,0 +1,24 @@
+---
+# S3 key for the trading site to write to the shared agents Garage bucket.
+# Used by the trading-dashboard cron job to upload HTML to Garage.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: trading-web-s3-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "trading web S3 key"
+  allBuckets:
+    read: true
+    write: true
+  secretTemplate:
+    name: trading-web-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      AWS_ENDPOINT_URL: "http://${COMMON_S3_ENDPOINT}"
+      AWS_ENDPOINT_URL_S3: "http://${COMMON_S3_ENDPOINT}"
+      AWS_REGION: "garage"
+      AWS_DEFAULT_REGION: "garage"

--- a/kubernetes/apps/base/agents/agents/app/trading/httproute-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/httproute-web.yaml
@@ -1,0 +1,37 @@
+---
+# trading.rajsingh.info static site served from Garage S3 via web API (port 3902).
+# Public — no OIDC, anyone can visit. Maps to the shared agents Garage bucket.
+# Garage resolves buckets by stripping the root_domain suffix from the Host
+# header, so we rewrite hostname -> agents.keiretsu.top.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: trading-web
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "trading.rajsingh.info"
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: "agents.${COMMON_DOMAIN}"
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          namespace: garage
+          port: 3902
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/trading/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/trading/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+resources:
+  - garagekey.yaml
+  - httproute-web.yaml


### PR DESCRIPTION
## What

Maps the **existing** `agents` Garage bucket to `trades.rajsingh.info` via a public HTTPRoute — **no OIDC**, anyone can visit.

### Changes

**Gateway**
- `certificate-rajsingh.yaml` — cert-manager Certificate for `*.rajsingh.info` (uses existing `rajsingh-info` ClusterIssuer). The `wildcard-rajsingh-info-https` listener already exists in `gateway-public.yaml`.

**Agents bucket**
- Added `website` stanza (index.html/error.html) — needed for serving via Garage web API
- Added `trading-web-s3-key` to keyPermissions

**Trading subdir (new)**
- `GarageKey (trading-web-s3-key)` — write-capable S3 key for the upload cron
- `HTTPRoute` — routes `trades.rajsingh.info` → `garage-gateway:3902` with hostname rewrite to `agents.keiretsu.top` (public + private gateways)

**Script** (`scripts/portfolio-page.py`)
- Switched from `raj-assistant-web` bucket to `agents` bucket
- Added proper HTML metadata: SVG favicon, OG/twitter meta tags, theme-color
- Uploads `favicon.svg` alongside `index.html`
- Resolves S3 creds from env vars (`TRADING_S3_KEY`/`TRADING_S3_SECRET`) instead of hardcoded values

### DNS
external-dns for `rajsingh.info` watches the public gateway and will auto-create `trades.rajsingh.info` after merge.