### PR TITLE
feat(apps): adopt ocm-agent + hubble-ui to kubernetes/apps tree (PR-A)

### DIFF
--- a/kubernetes/apps/base/hubble-ui/hubble-ui/app/dns-visibility.yaml
+++ b/kubernetes/apps/base/hubble-ui/hubble-ui/app/dns-visibility.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: intercept-all-dns
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: "io.kubernetes.pod.namespace"
+        operator: "NotIn"
+        values:
+        - "kube-system"
+      - key: "k8s-app"
+        operator: "NotIn"
+        values:
+        - kube-dns
+        - node-local-dns
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+          - port: "53"
+            protocol: TCP
+          - port: "53"
+            protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: node-local-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*" 

--- a/kubernetes/apps/base/hubble-ui/hubble-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/hubble-ui/hubble-ui/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hubble-ui
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: hubble-ui
+      version: 1.3.3
+      sourceRef:
+        kind: HelmRepository
+        name: isovalent # Use isovalent repo
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:

--- a/kubernetes/apps/base/hubble-ui/hubble-ui/app/httproute.yaml
+++ b/kubernetes/apps/base/hubble-ui/hubble-ui/app/httproute.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble
+  namespace: hubble-ui
+  annotations:
+    item.homer.rajsingh.info/name: "Hubble UI"
+    item.homer.rajsingh.info/subtitle: "Network Observability"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/cilium.png"
+    item.homer.rajsingh.info/keywords: "network, observability, cilium"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "hubble.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: hubble-ui
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/hubble-ui/hubble-ui/app/kustomization.yaml
+++ b/kubernetes/apps/base/hubble-ui/hubble-ui/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hubble-ui
+resources:
+  - helmrelease.yaml
+  - dns-visibility.yaml
+  - httproute.yaml
+components:
+  - ../../../../../components/oidc-protect

--- a/kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app/bootstrap-secret.yaml
+++ b/kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app/bootstrap-secret.yaml
@@ -1,0 +1,65 @@
+---
+# OCM bootstrap configs for hub connectivity
+# bootstrapHubKubeConfig: hub k8s API kubeconfig for work agent (still uses raw API)
+# grpcConfig: gRPC registration config — uses OCM-managed TLS, avoids Talos CA dependency
+# Bootstrap token pulled from Ottawa via ExternalSecret
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-ottawa-ocm
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: open-cluster-management
+      server:
+        url: https://ottawa-k8s-operator.keiretsu.ts.net
+      auth:
+        token:
+          bearerToken:
+            name: tailscale-api-token
+            namespace: external-secrets
+            key: token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ocm-bootstrap-kubeconfig
+  namespace: open-cluster-management-agent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-ottawa-ocm
+  target:
+    name: ocm-bootstrap-kubeconfig
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        bootstrapHubKubeConfig: |
+          apiVersion: v1
+          kind: Config
+          clusters:
+            - cluster:
+                server: https://kubernetes-ottawa.keiretsu.ts.net
+                certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJpRENDQVMrZ0F3SUJBZ0lRSU9Rd2llMzR6U1VJOGtocEZkeW1XekFLQmdncWhrak9QUVFEQWpBVk1STXcKRVFZRFZRUUtFd3ByZFdKbGNtNWxkR1Z6TUI0WERUSTFNRGd3T1RJek16Z3hNMW9YRFRNMU1EZ3dOekl6TXpneApNMW93RlRFVE1CRUdBMVVFQ2hNS2EzVmlaWEp1WlhSbGN6QlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VICkEwSUFCUGVOVWFzRzJNVmJZWUlhSUFVMnI2US9ad2JJUWQ2QWIzeGNQTEtneTZZVXcwU3BwQitEMlhxaEhXWlYKYXNoNmJIaWJyREhWWEIzNkJEVUpqN05DMUZtallUQmZNQTRHQTFVZER3RUIvd1FFQXdJQ2hEQWRCZ05WSFNVRQpGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZEJnTlZIUTRFCkZnUVU2cDMxL2R1WWZKOXEzdFhqS0NGWTBLUlNITDh3Q2dZSUtvWkl6ajBFQXdJRFJ3QXdSQUlnQ1BoVHlqVnQKM21hcW9ldkZvUFUxVlB1cGE0aW02cXhVK2Jad2tpbHRsdHNDSUhnanliK3luOUR1NGxNRnBDZ2Z0T0cvQ1pwbApqOEJuWU9uTXE5RkY1bm4wCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+              name: hub
+          contexts:
+            - context:
+                cluster: hub
+                user: bootstrap
+              name: hub
+          current-context: hub
+          users:
+            - name: bootstrap
+              user:
+                token: "{{ .token }}"
+        grpcConfig: |
+          caData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURQekNDQWllZ0F3SUJBZ0lJVDRxMVNqZTArZVV3RFFZSktvWklodmNOQVFFTEJRQXdMVEVyTUNrR0ExVUUKQXd3aVkyeDFjM1JsY2kxdFlXNWhaMlZ5TFhkbFltaHZiMnRBTVRjM05UQXhOelEzTmpBZUZ3MHlOakEwTURFdwpOREkwTXpWYUZ3MHlOekEwTURFd05ESTBNelphTUMweEt6QXBCZ05WQkFNTUltTnNkWE4wWlhJdGJXRnVZV2RsCmNpMTNaV0pvYjI5clFERTNOelV3TVRjME56WXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUsKQW9JQkFRRFR4azlMMlBhNWh0VG5HNFdLWlVrNzlHVUE3UXpLSkVRN3JGOFFrU0YxbGVnUlBZdGJVd0ROZUlhMwpDVmZCZGFSNEtYNHJ2eGU1VjY4c25PQmEzdXhSL0xsTjdLY0F6YUR5WDlWL25HOXB6NUFta2xDTjk1TitubzNFCkZtenJqclNDWTJzcVY1Rkl6T0JZQTROV1RMbW1FSE9mU3ZyS0ZqOEdiSENqcC9Nd0FFcE00cFFxajNZL2FRMmsKWkxSN3I0VVphazlmbUd5U2prSEEvc09OUm1oSjErcmhjOXpFU0tHeWFnOUozUFd5VERiWjM4VVlvTWdId0l1LwpWbjhveFBLbHdNSk5vbVMzZlk3RXFyQ0t2RWtGNmlSNDl6V3c1OWgwUzU1ditlVVlIanZPWW1LVklJOFl6Uk9ZCjJFU1l0YndzcUNwNmZaNU9TVFArV2pybitzQlJBZ01CQUFHall6QmhNQTRHQTFVZER3RUIvd1FFQXdJQ3BEQVAKQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlRvWGRiOE9rbjRsUDNWTU9oUHlFSUVWbXE2bHpBZgpCZ05WSFNNRUdEQVdnQlRvWGRiOE9rbjRsUDNWTU9oUHlFSUVWbXE2bHpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DCkFRRUF0L0RLT0h1K056am5Ba1Nzd2FVY3M1WkJkdGx4R1owa0JxZkt6UmV6U2Nyb3N5UFZsWTFrRTR4RWRvaFoKbzJBcXh1N0QzSC9CaWpyMmMvblR4VXRTY3EwR1d2QlZySWtMVmkyOW5MWWtJWThnTHBhUHhXSGJIVFBHNzAyRwo2MTdmdnhhYVlvTXgra2dsTTlCRnVCNHczYTFuTlQ0Y1owMjA4cEQzQjRqUS9ta0NyUmo2emFiT0pDdkkyVngxCkFka3FnMWdYL0VFL3k5V1ZQRlBnb2xraHM5Z2UrczNvWjhmU2xwc2pUQjNFN2NmMmxOOGxSSEdZTi92b0t5NE4KRCt4TU1VQXdsQXNZZFlrUy9lUFk2ak5oSy9NQXljZlQ3NHVIbzBaV0pjNTJHVVpQNVBIR09nSFJCUE56THlNYQo1ZlM4NVVkbkFYYzIzOHFqaVFSK0tqVy9nZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+          url: ocm-grpc-hub.keiretsu.ts.net:443
+          token: "{{ .token }}"
+  data:
+    - secretKey: token
+      remoteRef:
+        key: ocm-bootstrap-token
+        property: token

--- a/kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app/helmrelease.yaml
@@ -1,0 +1,42 @@
+---
+# OCM Klusterlet (Singleton mode) — registers this cluster with the OCM hub on Ottawa
+
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ocm-klusterlet
+  namespace: open-cluster-management-agent
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: klusterlet
+      version: "1.3.1"
+      sourceRef:
+        kind: HelmRepository
+        name: ocm
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: ocm-bootstrap-kubeconfig
+      valuesKey: bootstrapHubKubeConfig
+      targetPath: bootstrapHubKubeConfig
+    - kind: Secret
+      name: ocm-bootstrap-kubeconfig
+      valuesKey: grpcConfig
+      targetPath: grpcConfig
+  values:
+    klusterlet:
+      create: true
+      mode: Singleton
+      clusterName: "${CLUSTER_NAME}"
+      registrationConfiguration:
+        registrationDriver:
+          authType: grpc

--- a/kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app/kustomization.yaml
+++ b/kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - bootstrap-secret.yaml

--- a/kubernetes/apps/ottawa/hubble-ui/hubble-ui.yaml
+++ b/kubernetes/apps/ottawa/hubble-ui/hubble-ui.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hubble-ui
+  namespace: flux-system
+spec:
+  targetNamespace: hubble-ui
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/hubble-ui/hubble-ui/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: hubble
+      APP_HOST: hubble.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/ottawa/hubble-ui/kustomization.yaml
+++ b/kubernetes/apps/ottawa/hubble-ui/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./hubble-ui.yaml

--- a/kubernetes/apps/ottawa/hubble-ui/namespace.yaml
+++ b/kubernetes/apps/ottawa/hubble-ui/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hubble-ui
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -34,3 +33,5 @@ resources:
   - ./spegel
   - ./volsync
   - ./zot
+  - ./hubble-ui
+  - ./open-cluster-management-agent

--- a/kubernetes/apps/ottawa/open-cluster-management-agent/kustomization.yaml
+++ b/kubernetes/apps/ottawa/open-cluster-management-agent/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ocm-agent.yaml

--- a/kubernetes/apps/ottawa/open-cluster-management-agent/namespace.yaml
+++ b/kubernetes/apps/ottawa/open-cluster-management-agent/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-cluster-management-agent
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/open-cluster-management-agent/ocm-agent.yaml
+++ b/kubernetes/apps/ottawa/open-cluster-management-agent/ocm-agent.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ocm-agent
+  namespace: flux-system
+spec:
+  targetNamespace: open-cluster-management-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/robbinsdale/hubble-ui/hubble-ui.yaml
+++ b/kubernetes/apps/robbinsdale/hubble-ui/hubble-ui.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hubble-ui
+  namespace: flux-system
+spec:
+  targetNamespace: hubble-ui
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/hubble-ui/hubble-ui/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: hubble
+      APP_HOST: hubble.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/robbinsdale/hubble-ui/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/hubble-ui/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./hubble-ui.yaml

--- a/kubernetes/apps/robbinsdale/hubble-ui/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/hubble-ui/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hubble-ui
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -31,3 +30,5 @@ resources:
   - ./tailgate-operator-system
   - ./volsync
   - ./zot
+  - ./hubble-ui
+  - ./open-cluster-management-agent

--- a/kubernetes/apps/robbinsdale/open-cluster-management-agent/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/open-cluster-management-agent/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ocm-agent.yaml

--- a/kubernetes/apps/robbinsdale/open-cluster-management-agent/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/open-cluster-management-agent/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-cluster-management-agent
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/open-cluster-management-agent/ocm-agent.yaml
+++ b/kubernetes/apps/robbinsdale/open-cluster-management-agent/ocm-agent.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ocm-agent
+  namespace: flux-system
+spec:
+  targetNamespace: open-cluster-management-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/stpetersburg/hubble-ui/hubble-ui.yaml
+++ b/kubernetes/apps/stpetersburg/hubble-ui/hubble-ui.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hubble-ui
+  namespace: flux-system
+spec:
+  targetNamespace: hubble-ui
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/hubble-ui/hubble-ui/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: hubble
+      APP_HOST: hubble.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/stpetersburg/hubble-ui/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/hubble-ui/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./hubble-ui.yaml

--- a/kubernetes/apps/stpetersburg/hubble-ui/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/hubble-ui/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hubble-ui
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -31,3 +30,5 @@ resources:
   - ./tailbench
   - ./volsync
   - ./zot
+  - ./hubble-ui
+  - ./open-cluster-management-agent

--- a/kubernetes/apps/stpetersburg/open-cluster-management-agent/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/open-cluster-management-agent/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ocm-agent.yaml

--- a/kubernetes/apps/stpetersburg/open-cluster-management-agent/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/open-cluster-management-agent/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-cluster-management-agent
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/open-cluster-management-agent/ocm-agent.yaml
+++ b/kubernetes/apps/stpetersburg/open-cluster-management-agent/ocm-agent.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ocm-agent
+  namespace: flux-system
+spec:
+  targetNamespace: open-cluster-management-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/components/oidc-protect/kustomization.yaml
+++ b/kubernetes/components/oidc-protect/kustomization.yaml
@@ -1,0 +1,18 @@
+# oidc-protect: SSO in front of an HTTPRoute via the shared envoy-gateway
+# pocket-id client. Opt in from an app's app/kustomization.yaml:
+#   components:
+#     - ../../../components/oidc-protect        # adjust relative depth
+# and set in the app's Flux ks.yaml:
+#   spec.postBuild.substitute:
+#     APP: <httproute name>
+#     APP_HOST: <public host of the app, e.g. myapp.keiretsu.top>
+# Requires the app's ks.yaml to substituteFrom common-secrets (for
+# ENVOY_GATEWAY_OIDC_CLIENT_ID/SECRET) — the standard cluster wiring already
+# does this. Register https://<APP_HOST>/oauth2/callback on the shared
+# envoy-gateway client in pocket-id.
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - securitypolicy.yaml
+  - secret.yaml

--- a/kubernetes/components/oidc-protect/secret.yaml
+++ b/kubernetes/components/oidc-protect/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${APP}-oidc-secret
+type: Opaque
+stringData:
+  client-secret: "${ENVOY_GATEWAY_OIDC_CLIENT_SECRET}"

--- a/kubernetes/components/oidc-protect/securitypolicy.yaml
+++ b/kubernetes/components/oidc-protect/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ${APP}-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ${APP}
+  oidc:
+    provider:
+      issuer: "https://pocket-id.keiretsu.top"
+    clientID: "${ENVOY_GATEWAY_OIDC_CLIENT_ID}"
+    clientSecret:
+      name: ${APP}-oidc-secret
+    redirectURL: "https://${APP_HOST}/oauth2/callback"
+    logoutPath: "/logout"


### PR DESCRIPTION
Batch A Group 5 adopt: moves ocm-agent and hubble-ui base manifests + pointer files into kubernetes/apps tree.

- Copies clusters/common/apps/ocm-agent → kubernetes/apps/base/open-cluster-management-agent/ocm-agent/app/
- Copies clusters/common/apps/hubble-ui → kubernetes/apps/base/hubble-ui/hubble-ui/app/
- Copies clusters/common/components/oidc-protect → kubernetes/components/oidc-protect/ (re-pointed in hubble-ui kustomization)
- Adds pointer KS files for all 3 locations
- Byte-identical flate render verified: YES on all 6 (3 locations × 2 apps)

Old dirs remain; PR-B will remove them.