### PR TITLE
feat(apps): adopt external-secrets + snapshot-controller to kubernetes/apps tree (PR-A)

### DIFF
--- a/kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-stores.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-stores.yaml
@@ -1,0 +1,80 @@
+---
+# ClusterSecretStore for Ottawa cluster
+# Uses Tailscale egress service - auth handled by Tailscale impersonation
+# No caBundle needed - v2.1.0 falls back to system CA roots (Let's Encrypt is trusted)
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-ottawa
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: external-secrets
+      server:
+        url: https://ottawa-k8s-operator.tailscale.svc.cluster.local
+      auth:
+        token:
+          bearerToken:
+            name: tailscale-api-token
+            namespace: external-secrets
+            key: token
+---
+# ClusterSecretStore for Robbinsdale cluster
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-robbinsdale
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: external-secrets
+      server:
+        url: https://robbinsdale-k8s-operator.tailscale.svc.cluster.local
+      auth:
+        token:
+          bearerToken:
+            name: tailscale-api-token
+            namespace: external-secrets
+            key: token
+---
+# ClusterSecretStore for St. Petersburg cluster
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-stpetersburg
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: external-secrets
+      server:
+        url: https://stpetersburg-k8s-operator.tailscale.svc.cluster.local
+      auth:
+        token:
+          bearerToken:
+            name: tailscale-api-token
+            namespace: external-secrets
+            key: token
+---
+# ClusterSecretStore for local cluster secrets
+# Uses in-cluster auth via ServiceAccount
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-local
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: external-secrets
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: external-secrets
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: external-secrets-store
+          namespace: external-secrets
+---
+

--- a/kubernetes/apps/base/external-secrets/external-secrets/config/kustomization.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/config/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets
+resources:
+  - ./cluster-secret-stores.yaml
+  - ./rbac.yaml
+  - ./remote-tokens-secret.yaml

--- a/kubernetes/apps/base/external-secrets/external-secrets/config/rbac.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/config/rbac.yaml
@@ -1,0 +1,41 @@
+---
+# ServiceAccount for local cluster secret access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-store
+  namespace: external-secrets
+---
+# ClusterRole for reading secrets across namespaces
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-store
+rules:
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - selfsubjectrulesreviews
+    verbs:
+      - create
+---
+# Bind the ClusterRole to the ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-store
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-store
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-store
+    namespace: external-secrets

--- a/kubernetes/apps/base/external-secrets/external-secrets/config/remote-tokens-secret.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/config/remote-tokens-secret.yaml
@@ -1,0 +1,12 @@
+---
+# Token for Tailscale API proxy authentication
+# The actual auth is handled by Tailscale impersonation via the egress proxy
+# This token is effectively ignored - same pattern as Headlamp's kubeconfig
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-api-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: "unused"

--- a/kubernetes/apps/base/external-secrets/external-secrets/install/helmrelease.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/install/helmrelease.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: external-secrets
+      version: 2.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    installCRDs: true
+    priorityClassName: "infra-critical"
+    webhook:
+      port: 9443
+    certController:
+      requeueInterval: 5m
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/base/external-secrets/external-secrets/install/kustomization.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/install/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/base/snapshot-controller/app/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: snapshot-controller
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: snapshot-controller
+      version: 5.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: piraeus-charts # Use existing repo name
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controller:
+      enabled: true
+      replicaCount: 1
+      serviceMonitor:
+        create: true
+    volumeSnapshotClasses: [] 

--- a/kubernetes/apps/base/snapshot-controller/app/kustomization.yaml
+++ b/kubernetes/apps/base/snapshot-controller/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: snapshot-controller
+resources:
+  - helmrelease.yaml
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v5.0.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v5.0.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v5.0.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml 

--- a/kubernetes/apps/ottawa/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/ottawa/external-secrets/external-secrets.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-install
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/external-secrets/external-secrets/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-config
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/external-secrets/external-secrets/config
+  dependsOn:
+    - name: external-secrets-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/ottawa/external-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./external-secrets.yaml

--- a/kubernetes/apps/ottawa/external-secrets/namespace.yaml
+++ b/kubernetes/apps/ottawa/external-secrets/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -33,5 +33,7 @@ resources:
   - ./spegel
   - ./volsync
   - ./zot
+  - ./external-secrets
   - ./hubble-ui
   - ./open-cluster-management-agent
+  - ./snapshot-controller

--- a/kubernetes/apps/ottawa/snapshot-controller/kustomization.yaml
+++ b/kubernetes/apps/ottawa/snapshot-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./snapshot-controller.yaml

--- a/kubernetes/apps/ottawa/snapshot-controller/namespace.yaml
+++ b/kubernetes/apps/ottawa/snapshot-controller/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: snapshot-controller
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled 

--- a/kubernetes/apps/ottawa/snapshot-controller/snapshot-controller.yaml
+++ b/kubernetes/apps/ottawa/snapshot-controller/snapshot-controller.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app snapshot-controller
+  namespace: flux-system
+spec:
+  targetNamespace: snapshot-controller
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/snapshot-controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/robbinsdale/external-secrets/external-secrets.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-install
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/external-secrets/external-secrets/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-config
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/external-secrets/external-secrets/config
+  dependsOn:
+    - name: external-secrets-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/external-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./external-secrets.yaml

--- a/kubernetes/apps/robbinsdale/external-secrets/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/external-secrets/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -30,5 +30,7 @@ resources:
   - ./tailgate-operator-system
   - ./volsync
   - ./zot
+  - ./external-secrets
   - ./hubble-ui
   - ./open-cluster-management-agent
+  - ./snapshot-controller

--- a/kubernetes/apps/robbinsdale/snapshot-controller/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/snapshot-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./snapshot-controller.yaml

--- a/kubernetes/apps/robbinsdale/snapshot-controller/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/snapshot-controller/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: snapshot-controller
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled 

--- a/kubernetes/apps/robbinsdale/snapshot-controller/snapshot-controller.yaml
+++ b/kubernetes/apps/robbinsdale/snapshot-controller/snapshot-controller.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app snapshot-controller
+  namespace: flux-system
+spec:
+  targetNamespace: snapshot-controller
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/snapshot-controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/stpetersburg/external-secrets/external-secrets.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-install
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/external-secrets/external-secrets/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-config
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/external-secrets/external-secrets/config
+  dependsOn:
+    - name: external-secrets-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/external-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./external-secrets.yaml

--- a/kubernetes/apps/stpetersburg/external-secrets/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/external-secrets/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -30,5 +30,7 @@ resources:
   - ./tailbench
   - ./volsync
   - ./zot
+  - ./external-secrets
   - ./hubble-ui
   - ./open-cluster-management-agent
+  - ./snapshot-controller

--- a/kubernetes/apps/stpetersburg/snapshot-controller/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/snapshot-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./snapshot-controller.yaml

--- a/kubernetes/apps/stpetersburg/snapshot-controller/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/snapshot-controller/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: snapshot-controller
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled 

--- a/kubernetes/apps/stpetersburg/snapshot-controller/snapshot-controller.yaml
+++ b/kubernetes/apps/stpetersburg/snapshot-controller/snapshot-controller.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app snapshot-controller
+  namespace: flux-system
+spec:
+  targetNamespace: snapshot-controller
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/snapshot-controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Batch A deferred adopt: moves external-secrets and snapshot-controller base manifests + pointer files into kubernetes/apps tree.

- Copies clusters/common/apps/external-secrets/{install,config} → kubernetes/apps/base/external-secrets/external-secrets/{install,config}
- Copies clusters/common/apps/snapshot-controller/app → kubernetes/apps/base/snapshot-controller/app
- Adds pointer KS files for all 3 locations
- Byte-identical flate render: known flate v0.3.4 false-negative during dual-KS PR-A window (dependsOn chain); old-state renders confirm content identical

CI will fail (flate duplicate-KS issue); admin merge required. PR-B will remove old dirs.