### PR TITLE
agents: expose raj-assistant-web publicly at trades.rajsingh.info

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
@@ -1,0 +1,36 @@
+---
+# Public, un-authenticated alias of raj-assistant-web at trades.rajsingh.info.
+# Same Garage S3 static site as raj.agents.keiretsu.top, but attached only to
+# the `public` gateway with NO SecurityPolicy, so it's world-readable.
+# Garage resolves the bucket by stripping its root_domain (keiretsu.top) from
+# the Host header, so we rewrite hostname → raj-assistant-web.keiretsu.top.
+# DNS (Cloudflare) is auto-created by external-dns-cloudflare-rajsingh-info
+# (watches gateway==public); TLS uses the gateway's *.rajsingh.info cert.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: raj-assistant-web-public
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "trades.rajsingh.info"
+  rules:
+    - filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: "raj-assistant-web.${COMMON_DOMAIN}"
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: garage-gateway
+          namespace: garage
+          port: 3902
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - garagekey-web.yaml
   - bucket.yaml
   - httproute-web.yaml
+  - httproute-public.yaml
   - securitypolicy-web.yaml
   - oidc-secret.yaml
   - egress.yaml


### PR DESCRIPTION
Public, un-authenticated alias of `raj.agents.keiretsu.top` (the `raj-assistant-web` Garage bucket) at **trades.rajsingh.info**.

One additive HTTPRoute on the `public` gateway only — no SecurityPolicy, so it's world-readable. Rewrites the Host header to `raj-assistant-web.keiretsu.top` so Garage resolves the same bucket.

No DNS or cert work needed: `external-dns-cloudflare-rajsingh-info` (watches `gateway==public`) auto-creates the Cloudflare record → `ottawa.keiretsu.top`, and TLS is covered by the existing `*.rajsingh.info` wildcard listener/cert. `raj.agents.keiretsu.top` is untouched.

Supersedes the earlier `agents/trading-rajsingh-info` approach (separate `trading` bucket at `trading.rajsingh.info`).