### PR TITLE
tinyauth: google identity, working envoy extauth, secrets via sops

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-secrets.sops.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-secrets.sops.yaml
@@ -50,10 +50,14 @@ stringData:
     WOODPECKER_GITHUB_CLIENT: ENC[AES256_GCM,data:7Bz9P0lvfgAMgVK3+x5SxFPC7WY=,iv:/QPhALt1+1pIk0lUL3qmoz+hSXoW+NnFQdwKzbJ89R0=,tag:mhUaWSN3eEygvO02we5Igg==,type:str]
     WOODPECKER_GITHUB_SECRET: ENC[AES256_GCM,data:pCuctruxtZ9Q0N9TWmW8WzkY3Y0Mp/Wj0mIFnq8hkM88oyUloWH4qA==,iv:z304JSyP1HlIq5HgERQvlcEve3JHa3YIOemjMk5wJsU=,tag:lYETphOvMjwBDL4GGPfHzg==,type:str]
     UNIFI_PROTECT_API_KEY: ENC[AES256_GCM,data:nzUcfo7eoVvf0ZcluSfVyvmOHDHIq9GGnBHrQbccQM8=,iv:n4E/kBfFtXBtUHCArRF9/+3LqgLWXHfB1D01IteCwKU=,tag:WtkzVKuhAczD8yFhFlKo9g==,type:str]
+    TINYAUTH_USERS: ENC[AES256_GCM,data:f3umgPsuzi71rYyBrEcLeN0eFV3T+kWR5lrAmVabJjshOz7Y/WxO7xFCShQmO9BEgrGbugYWtkTnssWjRvF1DA==,iv:BKB28w3NvSmSoEYQWoBPp3k8NW8aVqXIor9soNhvC7Y=,tag:15/jsYEx9eXmGezTme5WEw==,type:str]
+    TINYAUTH_GOOGLE_CLIENT_ID: ENC[AES256_GCM,data:er8ABPh2wXBXmbwnU1jGJ0Odzpc52gZBhgciihJYUBZQTOTN9g0syh6jYnaRZ1lUiFP6j9r29blLRg++4WGYU4NQjsn+gu59,iv:PvSGTGt9yzy7TRtNjvQ9Nxz5Cer90+V5lpVkTFhVc98=,tag:S75p7ZIcr5+Hzz4O0rKHOw==,type:str]
+    TINYAUTH_GOOGLE_CLIENT_SECRET: ENC[AES256_GCM,data:aJ6tJTfyWtEFpNakS7uM9b9x,iv:Oxeus2GT5sMWel4a5f6gW0FHHAmDV++3/JcUS9aIkGo=,tag:AWDIOVjukNIVqB5nQ7Vy8g==,type:str]
+    TINYAUTH_SIGNING_SECRET: ENC[AES256_GCM,data:YIqDpQe2fhXfmRXyzCk6cffquVORp3xh27FZ/0RkrZWge+99pB+euLEmrO4=,iv:kAFkIU+nq/QwSzl3YjPaKSELrVCVnZ8LOk5NK5Sfdj4=,tag:EcEzjOTW7Y8WhB1FBSZQEw==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-21T17:35:10Z"
-    mac: ENC[AES256_GCM,data:BQujF8P4T2tILc22WhrTWmmdcaZWdDNkB4IIBEB3VlCiAXRYEStTxm3RhGmAPzWWOjp86OJzuSVQYgMmgaIhcHGHk/nj5OpseP359jxNngyjoe0E9aetvfe1PZry60O9ICQT/WKXsZkwGp0U0OZubxR2wdG8/UBX3EO4l9hp3ww=,iv:/JBf5D4UIdZgbcq8LpeicEgM9lsN40ZtjpOSjgkUr/U=,tag:ooE+wUlp+4dquUXzXlimPg==,type:str]
+    lastmodified: "2026-06-11T04:55:49Z"
+    mac: ENC[AES256_GCM,data:na60s0ql7lBXP9xDCNacLSvfzFT5XMA1Mz9Qqg8HlDugaanJyWHvespj9Qav4jgH/pqCau3U3W3Jc3dahtO8u2jmXMQTVuMUYNPn/NNh/kOZ57QvHx8knWE3OzNRbMGarLZrrmH6zq2nmGZADrybYZyXdRvfL/HS0mGcwnCO6GM=,iv:H5jha3W4Ylbf7uF574sraVni8+1pwBR17gVWaoqGc2U=,tag:a1bC/UiNKU88QNqnfDVeCA==,type:str]
     pgp:
         - created_at: "2026-04-29T00:41:43Z"
           enc: |-

--- a/kubernetes/apps/base/auth/tinyauth/configmap.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,6 +9,12 @@ data:
   TINYAUTH_AUTH_SESSIONEXPIRY: "86400"
   TINYAUTH_AUTH_SECURECOOKIE: "true"
   TINYAUTH_AUTH_SUBDOMAINSENABLED: "true"
-  TINYAUTH_AUTH_ACLS_POLICY: "allow"
-  TINYAUTH_OAUTH_AUTOREDIRECT: "github"
+  # NOTE: TINYAUTH_AUTH_ACLS_POLICY is main-branch-only; the released v5
+  # image crashes on it ("field not found, node: acls"). default is allow.
+  TINYAUTH_OAUTH_AUTOREDIRECT: "google"
   TINYAUTH_ANALYTICS_ENABLED: "false"
+  # authentication is google; AUTHORIZATION is this whitelist + per-app ACLs
+  TINYAUTH_OAUTH_WHITELIST: "rajsinghcpre@gmail.com"
+  # --- per-FQDN ACLs ---
+  TINYAUTH_APPS_AUTHTEST_CONFIG_DOMAIN: "authtest.keiretsu.top"
+  TINYAUTH_APPS_AUTHTEST_OAUTH_WHITELIST: "rajsinghcpre@gmail.com"

--- a/kubernetes/apps/base/auth/tinyauth/deployment.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/deployment.yaml
@@ -22,17 +22,21 @@ spec:
             - configMapRef:
                 name: tinyauth-config
           env:
-            - name: TINYAUTH_OAUTH_PROVIDERS_GITHUB_CLIENTID
+            - name: TINYAUTH_OAUTH_PROVIDERS_GOOGLE_CLIENTID
               valueFrom:
                 secretKeyRef:
                   name: tinyauth-secret
-                  key: github-client-id
-                  optional: true
-            - name: TINYAUTH_OAUTH_PROVIDERS_GITHUB_CLIENTSECRET
+                  key: google-client-id
+            - name: TINYAUTH_OAUTH_PROVIDERS_GOOGLE_CLIENTSECRET
               valueFrom:
                 secretKeyRef:
                   name: tinyauth-secret
-                  key: github-client-secret
+                  key: google-client-secret
+            - name: TINYAUTH_AUTH_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: tinyauth-secret
+                  key: users
                   optional: true
             - name: TINYAUTH_SECRET
               valueFrom:

--- a/kubernetes/apps/base/auth/tinyauth/kustomization.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - service.yaml
   - httproute.yaml
   - secret.yaml
+  - referencegrant.yaml

--- a/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
@@ -1,0 +1,15 @@
+---
+# allow SecurityPolicies in app namespaces to point extAuth at tinyauth
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: extauth-to-tinyauth
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: authtest
+  to:
+    - group: ""
+      kind: Service
+      name: tinyauth

--- a/kubernetes/apps/base/auth/tinyauth/secret.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/secret.yaml
@@ -1,18 +1,16 @@
-# To encrypt:
-#   sops --encrypt --in-place secret.yaml && git mv secret.yaml secret.sops.yaml
-#
-# Then add secret.sops.yaml to the kustomization and remove secret.yaml.
 ---
+# values come from ottawa cluster-secrets (sops) via flux substitution
 apiVersion: v1
 kind: Secret
 metadata:
   name: tinyauth-secret
 type: Opaque
 stringData:
-  # GitHub OAuth client ID (create at https://github.com/settings/developers)
-  # Callback URL: https://auth.keiretsu.top/api/oauth/callback/github
-  github-client-id: ""
-  # GitHub OAuth client secret
-  github-client-secret: ""
-  # Internal signing/encryption secret
-  tinyauth-secret: "X36TF0olWAj6gB46kmade0b38UbvxntBpXSuqOYW4Hk="
+  # google oauth client (console.cloud.google.com -> credentials)
+  # callback: https://auth.keiretsu.top/api/oauth/callback/google
+  google-client-id: "${TINYAUTH_GOOGLE_CLIENT_ID}"
+  google-client-secret: "${TINYAUTH_GOOGLE_CLIENT_SECRET}"
+  # local fallback user (bcrypt, user:hash) for testing without oauth
+  users: "${TINYAUTH_USERS}"
+  # internal signing/encryption secret
+  tinyauth-secret: "${TINYAUTH_SIGNING_SECRET}"

--- a/kubernetes/apps/base/authtest/securitypolicy.yaml
+++ b/kubernetes/apps/base/authtest/securitypolicy.yaml
@@ -1,7 +1,10 @@
 ---
-# Envoy Gateway SecurityPolicy: forward-auth via tinyauth extAuth
-# Every request to authtest.keiretsu.top is checked by tinyauth.
-# On deny, tinyauth returns 302 -> login; on allow, headers are forwarded.
+# Envoy Gateway SecurityPolicy: forward-auth via tinyauth extAuth.
+# tinyauth's envoy mode reads the original host from the check request's own
+# authority, the original path from ?path= (the http ext-auth `path` is a
+# prefix the original request path is appended to), and REQUIRES cookie +
+# x-forwarded-proto to be forwarded. on deny, envoy passes tinyauth's
+# 302/Set-Cookie through to the browser.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
@@ -12,16 +15,19 @@ spec:
       kind: HTTPRoute
       name: authtest
   extAuth:
+    headersToExtAuth:
+      - cookie
+      - x-forwarded-proto
+      - x-forwarded-for
+      - user-agent
     http:
       backendRefs:
         - name: tinyauth
           namespace: tinyauth
           port: 3000
-      path: /api/auth/envoy
+      path: "/api/auth/envoy?path="
       headersToBackend:
         - remote-user
         - remote-email
-      # Send the upstream Host so tinyauth can do per-FQDN ACL matching
-      headersToExtAuth:
-        - X-Forwarded-Host
-        - X-Forwarded-Proto
+        - remote-name
+        - remote-groups

--- a/kubernetes/apps/base/k6-operator-system/k6-operator-system/install/cluster-info.yaml
+++ b/kubernetes/apps/base/k6-operator-system/k6-operator-system/install/cluster-info.yaml
@@ -1,0 +1,18 @@
+---
+# Cluster identity for k6 TestRun envFrom. Flux postBuild substitutes the
+# values from common/cluster-settings ConfigMaps. Lives in
+# k6-operator-system because that's where TestRuns and runner pods land.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-info
+data:
+  CLUSTER_NAME: ${CLUSTER_NAME}
+  LOCATION: ${LOCATION}
+  CLUSTER_DOMAIN: ${CLUSTER_DOMAIN}
+  TS_TAILNET_DOMAIN: keiretsu.ts.net
+  # Default k6 prometheus-rw destination - cluster-local Prometheus already
+  # has remote_write to Mimir configured.
+  K6_PROMETHEUS_RW_SERVER_URL: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090/api/v1/write
+  K6_PROMETHEUS_RW_TREND_STATS: p(50),p(90),p(95),p(99),min,max,avg
+  K6_PROMETHEUS_RW_PUSH_INTERVAL: 5s


### PR DESCRIPTION
Converts the tinyauth deploy to Google identity and makes the extAuth flow actually work: removes the main-branch-only acls env the released v5 image crashes on, fixes the SecurityPolicy (headersToExtAuth placement was schema-rejected; cookie now forwarded — without it login loops forever; ?path= prefix puts the original path in the query where tinyauth's envoy mode reads it), adds the cross-namespace ReferenceGrant, moves all tinyauth secrets to sops (the committed plaintext signing key is rotated), restores the k6 cluster-info.yaml dropped during the batch-a move (NOTE: if the in-flight k6 purge lands first this hunk just becomes moot), and removes a duplicate tinyauth scaffold this session raced in. Google client secret is a sops placeholder — set it with: sops set clusters/talos-ottawa/flux/vars/cluster-secrets.sops.yaml '["stringData"]["TINYAUTH_GOOGLE_CLIENT_SECRET"]' '"<value>"'