### PR TITLE
tinyauth: v5.0.7 env compat, fix whoami image tag

### DIFF
--- a/kubernetes/apps/base/auth/tinyauth/configmap.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/configmap.yaml
@@ -8,7 +8,6 @@ data:
   TINYAUTH_SERVER_PORT: "3000"
   TINYAUTH_AUTH_SESSIONEXPIRY: "86400"
   TINYAUTH_AUTH_SECURECOOKIE: "true"
-  TINYAUTH_AUTH_SUBDOMAINSENABLED: "true"
   # NOTE: TINYAUTH_AUTH_ACLS_POLICY is main-branch-only; the released v5
   # image crashes on it ("field not found, node: acls"). default is allow.
   TINYAUTH_OAUTH_AUTOREDIRECT: "google"

--- a/kubernetes/apps/base/authtest/deployment.yaml
+++ b/kubernetes/apps/base/authtest/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: whoami
-          image: docker.io/traefik/whoami:v1.10.7
+          image: ghcr.io/traefik/whoami:v1.11.0
           ports:
             - containerPort: 80
           resources:


### PR DESCRIPTION
The released v5 image predates subdomainsEnabled (and acls) in the env schema — the pod fatals on unknown nodes. Also docker.io/traefik/whoami:v1.10.7 does not exist; use ghcr v1.11.0.