### PR TITLE
agents: fix trades.rajsingh.info DNS (Cloudflare 1014 cross-account)

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
@@ -6,10 +6,19 @@
 # the Host header, so we rewrite hostname → raj-assistant-web.keiretsu.top.
 # DNS (Cloudflare) is auto-created by external-dns-cloudflare-rajsingh-info
 # (watches gateway==public); TLS uses the gateway's *.rajsingh.info cert.
+#
+# The `public` gateway's default external-dns target is ottawa.keiretsu.top,
+# but keiretsu.top and rajsingh.info live in different Cloudflare accounts —
+# a cross-account CNAME gets Cloudflare Error 1014. Override the target to
+# ottawa.rajsingh.info (same account, ddns-maintained → home IP) and keep it
+# DNS-only, matching how raj.agents.keiretsu.top resolves.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: raj-assistant-web-public
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "ottawa.rajsingh.info"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io


### PR DESCRIPTION
`trades.rajsingh.info` returned **Cloudflare Error 1014 (CNAME Cross-User Banned)**.

The `public` gateway sets a default external-dns target of `ottawa.keiretsu.top`, so external-dns created `trades.rajsingh.info → CNAME ottawa.keiretsu.top`. But `keiretsu.top` and `rajsingh.info` are in **different Cloudflare accounts**, and Cloudflare bans a proxied cross-account CNAME → 1014.

Fix: per-route annotations overriding the target to `ottawa.rajsingh.info` (same account, already maintained by the rajsingh.info ddns deploy → home IP `76.71.101.187`) and forcing `cloudflare-proxied: false` (DNS-only), matching how `raj.agents.keiretsu.top` resolves.