### PR TITLE
tinyauth: attach auth + authtest routes to the ts gateway

### DIFF
--- a/kubernetes/apps/base/auth/tinyauth/httproute.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/httproute.yaml
@@ -8,6 +8,10 @@ spec:
       kind: Gateway
       name: public
       namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
   hostnames:
     - "auth.${COMMON_DOMAIN}"
   rules:

--- a/kubernetes/apps/base/authtest/httproute.yaml
+++ b/kubernetes/apps/base/authtest/httproute.yaml
@@ -8,6 +8,10 @@ spec:
       kind: Gateway
       name: public
       namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
   hostnames:
     - "authtest.${COMMON_DOMAIN}"
   rules:


### PR DESCRIPTION
auth.keiretsu.top currently resolves on no DNS horizon — the routes only attach to the public gateway and the keiretsu.top cloudflare external-dns is CRD-source-only. Attaching to ts publishes pihole records for tailnet browsers, enabling the interactive Google login test.