### PR TITLE
tinyauth: public dns for auth + authtest

### DIFF
--- a/clusters/common/apps/k8gb/config/cnames.yaml
+++ b/clusters/common/apps/k8gb/config/cnames.yaml
@@ -22,6 +22,20 @@ spec:
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "true"
+    - dnsName: "auth.${COMMON_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "ottawa.${COMMON_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
+    - dnsName: "authtest.${COMMON_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "ottawa.${COMMON_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "hello.${COMMON_DOMAIN}"
       recordType: CNAME
       targets:


### PR DESCRIPTION
auth.keiretsu.top resolved nowhere: pihole records exist but tailnet split-dns sends keiretsu.top to 1.1.1.1. CNAME both names to ottawa.keiretsu.top (existing k8gb gslb exposed hostname, verified resolving) via the cnames DNSEndpoint, unproxied so TLS terminates at the gateway.