### PR TITLE
cloudflare: force per-zone external-dns targets for all public domains

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
@@ -6,19 +6,14 @@
 # the Host header, so we rewrite hostname → raj-assistant-web.keiretsu.top.
 # DNS (Cloudflare) is auto-created by external-dns-cloudflare-rajsingh-info
 # (watches gateway==public); TLS uses the gateway's *.rajsingh.info cert.
-#
-# The `public` gateway's default external-dns target is ottawa.keiretsu.top,
-# but keiretsu.top and rajsingh.info live in different Cloudflare accounts —
-# a cross-account CNAME gets Cloudflare Error 1014. Override the target to
-# ottawa.rajsingh.info (same account, ddns-maintained → home IP) and keep it
-# DNS-only, matching how raj.agents.keiretsu.top resolves.
+# That instance forces a same-account target (ottawa.rajsingh.info) via
+# --default-targets, so this route needs no per-host target override — the
+# gateway's cross-account ottawa.keiretsu.top default (Cloudflare Error 1014)
+# is handled centrally for every domain.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: raj-assistant-web-public
-  annotations:
-    external-dns.alpha.kubernetes.io/target: "ottawa.rajsingh.info"
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-public.yaml
@@ -6,9 +6,9 @@
 # the Host header, so we rewrite hostname → raj-assistant-web.keiretsu.top.
 # DNS (Cloudflare) is auto-created by external-dns-cloudflare-rajsingh-info
 # (watches gateway==public); TLS uses the gateway's *.rajsingh.info cert.
-# That instance forces a same-account target (ottawa.rajsingh.info) via
+# That instance forces a same-account target (${LOCATION}.rajsingh.info) via
 # --default-targets, so this route needs no per-host target override — the
-# gateway's cross-account ottawa.keiretsu.top default (Cloudflare Error 1014)
+# gateway's cross-account ${LOCATION}.keiretsu.top default (Cloudflare Error 1014)
 # is handled centrally for every domain.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-killinit-cc.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-killinit-cc.yaml
@@ -33,6 +33,12 @@ spec:
             key: KILLINIT_CC_CLOUDFLARE_API_TOKEN
     extraArgs:
       - --gateway-label-filter=gateway==public
+      # Route the public gateway's hostnames to THIS zone's own ottawa.<domain>
+      # (same Cloudflare account) instead of inheriting the gateway's default
+      # target ottawa.keiretsu.top, which is a different account and triggers
+      # Cloudflare Error 1014 (CNAME cross-user banned).
+      - --default-targets=ottawa.killinit.cc
+      - --force-default-targets
     policy: sync
     sources:
       - gateway-httproute

--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-killinit-cc.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-killinit-cc.yaml
@@ -33,11 +33,11 @@ spec:
             key: KILLINIT_CC_CLOUDFLARE_API_TOKEN
     extraArgs:
       - --gateway-label-filter=gateway==public
-      # Route the public gateway's hostnames to THIS zone's own ottawa.<domain>
+      # Route the public gateway's hostnames to THIS zone's own ${LOCATION}.<domain>
       # (same Cloudflare account) instead of inheriting the gateway's default
-      # target ottawa.keiretsu.top, which is a different account and triggers
+      # target ${LOCATION}.keiretsu.top, which is a different account and triggers
       # Cloudflare Error 1014 (CNAME cross-user banned).
-      - --default-targets=ottawa.killinit.cc
+      - --default-targets=${LOCATION}.killinit.cc
       - --force-default-targets
     policy: sync
     sources:

--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-lukehouge-com.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-lukehouge-com.yaml
@@ -33,6 +33,12 @@ spec:
             key: LUKEHOUGE_COM_CLOUDFLARE_API_TOKEN
     extraArgs:
       - --gateway-label-filter=gateway==public
+      # Route the public gateway's hostnames to THIS zone's own ottawa.<domain>
+      # (same Cloudflare account) instead of inheriting the gateway's default
+      # target ottawa.keiretsu.top, which is a different account and triggers
+      # Cloudflare Error 1014 (CNAME cross-user banned).
+      - --default-targets=ottawa.lukehouge.com
+      - --force-default-targets
     policy: sync
     sources:
       - gateway-httproute

--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-lukehouge-com.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-lukehouge-com.yaml
@@ -33,11 +33,11 @@ spec:
             key: LUKEHOUGE_COM_CLOUDFLARE_API_TOKEN
     extraArgs:
       - --gateway-label-filter=gateway==public
-      # Route the public gateway's hostnames to THIS zone's own ottawa.<domain>
+      # Route the public gateway's hostnames to THIS zone's own ${LOCATION}.<domain>
       # (same Cloudflare account) instead of inheriting the gateway's default
-      # target ottawa.keiretsu.top, which is a different account and triggers
+      # target ${LOCATION}.keiretsu.top, which is a different account and triggers
       # Cloudflare Error 1014 (CNAME cross-user banned).
-      - --default-targets=ottawa.lukehouge.com
+      - --default-targets=${LOCATION}.lukehouge.com
       - --force-default-targets
     policy: sync
     sources:

--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-rajsingh-info.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-rajsingh-info.yaml
@@ -33,11 +33,11 @@ spec:
             key: RAJSINGH_INFO_CLOUDFLARE_API_TOKEN
     extraArgs:
       - --gateway-label-filter=gateway==public
-      # Route the public gateway's hostnames to THIS zone's own ottawa.<domain>
+      # Route the public gateway's hostnames to THIS zone's own ${LOCATION}.<domain>
       # (same Cloudflare account) instead of inheriting the gateway's default
-      # target ottawa.keiretsu.top, which is a different account and triggers
+      # target ${LOCATION}.keiretsu.top, which is a different account and triggers
       # Cloudflare Error 1014 (CNAME cross-user banned).
-      - --default-targets=ottawa.rajsingh.info
+      - --default-targets=${LOCATION}.rajsingh.info
       - --force-default-targets
     policy: sync
     sources:

--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-rajsingh-info.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-rajsingh-info.yaml
@@ -33,6 +33,12 @@ spec:
             key: RAJSINGH_INFO_CLOUDFLARE_API_TOKEN
     extraArgs:
       - --gateway-label-filter=gateway==public
+      # Route the public gateway's hostnames to THIS zone's own ottawa.<domain>
+      # (same Cloudflare account) instead of inheriting the gateway's default
+      # target ottawa.keiretsu.top, which is a different account and triggers
+      # Cloudflare Error 1014 (CNAME cross-user banned).
+      - --default-targets=ottawa.rajsingh.info
+      - --force-default-targets
     policy: sync
     sources:
       - gateway-httproute


### PR DESCRIPTION
## Problem
The `public` gateway sets a single external-dns target (`ottawa.keiretsu.top`) for **every** hostname it serves. For any non-keiretsu zone (rajsingh.info, killinit.cc, lukehouge.com) that produces a **cross-account CNAME**, which Cloudflare rejects with **Error 1014 (CNAME Cross-User Banned)** — exactly what `trades.rajsingh.info` hit.

## Fix
Give each per-domain external-dns instance its own same-account target:

```
- --default-targets=ottawa.<domain>
- --force-default-targets
```

So every public hostname resolves to `ottawa.<its-own-domain>` (each a ddns-maintained A record in that zone's own Cloudflare account) instead of inheriting the cross-account keiretsu.top default. Verified each target resolves: rajsingh/lukehouge/keiretsu → home IP, killinit → its own CF proxy.

The keiretsu-top external-dns is CRD-only (doesn't watch gateway routes) and is untouched. Also drops the now-redundant per-route target override on the trades HTTPRoute, since this handles it centrally for all domains.