### PR TITLE
feat(strimzi): adopt robbinsdale/strimzi to kubernetes/ tree

### DIFF
--- a/kubernetes/apps/base/strimzi/strimzi/certificate.yaml
+++ b/kubernetes/apps/base/strimzi/strimzi/certificate.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kafka-raj-tls
+spec:
+  secretName: kafka-raj-tls
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  usages:
+  - server auth
+  - client auth
+  dnsNames:
+  - '*.kafka.k8s.rajsingh.info'
+  issuerRef:
+    name: rajsingh-info
+    kind: ClusterIssuer 

--- a/kubernetes/apps/base/strimzi/strimzi/cluster.yaml
+++ b/kubernetes/apps/base/strimzi/strimzi/cluster.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: robbinsdale
+  annotations:
+    strimzi.io/kraft: enabled
+    strimzi.io/node-pools: enabled
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    authorization:
+      type: simple
+    listeners:
+    - authentication:
+        type: scram-sha-512
+      configuration:
+        brokerCertChainAndKey:
+          certificate: tls.crt
+          key: tls.key
+          secretName: kafka-raj-tls
+        brokers:
+        - advertisedHost: broker-10.kafka.k8s.rajsingh.info
+          advertisedPort: 9092
+          broker: 10
+        - advertisedHost: broker-11.kafka.k8s.rajsingh.info
+          advertisedPort: 9092
+          broker: 11
+        - advertisedHost: broker-12.kafka.k8s.rajsingh.info
+          advertisedPort: 9092
+          broker: 12
+        createBootstrapService: true
+      name: raj
+      port: 9092
+      tls: true
+      type: cluster-ip
+    version: 3.7.1 

--- a/kubernetes/apps/base/strimzi/strimzi/helmrelease.yaml
+++ b/kubernetes/apps/base/strimzi/strimzi/helmrelease.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: strimzi-kafka-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: strimzi-kafka-operator
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: strimzi
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    watchAnyNamespace: true
+    generateNetworkPolicy: false 

--- a/kubernetes/apps/base/strimzi/strimzi/kustomization.yaml
+++ b/kubernetes/apps/base/strimzi/strimzi/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: strimzi
+resources:
+  - helmrelease.yaml
+  - certificate.yaml
+  - tlsroute.yaml
+  - cluster.yaml
+  - nodepool.yaml 

--- a/kubernetes/apps/base/strimzi/strimzi/nodepool.yaml
+++ b/kubernetes/apps/base/strimzi/strimzi/nodepool.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  annotations:
+    strimzi.io/next-node-ids: "[10-100]"
+  labels:
+    strimzi.io/cluster: robbinsdale
+  name: broker
+spec:
+  replicas: 2
+  roles:
+    - broker
+  storage:
+    class: ceph-block-replicated
+    size: 10G
+    type: persistent-claim
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  annotations:
+    strimzi.io/next-node-ids: "[0-9]"
+  labels:
+    strimzi.io/cluster: robbinsdale
+  name: controller
+spec:
+  replicas: 1
+  roles:
+    - controller
+  storage:
+    class: ceph-block-replicated
+    size: 10G
+    type: persistent-claim 

--- a/kubernetes/apps/base/strimzi/strimzi/tlsroute.yaml
+++ b/kubernetes/apps/base/strimzi/strimzi/tlsroute.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: robbinsdale-broker-10
+spec:
+  hostnames:
+  - broker-10.kafka.k8s.rajsingh.info
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: private # Assuming private gateway for Kafka
+    namespace: envoy-gateway-system
+    sectionName: kafka-listener
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: robbinsdale-broker-raj-10
+      port: 9092
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: robbinsdale-broker-11
+spec:
+  hostnames:
+  - broker-11.kafka.k8s.rajsingh.info
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: private # Assuming private gateway for Kafka
+    namespace: envoy-gateway-system
+    sectionName: kafka-listener
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: robbinsdale-broker-raj-11
+      port: 9092
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: robbinsdale-broker-12
+spec:
+  hostnames:
+  - broker-12.kafka.k8s.rajsingh.info
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: private # Assuming private gateway for Kafka
+    namespace: envoy-gateway-system
+    sectionName: kafka-listener
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: robbinsdale-broker-raj-12
+      port: 9092
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: robbinsdale-bootstrap
+spec:
+  hostnames:
+  - bootstrap.kafka.k8s.rajsingh.info
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: private # Assuming private gateway for Kafka
+    namespace: envoy-gateway-system
+    sectionName: kafka-listener
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: robbinsdale-kafka-raj-bootstrap
+      port: 9092 

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -34,3 +34,4 @@ resources:
   - ./open-cluster-management-agent
   - ./snapshot-controller
   - ./media
+  - ./strimzi

--- a/kubernetes/apps/robbinsdale/strimzi/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/strimzi/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - strimzi.yaml

--- a/kubernetes/apps/robbinsdale/strimzi/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/strimzi/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: strimzi
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled 

--- a/kubernetes/apps/robbinsdale/strimzi/strimzi.yaml
+++ b/kubernetes/apps/robbinsdale/strimzi/strimzi.yaml
@@ -1,0 +1,19 @@
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app strimzi
+#   namespace: flux-system
+# spec:
+#   targetNamespace: strimzi
+#   commonMetadata:
+#     labels:
+#       app.kubernetes.io/name: *app
+#   path: ./kubernetes/apps/base/strimzi/strimzi
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: kubernetes-manifests
+#   interval: 30m
+#   retryInterval: 1m
+#   timeout: 10m # Increased timeout for Kafka operator and cluster 


### PR DESCRIPTION
## summary

PR-A for the robbinsdale strimzi wave-C migration (issue #1553).

- verbatim copy `clusters/talos-robbinsdale/apps/strimzi/app` → `kubernetes/apps/base/strimzi/strimzi/`
- pointer file at `kubernetes/apps/robbinsdale/strimzi/strimzi.yaml` — all-commented (descheduled CR), spec.path updated in comment
- namespace.yaml moved to location tree, `prune: disabled` label preserved
- listed in `kubernetes/apps/robbinsdale/kustomization.yaml`

## what moves

0 live Flux KS CRs — strimzi is descheduled (ks.yaml fully commented). Dir moved anyway per fleet/keiretsu precedent. No adoption verify possible.

6 app files: helmrelease, certificate, tlsroute, cluster, nodepool, kustomization.

## verification

- no live CR to byte-check (flate: "no Kustomization named strimzi")
- `make test` ×3: all 223 passed

## next

PR-B removes `clusters/talos-robbinsdale/apps/strimzi/` — no live reconcile to verify, just confirm CR count unchanged.

closes part of #1553