### PR TITLE
migrate(wave-e/cluster-home): adopt home-apps-ottawa, lan, home-apps (PR-A)

### DIFF
--- a/kubernetes/apps/base/home/home-ottawa/frigate/configmap.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/configmap.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frigate-config
+  namespace: home
+  labels:
+    app: frigate
+data:
+  config.yml: |
+    mqtt:
+      enabled: false
+
+    auth:
+      enabled: false
+
+    ffmpeg:
+      path: "7.0"
+      hwaccel_args: preset-vaapi
+
+    detectors:
+      cpu1:
+        type: cpu
+
+    go2rtc:
+      webrtc:
+        candidates:
+          - "frigate.${CLUSTER_DOMAIN}:8555"
+          - "stun:8555"
+      streams:
+        ottawa_cam:
+          - rtspx://192.168.169.1:7441/YgigQ2PzZ1QwPCHW#backchannel=0
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f alaw -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.66:7004#backchannel=1#audio=pcma/8000
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f mulaw -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.66:7004#backchannel=1#audio=pcmu/8000
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f s16le -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.66:7004#backchannel=1#audio=pcml/8000
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f s16be -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.66:7004#backchannel=1#audio=pcm/8000
+        kitchen_cam:
+          - rtspx://192.168.169.1:7441/VZouUKvu0Acus3hO#backchannel=0
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f alaw -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.64:7004#backchannel=1#audio=pcma/8000
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f mulaw -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.64:7004#backchannel=1#audio=pcmu/8000
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f s16le -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.64:7004#backchannel=1#audio=pcml/8000
+          - exec:/usr/lib/ffmpeg/7.0/bin/ffmpeg -re -fflags nobuffer -f s16be -ar 8000 -i - -vn -acodec libopus -b:a 32k -f rtp rtp://192.168.169.64:7004#backchannel=1#audio=pcm/8000
+
+    cameras:
+      ottawa_cam:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/ottawa_cam
+              input_args: preset-rtsp-restream
+              roles:
+                - detect
+        detect:
+          enabled: false
+          width: 1280
+          height: 720
+        record:
+          enabled: false
+        snapshots:
+          enabled: false
+      kitchen_cam:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/kitchen_cam
+              input_args: preset-rtsp-restream
+              roles:
+                - detect
+        detect:
+          enabled: false
+          width: 1280
+          height: 720
+        record:
+          enabled: false
+        snapshots:
+          enabled: false
+
+    version: 0.17-0

--- a/kubernetes/apps/base/home/home-ottawa/frigate/deployment.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/deployment.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frigate
+  namespace: home
+  labels:
+    app: frigate
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: frigate
+  template:
+    metadata:
+      labels:
+        app: frigate
+    spec:
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: frigate-gpu
+      initContainers:
+        - name: seed-config
+          image: ghcr.io/blakeblackshear/frigate:stable-rocm
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              cp -f /config-template/config.yml /config/config.yml
+              mkdir -p /config/model_cache /config/exports /config/recordings
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: config-template
+              mountPath: /config-template
+      containers:
+        - name: frigate
+          image: ghcr.io/blakeblackshear/frigate:stable-rocm
+          resources:
+            claims:
+              - name: gpu
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              memory: 8Gi
+          env:
+            - name: TZ
+              value: ${TIMEZONE}
+            - name: LIBVA_DRIVER_NAME
+              value: radeonsi
+            - name: GO2RTC_ALLOW_ARBITRARY_EXEC
+              value: "true"
+          ports:
+            - containerPort: 5000
+              name: http
+            - containerPort: 8554
+              name: rtsp
+            - containerPort: 8555
+              name: webrtc-tcp
+              protocol: TCP
+            - containerPort: 8555
+              name: webrtc-udp
+              protocol: UDP
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: media
+              mountPath: /media/frigate
+            - name: dshm
+              mountPath: /dev/shm
+            - name: cache
+              mountPath: /tmp/cache
+        - name: talkback-keepalive
+          image: ghcr.io/blakeblackshear/frigate:stable-rocm
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -u
+              while true; do
+                CAMERAS=$(curl -ks -X GET "https://$${UNIFI_PROTECT_HOST}/proxy/protect/integration/v1/cameras" \
+                  -H "X-API-KEY: $${UNIFI_PROTECT_API_KEY}" -H "Accept: application/json" \
+                  | jq -r '.[] | "\(.id) \(.name)"')
+                if [ -z "$${CAMERAS}" ]; then
+                  echo "$(date -u +%FT%TZ) ERROR: no cameras returned from Protect API"
+                else
+                  echo "$${CAMERAS}" | while read -r CAM_ID CAM_NAME; do
+                    [ -z "$${CAM_ID}" ] && continue
+                    RESP=$(curl -ks -X POST "https://$${UNIFI_PROTECT_HOST}/proxy/protect/integration/v1/cameras/$${CAM_ID}/talkback-session" \
+                      -H "X-API-KEY: $${UNIFI_PROTECT_API_KEY}" -H "Accept: application/json")
+                    echo "$(date -u +%FT%TZ) talkback-session $${CAM_NAME} ($${CAM_ID}): $${RESP}"
+                  done
+                fi
+                sleep 300
+              done
+          env:
+            - name: UNIFI_PROTECT_HOST
+              value: "192.168.169.1"
+            - name: UNIFI_PROTECT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: frigate-unifi-talkback
+                  key: UNIFI_PROTECT_API_KEY
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: frigate-config
+        - name: config-template
+          configMap:
+            name: frigate-config
+        - name: media
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        - name: cache
+          emptyDir:
+            sizeLimit: 5Gi

--- a/kubernetes/apps/base/home/home-ottawa/frigate/httproute.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/httproute.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frigate
+  namespace: home
+  annotations:
+    item.homer.rajsingh.info/name: "Frigate"
+    item.homer.rajsingh.info/subtitle: "NVR"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/frigate.svg"
+    item.homer.rajsingh.info/keywords: "nvr, cameras, surveillance, protect"
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-video"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "frigate.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: frigate
+          port: 5000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home/home-ottawa/frigate/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - ./resourceclaimtemplate.yaml
+  - ./pvc.yaml
+  - ./configmap.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./httproute.yaml
+  - ./securitypolicy.yaml
+  - ./oidc-secret.yaml
+  - ./unifi-talkback-secret.yaml
+  - ./webrtc-routes.yaml

--- a/kubernetes/apps/base/home/home-ottawa/frigate/oidc-secret.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/oidc-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frigate-oidc-secret
+  namespace: home
+type: Opaque
+stringData:
+  client-secret: "${ENVOY_GATEWAY_OIDC_CLIENT_SECRET}"

--- a/kubernetes/apps/base/home/home-ottawa/frigate/pvc.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-config
+  namespace: home
+  labels:
+    app: frigate
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block-replicated

--- a/kubernetes/apps/base/home/home-ottawa/frigate/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/resourceclaimtemplate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: frigate-gpu
+  namespace: home
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.amd.com

--- a/kubernetes/apps/base/home/home-ottawa/frigate/securitypolicy.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/securitypolicy.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: frigate-oidc
+  namespace: home
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: frigate
+  oidc:
+    provider:
+      issuer: "https://pocket-id.keiretsu.top"
+    clientID: "${ENVOY_GATEWAY_OIDC_CLIENT_ID}"
+    clientSecret:
+      name: frigate-oidc-secret
+    redirectURL: "https://frigate.${CLUSTER_DOMAIN}/oauth2/callback"
+    logoutPath: "/logout"
+    cookieDomain: "${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/base/home/home-ottawa/frigate/service.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/service.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frigate
+  namespace: home
+  labels:
+    app: frigate
+spec:
+  selector:
+    app: frigate
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000
+    - name: rtsp
+      port: 8554
+      targetPort: 8554
+    - name: webrtc-tcp
+      port: 8555
+      targetPort: 8555
+      protocol: TCP
+    - name: webrtc-udp
+      port: 8555
+      targetPort: 8555
+      protocol: UDP

--- a/kubernetes/apps/base/home/home-ottawa/frigate/unifi-talkback-secret.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/unifi-talkback-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frigate-unifi-talkback
+  namespace: home
+type: Opaque
+stringData:
+  UNIFI_PROTECT_API_KEY: "${UNIFI_PROTECT_API_KEY}"

--- a/kubernetes/apps/base/home/home-ottawa/frigate/webrtc-routes.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/webrtc-routes.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: frigate-webrtc-tcp
+  namespace: home
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+      sectionName: webrtc-tcp
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: frigate
+          port: 8555
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: frigate-webrtc-udp
+  namespace: home
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+      sectionName: webrtc-udp
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: frigate
+          port: 8555

--- a/kubernetes/apps/base/home/home-ottawa/home-assistant/configmap.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/home-assistant/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homeassistant-http-config
+  namespace: home
+data:
+  configuration.yaml: |
+    # Loads default set of integrations. Do not remove.
+    default_config:
+
+    # Load frontend themes from the themes folder
+    frontend:
+      themes: !include_dir_merge_named themes
+
+    # Text to speech
+    tts:
+      - platform: google_translate
+
+    automation: !include automations.yaml
+    script: !include scripts.yaml
+    scene: !include scenes.yaml
+
+    http:
+      use_x_forwarded_for: true
+      trusted_proxies:
+        - 10.0.0.0/8
+        - 172.16.0.0/12

--- a/kubernetes/apps/base/home/home-ottawa/home-assistant/deployment.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/home-assistant/deployment.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homeassistant
+  namespace: home
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: homeassistant
+  template:
+    metadata:
+      labels:
+        app: homeassistant
+    spec:
+      hostNetwork: true
+      containers:
+      - name: homeassistant
+        image: homeassistant/home-assistant:2026.6
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "pip install pyalarmdotcomajax"]
+        env:
+        - name: TZ
+          value: ${TIMEZONE}
+        ports:
+          - containerPort: 8123
+          - containerPort: 5353
+          - containerPort: 21084
+          - containerPort: 51827
+        volumeMounts:
+          - mountPath: /config
+            name: homeassistant-config
+          - mountPath: /config/http-config.yaml
+            name: homeassistant-http-config
+            subPath: configuration.yaml
+      restartPolicy: Always
+      volumes:
+        - name: homeassistant-config
+          persistentVolumeClaim:
+            claimName: homeassistant-config
+        - name: homeassistant-http-config
+          configMap:
+            name: homeassistant-http-config

--- a/kubernetes/apps/base/home/home-ottawa/home-assistant/httproute.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/home-assistant/httproute.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homeassistant
+  namespace: home
+  annotations:
+    item.homer.rajsingh.info/name: "Home Assistant"
+    item.homer.rajsingh.info/subtitle: "Smart Home Hub"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/home-assistant.svg"
+    item.homer.rajsingh.info/keywords: "smart home, automation, iot"
+
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-home"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "homeassistant.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: homeassistant
+          port: 8123
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home/home-ottawa/home-assistant/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/home-assistant/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - ./pvc.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/base/home/home-ottawa/home-assistant/pvc.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/home-assistant/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homeassistant-config
+  namespace: home
+  labels:
+    app: homeassistant
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: ceph-block-replicated

--- a/kubernetes/apps/base/home/home-ottawa/home-assistant/service.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/home-assistant/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: homeassistant
+  namespace: home
+spec:
+  selector:
+    app: homeassistant
+  ports:
+  - name: homeassistant-web
+    port: 8123
+    targetPort: 8123
+  - name: homekit-udp
+    port: 5353
+    targetPort: 5353
+  - name: homekit-tcp
+    port: 21084
+    targetPort: 21084
+  type: LoadBalancer
+  loadBalancerIP: 10.169.10.13

--- a/kubernetes/apps/base/home/home-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: home
 resources:
-  - ./namespace.yaml
-  - ./grafana-redirect.yaml
-  - ./home-robbinsdale.yaml
+  - ./home-assistant
+  - ./frigate

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/app.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/app.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frigate
+  labels:
+    app: frigate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frigate
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: frigate
+    spec:
+      containers:
+        - name: frigate
+          image: ghcr.io/blakeblackshear/frigate:0.15.0-beta5
+          ports:
+            - name: web
+              containerPort: 8971
+            - name: rtsp
+              containerPort: 8554
+            - name: stream-8555-tcp
+              containerPort: 8555
+              protocol: TCP
+            - name: stream-8555-udp
+              containerPort: 8555
+              protocol: UDP
+            - name: internal
+              containerPort: 5000
+          resources:
+            limits:
+              memory: "16Gi"
+              cpu: "8"
+            requests:
+              memory: "8Gi"
+              cpu: "4"
+          volumeMounts:
+            - name: storage
+              mountPath: /media/frigate
+            - name: config
+              mountPath: /config
+            - name: dshm
+              mountPath: /dev/shm
+            - name: cache
+              mountPath: /tmp/cache/
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: frigate-data-unas
+        - name: config
+          persistentVolumeClaim:
+            claimName: frigate-config-ceph
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        - name: cache
+          emptyDir:
+            sizeLimit: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frigate
+  labels:
+    app: frigate
+spec:
+  selector:
+    app: frigate
+  ports:
+    - name: web
+      port: 443
+      targetPort: 8971
+    - name: rtsp
+      port: 8554
+      targetPort: 8554
+    - name: stream-8555-tcp
+      port: 8555
+      targetPort: 8555
+      protocol: TCP
+    - name: stream-8555-udp
+      port: 8555
+      targetPort: 8555
+      protocol: UDP
+    - name: internal
+      port: 5000
+      targetPort: 5000
+  type: ClusterIP

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/certificate.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/certificate.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: frigate-luke-tls
+  namespace: home
+spec:
+  dnsNames:
+    - frigate.${CLUSTER_DOMAIN}
+    - frigate-tunnel.${CLUSTER_DOMAIN}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: ${CLUSTER_DOMAIN//./-}
+  secretName: frigate-luke-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/frigate-config-backup.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/frigate-config-backup.yaml
@@ -1,0 +1,523 @@
+mqtt:
+  host: 10.50.10.11
+  port: 1883
+  user: lhouge
+  password: applegeek
+###################################################################################################################################################
+# CAMERAS
+# 
+# 4K / 8MP
+#   ⁠garage - 3840x2160 (8.29MP, 16:9)
+#   ⁠alley back - 3840x2160 (8.29MP, 16:9)
+# 6MP
+#   ⁠house side - 3072x2048 (6.39MP, 3:2)
+#   ⁠backyard back - 3072x2048 (6.39MP, 3:2)
+#   ⁠front door - 3072x2048 (6.39MP, 3:2)
+# 2K / 4MP
+#   ⁠driveway - 2688x1520 (4.09MP, 16:9)
+#   ⁠alley front - 2688x1520 (4.09MP, 16:9)
+#   ⁠backyard - 2688x1520 (4.09MP, 16:9)
+#   ⁠backyard front - 2688x1520 (4.09MP, 16:9)
+#   ⁠shop 1&2- 2688x1520 (4.09MP, 16:9)
+###################################################################################################################################################
+go2rtc:
+  streams:
+    alley_front:
+      - rtsp://frigate:Applegeek1@192.168.50.247:554/Streaming/Channels/1
+    alley_front_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.247:554/Streaming/Channels/2
+    alley_back:
+      - rtsp://frigate:Applegeek1@192.168.50.246:554/Streaming/Channels/1
+    alley_back_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.246:554/Streaming/Channels/2
+    backyard:
+      - rtsp://frigate:Applegeek1@192.168.50.249:554/Streaming/Channels/1
+    backyard_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.249:554/Streaming/Channels/2
+    house_side:
+      - rtsp://frigate:Applegeek1@192.168.50.252:554/Streaming/Channels/1
+    house_side_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.252:554/Streaming/Channels/2
+    driveway:
+      - rtsp://frigate:Applegeek1@192.168.50.8:554/Streaming/Channels/1
+    driveway_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.8:554/Streaming/Channels/2
+    backyard_front:
+      - rtsp://frigate:Applegeek1@192.168.50.88:554/Streaming/Channels/1
+    backyard_front_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.88:554/Streaming/Channels/2
+    garage:
+      - rtsp://frigate:Applegeek1@192.168.50.237:554/Streaming/Channels/1
+    garage_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.237:554/Streaming/Channels/2
+    backyard_back:
+      - rtsp://frigate:Applegeek1@192.168.50.60:554/Streaming/Channels/1
+    backyard_back_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.60:554/Streaming/Channels/2
+    front_door:
+      - rtsp://frigate:Applegeek1@192.168.50.42:554/Streaming/Channels/1
+    front_door_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.42:554/Streaming/Channels/2
+    shop_1:
+      - rtsp://frigate:Applegeek1@192.168.50.250:554/Streaming/Channels/1
+    shop_1_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.250:554/Streaming/Channels/2
+    shop_2:
+      - rtsp://frigate:Applegeek1@192.168.50.251:554/Streaming/Channels/1
+    shop_2_sub:
+      - rtsp://frigate:Applegeek1@192.168.50.251:554/Streaming/Channels/2
+cameras:
+  alley_front:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/alley_front
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/alley_front_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 9
+    live:
+      stream_name: alley_front
+    zones:
+      alley:
+        coordinates: 0,0,0.539,0,0.542,0.115,0.621,0.111,0.619,0,1,0,1,1,0,1
+        loitering_time: 0
+    review:
+      alerts:
+        required_zones: alley
+    objects:
+      filters:
+        cat:
+          mask: 0.104,0.869,0.33,0.866,0.329,0.982,0.102,0.977
+        dog:
+          mask: 0.103,0.863,0.332,0.863,0.332,0.981,0.102,0.978
+  alley_back:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/alley_back
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/alley_back_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 10
+    live:
+      stream_name: alley_back
+    zones:
+      alley:
+        coordinates: 0.54,0.004,0.587,0.307,0.663,0.305,0.755,0.439,0.723,0.005,1,0,1,1,0,1,0,0
+        loitering_time: 0
+    review:
+      alerts:
+        required_zones: alley
+  backyard:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/backyard
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/backyard_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 5
+    live:
+      stream_name: backyard
+    zones:
+      yard:
+        coordinates: 
+          0.004,0.425,0.087,0.327,0.192,0.187,0.296,0.104,0.372,0.044,0.431,0.021,0.514,0.019,0.648,0.021,0.662,0,1,0,1,1,0,1
+        loitering_time: 0
+    review:
+      alerts:
+        required_zones: yard
+  house_side:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/house_side
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/house_side_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 1
+    live:
+      stream_name: house_side
+    review:
+      detections:
+        labels:
+          - cat
+          - dog
+          - person
+      alerts:
+        labels:
+          - cat
+          - dog
+          - person
+  shop_1:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/shop_1
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    objects:
+      track: []
+    ui:
+      order: 8
+    live:
+      stream_name: shop_2
+  shop_2:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/shop_2
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    objects:
+      track: []
+    ui:
+      order: 7
+    live:
+      stream_name: shop_2
+  driveway:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/driveway
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/driveway_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 0
+    live:
+      stream_name: driveway
+    zones:
+      not_road:
+        coordinates: 
+          0.205,0,0.211,0.139,0.316,0.109,0.444,0.091,0.616,0.083,0.752,0.099,0.755,0,1,0,1,1,0,1,0,0
+        inertia: 3
+        loitering_time: 0
+        objects:
+          - cat
+          - dog
+          - person
+          - suitecase
+      # car_valid:
+      #   coordinates: 0.216,0.149,0,0.491,0,1,0.456,1,0.49,0.109
+      #   loitering_time: 1
+      #   objects:
+      #     - car
+      #     - bus
+      #   inertia: 10
+    review:
+      alerts:
+        required_zones:
+          # - car_valid
+          - not_road
+  backyard_front:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/backyard_front
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/backyard_front_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 4
+    live:
+      stream_name: backyard_front
+    zones:
+      yard:
+        coordinates: 
+          0.421,0.21,0.581,0.185,0.744,0.176,0.904,0.194,0.999,0.221,1,1,0,1,0,0,0.351,0.005,0.355,0.051,0.409,0.093
+        loitering_time: 0
+    review:
+      alerts:
+        required_zones: yard
+  garage:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/garage
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/garage_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 3
+    live:
+      stream_name: garage
+    review:
+      detections:
+        labels:
+          - cat
+          - dog
+          - person
+      alerts:
+        labels:
+          - cat
+          - dog
+          - person
+  backyard_back:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/backyard_back
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/backyard_back_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 6
+    live:
+      stream_name: backyard_back
+    zones:
+      yard:
+        coordinates: 
+          0.007,0.336,0.218,0.211,0.391,0.139,0.509,0.112,0.57,0.09,0.602,0.039,0.64,0.032,0.675,0.056,0.677,0.084,0.761,0.095,0.829,0.096,0.885,0.104,0.927,0.111,0.932,0.042,1,0,1,1,0,1
+        loitering_time: 0
+    review:
+      alerts:
+        required_zones: yard
+  front_door:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/front_door
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/front_door_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: True
+      retain:
+        days: 10
+        mode: all
+      events:
+        retain:
+          default: 30
+          mode: motion
+    ui:
+      order: 2
+    review:
+      alerts:
+        required_zones:
+          - front_yard
+    zones:
+      front_yard:
+        coordinates: 0,0,0,1,1,1,1,0.495,0.763,0.29,0.471,0.099,0.474,0
+    live:
+      stream_name: front_door
+birdseye:
+  restream: true
+# Optional: Object configuration
+# NOTE: Can be overridden at the camera level
+objects:
+  # Optional: list of objects to track from labelmap.txt (default: shown below)
+  track:
+    - person
+    # - car
+    - bus
+    - cat
+    - dog
+    - suitecase
+  filters:
+    person:
+      threshold: 0.70
+# Optional
+ui:
+  # Optional: Set the default live mode for cameras in the UI (default: shown below)
+  # live_mode: mse
+  # Optional: Set a timezone to use in the UI (default: use browser local time)
+  # timezone: None
+  # Optional: Use an experimental recordings / camera view UI (default: shown below)
+  # use_experimental: true
+  # Optional: Set the time format used.
+  # Options are browser, 12hour, or 24hour (default: shown below)
+  time_format: 12hour
+  # Optional: Set the date style for a specified length.
+  # Options are: full, long, medium, sort
+  # Examples:
+  #    short: 2/11/23
+  #    medium: Feb 11, 2023
+  #    full: Saturday, February 11, 2023
+  # (default: shown below).
+  date_style: full
+  # Optional: Set the time style for a specified length.
+  # Options are: full, long, medium, sort
+  # Examples:
+  #    short: 8:14 PM
+  #    medium: 8:15:22 PM
+  #    full: 8:15:22 PM Mountain Standard Time
+  # (default: shown below).
+  time_style: medium
+  # Optional: Ability to manually override the date / time styling to use strftime format
+  # https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html
+  # possible values are shown above (default: not set)
+  # strftime_fmt: "%Y/%m/%d %H:%M"
+# Optional: Configuration for the jpg snapshots written to the clips directory for each event
+# NOTE: Can be overridden at the camera level
+snapshots:
+  # Optional: Enable writing jpg snapshot to /media/frigate/clips (default: shown below)
+  enabled: true
+  # Optional: save a clean PNG copy of the snapshot image (default: shown below)
+  clean_copy: true
+  # Optional: print a timestamp on the snapshots (default: shown below)
+  timestamp: true
+  # Optional: draw bounding box on the snapshots (default: shown below)
+  bounding_box: true
+  # Optional: crop the snapshot (default: shown below)
+  crop: false
+  # Optional: height to resize the snapshot to (default: original size)
+  # height: 175
+  # Optional: Restrict snapshots to objects that entered any of the listed zones (default: no required zones)
+  # required_zones: []
+  # Optional: Camera override for retention settings (default: global values)
+  # retain:
+    # Required: Default retention days (default: shown below)
+    # default: 10
+    # Optional: Per object retention days
+    # objects:
+      # person: 15
+  # Optional: quality of the encoded jpeg, 0-100 (default: shown below)
+  quality: 70
+version: 0.14
+camera_groups:
+  Birdseye:
+    order: 1
+    icon: LuEye
+    cameras: birdseye
+  All:
+    order: 2
+    icon: LuGalleryVertical
+    cameras:
+      - birdseye
+      - alley_back
+      - alley_front
+      - backyard
+      - backyard_back
+      - backyard_front
+      - driveway
+      - garage
+      - front_door
+      - house_side
+      - shop_1
+      - shop_2
+logger:
+  logs:
+    frigate.record.maintainer: debug

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/httproute.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/httproute.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frigate
+  namespace: home
+  annotations:
+    item.homer.rajsingh.info/name: "Frigate"
+    item.homer.rajsingh.info/subtitle: "Camera Dashboard"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/frigate.svg"
+    item.homer.rajsingh.info/keywords: "frigate, camera, dashboard"
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-home"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+      sectionName: wildcard-lukehouge-com-https
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+      sectionName: wildcard-lukehouge-com-https
+  hostnames:
+    - "frigate.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: frigate
+          port: 5000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - app.yaml
+  - pvc.yaml
+  - storagestack.yaml
+  - httproute.yaml

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/pvc.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/pvc.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: smb.csi.k8s.io
+  name: frigate-data-unas
+spec:
+  capacity:
+    storage: 2Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: smb-server.default.svc.cluster.local/k8s_shortsnap/home/frigate-data
+    volumeAttributes:
+      source: //192.168.50.115/k8s_shortsnap/home/frigate-data
+    nodeStageSecretRef:
+      name: csi-smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-data-unas
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Ti
+  volumeName: frigate-data-unas
+  storageClassName: smb
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: smb.csi.k8s.io
+  name: frigate-config-unas
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: smb-server.default.svc.cluster.local/k8s_shortsnap/home/frigate-config
+    volumeAttributes:
+      source: //192.168.50.115/k8s_shortsnap/home/frigate-config
+    nodeStageSecretRef:
+      name: csi-smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-config-unas
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: frigate-config-unas
+  storageClassName: smb

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/storagestack.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/storagestack.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: frigate-config-ceph
+  namespace: home
+  labels:
+    keiretsu.ts.net/location: robbinsdale
+spec:
+  name: frigate-config-ceph
+  size: 100Gi
+  storageClass: ceph-block-replicated-nvme
+  s3Path: home/frigate-config
+  schedule: "0 5 * * *"
+  restorePaused: false
+  copyMethod: Snapshot

--- a/kubernetes/apps/base/home/home-robbinsdale/home-assistant/app.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/home-assistant/app.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homeassistant
+  namespace: home
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: homeassistant
+  template:
+    metadata:
+      labels:
+        app: homeassistant
+    spec:
+      hostNetwork: true
+      containers:
+        - name: homeassistant
+          image: homeassistant/home-assistant:2026.6
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "pip install pyalarmdotcomajax"]
+          env:
+            - name: TZ
+              value: ${TIMEZONE}
+          ports:
+            - containerPort: 8123
+            - containerPort: 5353
+            - containerPort: 21084
+            - containerPort: 51827
+          volumeMounts:
+            - mountPath: /config
+              name: homeassistant-config
+      restartPolicy: Always
+      volumes:
+        - name: homeassistant-config
+          persistentVolumeClaim:
+            claimName: homeassistant-config-ceph
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: homeassistant
+  namespace: home
+spec:
+  selector:
+    app: homeassistant
+  ports:
+    - name: homeassistant-web
+      port: 8123
+      targetPort: 8123
+    - name: homekit-udp
+      port: 5353
+      targetPort: 5353
+    - name: homekit-tcp
+      port: 21084
+      targetPort: 21084
+  type: LoadBalancer
+  loadBalancerIP: 10.50.10.13

--- a/kubernetes/apps/base/home/home-robbinsdale/home-assistant/httproute.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/home-assistant/httproute.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homeassistant
+  namespace: home
+  annotations:
+    item.homer.rajsingh.info/name: "Home Assistant"
+    item.homer.rajsingh.info/subtitle: "Smart Home Hub"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/home-assistant.svg"
+    item.homer.rajsingh.info/keywords: "smart home, automation, iot"
+
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-home"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "homeassistant.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: homeassistant
+          port: 8123
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home/home-robbinsdale/home-assistant/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/home-assistant/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - app.yaml
+  - pvc.yaml
+  - httproute.yaml
+  - storagestack.yaml

--- a/kubernetes/apps/base/home/home-robbinsdale/home-assistant/pvc.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/home-assistant/pvc.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: smb.csi.k8s.io
+  name: homeassistant-config-unas
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: smb-server.default.svc.cluster.local/k8s_shortsnap/home/homeassistant-config
+    volumeAttributes:
+      source: //192.168.50.115/k8s_shortsnap/home/homeassistant-config
+    nodeStageSecretRef:
+      name: csi-smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homeassistant-config-unas
+  namespace: home
+  labels:
+    app: homeassistant
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: homeassistant-config-unas
+  storageClassName: smb

--- a/kubernetes/apps/base/home/home-robbinsdale/home-assistant/storagestack.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/home-assistant/storagestack.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: storage.keiretsu.ts.net/v1alpha1
+kind: StorageStack
+metadata:
+  name: homeassistant-config-ceph
+  namespace: home
+  labels:
+    keiretsu.ts.net/location: robbinsdale
+spec:
+  name: homeassistant-config-ceph
+  size: 50Gi
+  storageClass: ceph-block-replicated-nvme
+  s3Path: home/homeassistant-config
+  schedule: "0 12 * * *"
+  restorePaused: false
+  restorePrevious: 1
+  copyMethod: Snapshot

--- a/kubernetes/apps/base/home/home-robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/kustomization.yaml
@@ -1,7 +1,9 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: home
 resources:
-  - ./namespace.yaml
-  - ./grafana-redirect.yaml
-  - ./home-robbinsdale.yaml
+  - ./frigate
+  - ./mqtt
+  - ./home-assistant
+  - probes.yaml

--- a/kubernetes/apps/base/home/home-robbinsdale/mqtt/ceph.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/mqtt/ceph.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mqtt-data-ceph
+  namespace: home
+  labels:
+    app: mqtt
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block-replicated-nvme 

--- a/kubernetes/apps/base/home/home-robbinsdale/mqtt/deployment.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/mqtt/deployment.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mqtt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mqtt
+  template:
+    metadata:
+      labels:
+        app: mqtt
+    spec:
+      containers:
+      - name: mosquitto
+        image: eclipse-mosquitto
+        command: ['sh', '-c', 'mosquitto -c /etc/mosquitto/mosquitto.conf']
+        ports:
+        - containerPort: 1883
+        volumeMounts:
+        - mountPath: /etc/mosquitto/
+          name: config
+        - mountPath: /mosquitto/data/
+          name: data
+      volumes:
+      - name: config
+        configMap:
+          name: mqtt-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: mqtt-data-ceph

--- a/kubernetes/apps/base/home/home-robbinsdale/mqtt/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/mqtt/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ceph.yaml
+configMapGenerator:
+  - name: mqtt-config
+    files:
+    - mosquitto.conf

--- a/kubernetes/apps/base/home/home-robbinsdale/mqtt/mosquitto.conf
+++ b/kubernetes/apps/base/home/home-robbinsdale/mqtt/mosquitto.conf
@@ -1,0 +1,5 @@
+persistence true
+persistence_location /mosquitto/data/
+log_dest stdout
+listener 1883
+allow_anonymous true

--- a/kubernetes/apps/base/home/home-robbinsdale/mqtt/service.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/mqtt/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mqtt
+spec:
+  selector:
+    app: mqtt
+  ports:
+    - name: mqtt
+      port: 1883
+      protocol: TCP
+      targetPort: 1883
+  type: LoadBalancer
+  loadBalancerIP: 10.50.10.11

--- a/kubernetes/apps/base/home/home-robbinsdale/probes.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/probes.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-home-services
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://frigate.home:5000
+        - http://homeassistant.home:8123
+      labels:
+        service: home-automation
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-home-pihole-dns
+spec:
+  jobName: blackbox
+  module: dns_a
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - ts-pihole-dns.home:53
+      labels:
+        service: pihole
+        target: dns

--- a/kubernetes/apps/base/lan/lan/externalname.yaml
+++ b/kubernetes/apps/base/lan/lan/externalname.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jetkvm
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "jetkvm"
+    tailscale.com/tag: "${LOCATION}"
+    tailscale.com/proxy-group: "common-ingress"
+spec:
+  type: ExternalName
+  externalName: jetkvm.killinit.internal
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80

--- a/kubernetes/apps/base/lan/lan/kustomization.yaml
+++ b/kubernetes/apps/base/lan/lan/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./grafana-redirect.yaml
-  - ./home-robbinsdale.yaml
+  - externalname.yaml

--- a/kubernetes/apps/ottawa/home/home-ottawa.yaml
+++ b/kubernetes/apps/ottawa/home/home-ottawa.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-apps-ottawa
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/ottawa/home/kustomization.yaml
+++ b/kubernetes/apps/ottawa/home/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./grafana-redirect.yaml
-  - ./home-robbinsdale.yaml
+  - ./home-ottawa.yaml

--- a/kubernetes/apps/ottawa/home/namespace.yaml
+++ b/kubernetes/apps/ottawa/home/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: home
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  annotations:
+    volsync.backube/privileged-movers: "true"

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ./gatus
   - ./gvisor
   - ./hermes
+  - ./home
   - ./homer-operator
   - ./immich
   - ./kener
@@ -37,3 +38,4 @@ resources:
   - ./open-cluster-management-agent
   - ./snapshot-controller
   - ./media
+  - ./lan

--- a/kubernetes/apps/ottawa/lan/kustomization.yaml
+++ b/kubernetes/apps/ottawa/lan/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./grafana-redirect.yaml
-  - ./home-robbinsdale.yaml
+  - ./lan.yaml

--- a/kubernetes/apps/ottawa/lan/lan.yaml
+++ b/kubernetes/apps/ottawa/lan/lan.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app lan
+  namespace: flux-system
+spec:
+  targetNamespace: lan
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/lan/lan
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  dependsOn:
+    - name: tailscale-operator-resources
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/lan/namespace.yaml
+++ b/kubernetes/apps/ottawa/lan/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lan
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/home/home-robbinsdale.yaml
+++ b/kubernetes/apps/robbinsdale/home/home-robbinsdale.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-apps
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: dragonfly-operator-system
+    - name: rook-ceph-cluster-config
+    - name: volsync
+  path: ./kubernetes/apps/base/home/home-robbinsdale
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## summary

PR-A of the wave-E cluster-specific home/lan migration.

Verbatim-copies three cluster-specific app dirs into the new `kubernetes/` tree and registers pointer files. No content changes — spec.path only, CR names preserved.

**dirs adopted:**
- `clusters/talos-ottawa/apps/home/app` → `kubernetes/apps/base/home/home-ottawa` (CR: `home-apps-ottawa`)
- `clusters/talos-ottawa/apps/lan/app` → `kubernetes/apps/base/lan/lan` (CR: `lan`)
- `clusters/talos-robbinsdale/apps/home/app` → `kubernetes/apps/base/home/home-robbinsdale` (CR: `home-apps`)

**verification:**
- `diff -r` on all three app dirs: no diff (byte-identical)
- `make test` ×3 clusters: 262+236+223 passed

**post-merge gates (per cluster where the CR runs):**
1. `kubectl get kustomization home-apps-ottawa -n flux-system` — label `kubernetes-apps`, new path
2. `kubectl get kustomization lan -n flux-system` — label `kubernetes-apps`, new path
3. `kubectl get kustomization home-apps -n flux-system` (robbinsdale) — label `kubernetes-apps`, new path
4. pod start times unchanged (frigate, home-assistant, mqtt)

PR-B (release from clusters/) to follow after reconcile confirms ownership.

closes part of #1553