### PR TITLE
migrate(wave-f/tailscale-examples): adopt tailscale-examples-sandbox into kubernetes/ tree (PR-A)

### DIFF
--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/certificate.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/certificate.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: common-derper-tls
+spec:
+  dnsNames:
+    - 'derp.${CLUSTER_DOMAIN}'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: common-issuer
+  secretName: common-derper-tls
+  usages:
+    - digital signature
+    - key encipherment 

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+  - certificate.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/secret.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: derper
+type: Opaque
+stringData:
+  TS_AUTHKEY: ${TS_AUTHKEY}

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/service.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: derper
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: derp.${CLUSTER_DOMAIN}
+spec:
+  ports:
+  - name: derp-http
+    port: 80
+    targetPort: 80
+  - name: derp-https
+    port: 443
+    targetPort: 443
+  - name: derp-stun
+    port: 3478
+    targetPort: 3478
+  selector:
+    app: derper

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/statefulset.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/statefulset.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: derper
+  namespace: tailscale
+  labels:
+    app.kubernetes.io/name: derper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: derper
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: derper
+    spec:
+      containers:
+      - name: derper
+        image: ghcr.io/erisa/ts-derper:latest
+        env:
+        - name: TS_DERP_HOSTNAME
+          value: "derp.${CLUSTER_DOMAIN}"
+        - name: TS_DERP_VERIFY_CLIENTS
+          value: "true"
+        - name: TS_DERP_CERTMODE
+          value: "letsencrypt"
+        - name: TS_DERP_HTTP_PORT
+          value: "80"
+        - name: TS_DERP_LISTEN_PORT
+          value: "443"
+        - name: TS_DERP_STUN_PORT
+          value: "3478"
+        - name: TS_RUN_TAILSCALE
+          value: "true"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: derper
+              key: TS_AUTHKEY
+        - name: TS_HOSTNAME
+          value: "derp-${LOCATION}"
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_ACCEPT_DNS
+          value: "false"
+        - name: TS_STATE_DIR
+          value: "/var/lib/tailscale"
+        - name: TS_AUTH_ONCE
+          value: "true"
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        - containerPort: 443
+          protocol: TCP
+        - containerPort: 3478
+          protocol: UDP
+        volumeMounts:
+        - name: certs
+          mountPath: /root/derper/${TS_DERP_HOSTNAME}
+        - name: tailscale-state
+          mountPath: /var/lib/tailscale
+      volumes:
+      - name: certs
+        secret:
+          secretName: common-derper-tls
+      - name: tailscale-state
+        emptyDir: {}
+      hostNetwork: false
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/egress/helmrelease.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/egress/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-egress
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: tailscale-egress
+      version: 0.0.0-latest
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale-k8s-operator-helper-charts
+        namespace: flux-system 
+      interval: 1m
+  releaseName: tailscale-egress
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    proxyGroup: "common-egress"
+    services:
+      - name: robbinsdale-k8s-operator
+        fqdn: robbinsdale-k8s-operator.keiretsu.ts.net
+        ports:
+          - port: 443
+            protocol: TCP
+      - name: ottawa-k8s-operator
+        fqdn: ottawa-k8s-operator.keiretsu.ts.net
+        ports:
+          - port: 443
+            protocol: TCP
+      - name: stpetersburg-k8s-operator
+        fqdn: stpetersburg-k8s-operator.keiretsu.ts.net
+        ports:
+          - port: 443
+            protocol: TCP
+      - name: ottawa-envoy-gateway
+        ip: 10.169.10.15
+        ports:
+          - port: 443
+            name: https
+            protocol: TCP
+          - port: 80
+            name: http
+            protocol: TCP
+      - name: robbinsdale-unifi
+        ip: 192.168.50.1
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+      - name: robbinsdale-unifi-ipv6
+        ip: fd7a:115c:a1e0:b1a:0:1:c0a8:3201
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+      - name: kusanagi
+        fqdn: kusanagi.keiretsu.ts.net
+        ports:
+          - port: 22
+            protocol: TCP
+      - name: robbinsdale-udm-pro
+        fqdn: robbinsdale-udm-pro.keiretsu.ts.net
+        ports:
+          - port: 22
+            protocol: TCP

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/egress/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/egress/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/deployment.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/deployment.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: golink
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: golink
+  template:
+    metadata:
+      labels:
+        app: golink
+    spec:
+      containers:
+      - name: golink
+        imagePullPolicy: Always
+        image: "ghcr.io/tailscale/golink:main"
+        args: ["--sqlitedb", "/home/nonroot/golink.db", "--verbose", "--config-dir", "/home/nonroot/tsnet-golink", "--hostname", "golink", "--snapshot", "/backups/links.json", "--dev-listen", ":80"]
+        env:
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        volumeMounts:
+        - name: links
+          mountPath: /backups/links.json
+          subPath: links.json
+      volumes:
+      - name: links
+        configMap:
+          name: golink

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml
+
+configMapGenerator:
+  - name: golink
+    files:
+      - links.json

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/links.json
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/links.json
@@ -1,0 +1,3 @@
+{"Short":"raj","Long":"https://rajsingh.info","Created":"2025-08-17T02:13:38Z","LastEdit":"2025-08-17T02:14:57Z","Owner":"rajsinghcpre@gmail.com"}
+{"Short":"luke","Long":"https://lukehouge.com","Created":"2025-09-11T02:13:38Z","LastEdit":"2025-09-11T02:14:57Z","Owner":"lukehouge@gmail.com"}
+{"Short":"kartik","Long":"https://killinit.cc","Created":"2025-09-11T02:13:38Z","LastEdit":"2025-09-11T02:14:57Z","Owner":"kartikb@gmail.com"}

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/service.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/golink/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: golink
+  annotations:
+    tailscale.com/hostname: go
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+spec:
+  ports:
+  - name: http-web
+    port: 80  
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: golink
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/configmap-nginx.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/configmap-nginx.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  nginx.conf: |
+    events {}
+    http {
+      log_format custom '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent"';
+      access_log /dev/stdout custom;
+      error_log /dev/stderr;
+
+      server {
+        listen 80;
+        root /usr/share/nginx/html;
+
+        location / {
+          return 200 "Hello, World! I'm from ${LOCATION}!";
+        }
+
+        location /10mb {
+          alias /usr/share/nginx/html/10mb.bin;
+        }
+
+        location /100mb {
+          alias /usr/share/nginx/html/100mb.bin;
+        }
+      }
+    }
+  init.sh: |
+    #!/bin/sh
+    # Create test files for bandwidth testing
+    dd if=/dev/zero of=/usr/share/nginx/html/10mb.bin bs=1M count=10
+    dd if=/dev/zero of=/usr/share/nginx/html/100mb.bin bs=1M count=100 

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/deployment-curl-hello-world.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/deployment-curl-hello-world.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curl-hello-world-${LOCATION}
+  namespace: default
+  labels:
+    app: curl-hello-world-${LOCATION}
+  
+data:
+  curl-loop.sh: |
+    #!/bin/bash
+
+    URL="http://hello-world-${LOCATION}-egress.tailscale-examples"
+    INTERVAL=1
+    echo "Starting infinite curl loop to $URL every $INTERVAL second(s)..."
+    while true; do
+        echo -e "\n[$(date)] Sending request to $URL"
+        curl -s $URL || echo "[$(date)] ❌ Failed to connect"
+        sleep $INTERVAL
+    done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: curl-hello-world-${LOCATION}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: curl-hello-world-${LOCATION}
+  template:
+    metadata:
+      labels:
+        app: curl-hello-world-${LOCATION}
+    spec:
+      containers:
+      - name: curl
+        image: nicolaka/netshoot:latest
+        command: ["/bin/sh", "/curl-loop.sh"]
+        volumeMounts:
+        - name: script
+          mountPath: /curl-loop.sh
+          subPath: curl-loop.sh
+      volumes:
+      - name: script
+        configMap:
+          name: curl-hello-world-${LOCATION} 

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/deployment-hello-world.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/deployment-hello-world.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+    spec:
+      initContainers:
+      - name: init-test-files
+        image: busybox:latest
+        command: ['sh', '/scripts/init.sh']
+        volumeMounts:
+        - name: init-script
+          mountPath: /scripts
+        - name: html
+          mountPath: /usr/share/nginx/html
+      containers:
+      - name: nginx
+        image: nginx:latest
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: html
+          mountPath: /usr/share/nginx/html
+        ports:
+        - containerPort: 80
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-config
+      - name: init-script
+        configMap:
+          name: nginx-config
+          defaultMode: 0755
+      - name: html
+        emptyDir: {} 

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/egress.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/egress.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world-robbinsdale
+  annotations:
+    # IfNotPresent: Flux creates the Service once with placeholder externalName,
+    # then never re-applies. The Tailscale operator owns spec.externalName
+    # exclusively. See SSA-field-conflict notes.
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-tailscale-examples-hello-world-service.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world-ottawa
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-tailscale-examples-hello-world-service.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world-stpetersburg
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-tailscale-examples-hello-world-service.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment-hello-world.yaml
+  - configmap-nginx.yaml
+  - service-hello-world.yaml
+  - deployment-curl-hello-world.yaml
+  - egress.yaml 

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/service-hello-world.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/service-hello-world.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-tailscale-examples-hello-world-service
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+spec:
+  selector:
+    app: hello-world
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${LOCATION}-tailscale-examples-hello-world-ingress
+spec:
+  defaultBackend:
+    service:
+      name: hello-world
+      port:
+        number: 80
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - ${LOCATION}-tailscale-examples-hello-world-ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${LOCATION}-tailscale-examples-hello-world-funnel
+  annotations:
+    tailscale.com/funnel: "true"
+    tailscale.com/proxy-class: "common"
+spec:
+  defaultBackend:
+    service:
+      name: hello-world
+      port:
+        number: 80
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - ${LOCATION}-tailscale-examples-hello-world-funnel

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # - ./derper
+  # - ./hello
+  - ./proxyt
+  # - ./tsidp
+  # - ./tsddns
+  - ./tsflow
+  - ./sidecar
+  - ./secret.yaml
+  # - ./golink
+  # - ./egress
+  # - ./vector
+  - ./tsk9s

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/backendtrafficpolicy.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/backendtrafficpolicy.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: proxyt-upgrade-policy
+  namespace: tailscale-examples
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: proxyt
+  httpUpgrade:
+    - type: websocket
+    - type: tailscale-control-protocol

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/deployment.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/deployment.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxyt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxyt
+  template:
+    metadata:
+      labels:
+        app: proxyt
+    spec:
+      containers:
+      - name: proxyt
+        image: ghcr.io/jaxxstorm/proxyt:latest
+        ports:
+        - containerPort: 80
+        command: ["proxyt"]
+        args:
+        - "serve"
+        - "--domain"
+        - "proxyt.${CLUSTER_DOMAIN}"
+        - "--http-only"
+        - "--debug"
+        - "--port"
+        - "80"
+        - "--bind"
+        - "0.0.0.0"

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/httproute.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/httproute.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: proxyt
+  annotations:
+    item.homer.rajsingh.info/name: "Proxyt"
+    item.homer.rajsingh.info/subtitle: "Proxyt"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/cilium.png"
+    item.homer.rajsingh.info/keywords: "proxyt, network, tailscale"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "proxyt.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: proxyt
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: / 

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./httproute.yaml
+  - ./backendtrafficpolicy.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/service.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/proxyt/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxyt
+spec:
+  selector:
+    app: proxyt
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  type: ClusterIP

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/secret.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/secret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ts-authkey
+type: Opaque
+stringData:
+  TS_AUTHKEY: ${TS_AUTHKEY}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ts-oauth
+type: Opaque
+stringData:
+  client_id: ${TS_OAUTH_CLIENT_ID}
+  client_secret: ${TS_OAUTH_CLIENT_SECRET}
+  TS_AUTHKEY_EPHEMERAL: ${TS_OAUTH_CLIENT_SECRET}?ephemeral=true&preauthorized=true
+  TS_AUTHKEY: ${TS_OAUTH_CLIENT_SECRET}?ephemeral=false&preauthorized=true

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ts-sidecar.yaml
+  - ./ts-sidecar-userspace.yaml
+  - ./ts-exit-node.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/rbac.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "update", "patch", "create"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale
+subjects:
+- kind: ServiceAccount
+  name: "tailscale"
+roleRef:
+  kind: Role
+  name: tailscale
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-exit-node.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-exit-node.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${LOCATION}-exit-node
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-exit-node
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-exit-node
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: Always
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: tailscale
+        imagePullPolicy: Always
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        env:
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: auto
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --ssh --accept-routes --advertise-exit-node"
+        - name: POD_NAME
+          value: "${LOCATION}-exit-node"
+        - name: TS_HOSTNAME
+          value: "${LOCATION}-exit-node"
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-sidecar-userspace.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-sidecar-userspace.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${LOCATION}-sidecar-userspace
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-userspace
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-sidecar-userspace
+    spec:
+      serviceAccountName: "tailscale"
+      containers:
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["python3", "-m", "http.server", "8080", "--bind", "127.0.0.1"]
+      - name: tailscale
+        imagePullPolicy: Always
+        image: "ghcr.io/tailscale/tailscale:latest"
+        env:
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "true"
+        - name: TS_SOCKS5_SERVER
+          value: ":1055"
+        - name: TS_OUTBOUND_HTTP_PROXY_LISTEN
+          value: ":1055"
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: auto
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: POD_NAME
+          value: "${LOCATION}-sidecar-userspace"
+        - name: TS_HOSTNAME
+          value: "${LOCATION}-sidecar-userspace"
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-sidecar.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-sidecar.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${LOCATION}-sidecar
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-sidecar
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: Always
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/sh", "-c", "while true; do sleep 3600; done"]
+      - name: tailscale
+        imagePullPolicy: Always
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        env:
+        - name: TS_KUBE_SECRET
+          value: "${LOCATION}-sidecar"
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: auto
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_HOSTNAME
+          value: "${LOCATION}-sidecar"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-tunnel-ottawa.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-tunnel-ottawa.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${LOCATION}-tunnel-ottawa
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-tunnel-ottawa
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-tunnel-ottawa
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: Always
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/sh", "-c", "while true; do sleep 3600; done"]
+      - name: tailscale
+        imagePullPolicy: Always
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10 && tailscale set --exit-node=ottawa-exit-node"]
+        env:
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: auto
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_HOSTNAME
+          value: "${LOCATION}-tunnel-ottawa"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-tunnel-robbinsdale.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/sidecar/ts-tunnel-robbinsdale.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${LOCATION}-tunnel-robbinsdale
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-tunnel-robbinsdale
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-tunnel-robbinsdale
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: Always
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/sh", "-c", "while true; do sleep 3600; done"]
+      - name: tailscale
+        imagePullPolicy: Always
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10 && tailscale set --exit-node=robbinsdale-exit-node"]
+        env:
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: auto
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_HOSTNAME
+          value: "${LOCATION}-tunnel-robbinsdale"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/deployment.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/deployment.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tsflow
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tsflow
+  template:
+    metadata:
+      labels:
+        app: tsflow
+    spec:
+      containers:
+      - name: tsflow
+        image: ghcr.io/rajsinghtech/tsflow:v1.6.1
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        env:
+        - name: TSFLOW_FLOW_BACKEND
+          value: "s3"
+        - name: TSFLOW_S3_BUCKET
+          value: "tailscale-logs"
+        - name: TSFLOW_S3_PREFIX
+          value: "network/"
+        - name: TSFLOW_S3_ENDPOINT
+          value: "http://${COMMON_S3_ENDPOINT}"
+        - name: TSFLOW_S3_REGION
+          value: "garage"
+        - name: TSFLOW_S3_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: tsflow-tailscale-logs-s3-auth
+              key: TSFLOW_S3_ACCESS_KEY_ID
+        - name: TSFLOW_S3_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: tsflow-tailscale-logs-s3-auth
+              key: TSFLOW_S3_SECRET_ACCESS_KEY
+        - name: TSFLOW_INITIAL_BACKFILL
+          value: "6h"
+        - name: ENVIRONMENT
+          value: "production"
+        - name: TAILSCALE_TAILNET
+          value: "-"
+        - name: TAILSCALE_OAUTH_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: client_id
+        - name: TAILSCALE_OAUTH_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: client_secret
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: data
+          mountPath: /app/data
+        # resources:
+        #   requests:
+        #     memory: "128Mi"
+        #     cpu: "100m"
+        #   limits:
+        #     memory: "1512Mi"
+        #     cpu: "1000m"
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/garagekey.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/garagekey.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: tsflow-tailscale-logs-key
+  namespace: tailscale-examples
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "TSFlow Tailscale Logs Key"
+  secretTemplate:
+    name: tsflow-tailscale-logs-s3-auth
+    accessKeyIdKey: TSFLOW_S3_ACCESS_KEY_ID
+    secretAccessKeyKey: TSFLOW_S3_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: tailscale-logs
+        namespace: garage
+      read: true

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/httproute.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/httproute.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tsflow
+  namespace: tailscale-examples
+  annotations:
+    item.homer.rajsingh.info/name: "TSFlow"
+    item.homer.rajsingh.info/subtitle: "Tailscale Flow Logs"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/tailscale.svg"
+    item.homer.rajsingh.info/keywords: "tailscale, network, logs"
+
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "tsflow.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: tsflow
+          port: 8080
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/ingress.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tsflow
+  annotations:
+    tailscale.com/proxy-group: "common-ingress"
+    tailscale.com/tags: "tag:k8s"
+spec:
+  defaultBackend:
+    service:
+      name: tsflow
+      port:
+        number: 8080
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - tsflow

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - garagekey.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - ingress.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/service.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsflow/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tsflow
+spec:
+  selector:
+    app: tsflow
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  type: ClusterIP

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/egress.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/egress.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-idp.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: ottawa-idp-egress
+spec:
+  externalName: placeholder   # any value - will be overwritten by operator
+  type: ExternalName 
+  ports:
+  - name: https # any value
+    port: 443
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-idp.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+  name: robbinsdale-idp-egress
+spec:
+  externalName: placeholder   # any value - will be overwritten by operator
+  type: ExternalName 
+  ports:
+  - name: https # any value
+    port: 443
+    protocol: TCP

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - manifest.yaml
+  - egress.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/manifest.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/manifest.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tsidp
+  namespace: tailscale
+  labels:
+    app: tsidp
+spec:
+  replicas: 1
+  serviceName: tsidp
+  selector:
+    matchLabels:
+      app: tsidp
+  volumeClaimTemplates:
+  - metadata:
+      name: tsidp-data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+  template:
+    metadata:
+      labels:
+        app: tsidp
+    spec:
+      securityContext:
+        fsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+      containers:
+      - name: tsidp
+        image: ghcr.io/tailscale/tsidp:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 443
+          name: https
+        env:
+        - name: TAILSCALE_USE_WIP_CODE
+          value: "1"
+        - name: TS_STATE_DIR
+          value: "/data"
+        - name: TS_HOSTNAME
+          value: "${LOCATION}-idp"
+        - name: TSIDP_ENABLE_STS
+          value: "1"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-authkey
+              key: TS_AUTHKEY
+        volumeMounts:
+        - name: tsidp-data
+          mountPath: /data

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/deployment.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/deployment.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tsk9s
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tsk9s
+  template:
+    metadata:
+      labels:
+        app: tsk9s
+    spec:
+      containers:
+      - name: tsk9s
+        image: ghcr.io/rajsinghtech/tsk9s:v0.1.7
+        args:
+          - --state-dir=/data/tsk9s-state
+          - --hostname=${LOCATION}-tsk9s
+          - --endpoints=ottawa-k8s.keiretsu.ts.net,robbinsdale-k8s.keiretsu.ts.net,stpetersburg-k8s.keiretsu.ts.net
+          - --local-addr=0.0.0.0:8080
+          - --tags=tag:k8s,tag:${LOCATION}
+        env:
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        ports:
+        - containerPort: 8080
+          name: http
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/httproute.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/httproute.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tsk9s
+  annotations:
+    item.homer.rajsingh.info/name: "tsk9s"
+    item.homer.rajsingh.info/subtitle: "Multi-cluster K8s terminal"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/kubernetes.svg"
+    item.homer.rajsingh.info/keywords: "k8s, terminal, tailscale"
+
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "k9s.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: tsk9s
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/service.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsk9s/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tsk9s
+  annotations:
+    tailscale.com/hostname: k9s
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+spec:
+  selector:
+    app: tsk9s
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/vector/helmrelease.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/vector/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: vector
+      version: "0.56.0"
+      sourceRef:
+        kind: HelmRepository
+        name: vector
+        namespace: flux-system 
+      interval: 1m
+  releaseName: vector
+  values:
+    service:
+      enabled: true
+    customConfig:
+      sources:
+        splunk_hec:
+          type: "splunk_hec"
+          address: "0.0.0.0:8088"
+          valid_tokens:
+            - "${DEFAULT_PASSWORD}"
+
+      sinks:
+        stdout_sink:
+          type: "console"
+          inputs:
+            - "splunk_hec"
+          encoding:
+            codec: "json"

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/vector/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/vector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - service.yaml

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/vector/service.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/vector/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: logstreaming
+  name: vector-ts
+spec:
+  ports:
+  - name: splunk-hec
+    port: 8088
+    protocol: TCP
+    targetPort: 8088
+  selector:
+    app.kubernetes.io/component: Aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/name: vector
+  loadBalancerClass: tailscale
+  type: LoadBalancer

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -39,3 +39,4 @@ resources:
   - ./snapshot-controller
   - ./media
   - ./lan
+  - ./tailscale-examples

--- a/kubernetes/apps/ottawa/tailscale-examples/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tailscale-examples/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale-examples-sandbox.yaml

--- a/kubernetes/apps/ottawa/tailscale-examples/namespace.yaml
+++ b/kubernetes/apps/ottawa/tailscale-examples/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-examples
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/ottawa/tailscale-examples/tailscale-examples-sandbox.yaml
+++ b/kubernetes/apps/ottawa/tailscale-examples/tailscale-examples-sandbox.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-examples-sandbox
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale-examples
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -35,3 +35,4 @@ resources:
   - ./snapshot-controller
   - ./media
   - ./strimzi
+  - ./tailscale-examples

--- a/kubernetes/apps/robbinsdale/tailscale-examples/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-examples/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale-examples-sandbox.yaml

--- a/kubernetes/apps/robbinsdale/tailscale-examples/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-examples/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-examples
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/robbinsdale/tailscale-examples/tailscale-examples-sandbox.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-examples/tailscale-examples-sandbox.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-examples-sandbox
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale-examples
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -33,3 +33,4 @@ resources:
   - ./hubble-ui
   - ./open-cluster-management-agent
   - ./snapshot-controller
+  - ./tailscale-examples

--- a/kubernetes/apps/stpetersburg/tailscale-examples/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-examples/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale-examples-sandbox.yaml

--- a/kubernetes/apps/stpetersburg/tailscale-examples/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-examples/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-examples
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/stpetersburg/tailscale-examples/tailscale-examples-sandbox.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-examples/tailscale-examples-sandbox.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-examples-sandbox
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale-examples
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true


### PR DESCRIPTION
## summary

verbatim copy of `clusters/common/apps/tailscale-examples/sandbox` →
`kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox`

pointer files for all 3 clusters (ottawa, robbinsdale, stpetersburg) with
namespace.yaml carrying the `prune: disabled` label. sandbox is lowest-risk;
rehearsal for the tailscale-system and tailscale operator that follow.

## gates

- make test ×3: 262/236/223 passed
- byte-identical dir diff confirmed (`diff -r` empty)
- PR-A touches only `kubernetes/`; rendered diff = CR path change only

## next

PR-B: `git rm -r clusters/common/apps/tailscale-examples` after this merges
and reconciles on all 3 clusters.

refs #1553