### PR TITLE
migrate(wave-e/common-home): adopt home gateways, homer, code-server, dnsrecords (PR-A)

### DIFF
--- a/kubernetes/apps/base/home/home/code-server/deployment.yaml
+++ b/kubernetes/apps/base/home/home/code-server/deployment.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: code-server
+spec:
+  replicas: 1 # Adjust the number of replicas as needed
+  selector:
+    matchLabels:
+      app: code-server
+  template:
+    metadata:
+      labels:
+        app: code-server
+    spec:
+      containers:
+        - name: code-server
+          image: lscr.io/linuxserver/code-server:latest # Docker image for code-server
+          env:
+            - name: PUID
+              value: "0"
+            - name: PGID
+              value: "0"
+            - name: TZ
+              value: "Etc/UTC"
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: code-server-secret
+                  key: password
+            # - name: HASHED_PASSWORD
+            #   value: ""  # Optional: Leave empty if not using hashed password
+            # - name: SUDO_PASSWORD
+            # secretKeyRef:
+            #   name: code-server-secret
+            #   key: admin-password
+            # - name: SUDO_PASSWORD_HASH
+            #   value: ""  # Optional: Leave empty if not using hashed sudo password
+            # - name: PROXY_DOMAIN
+            #   value: "code.${CLUSTER_DOMAIN}" # Optional: Specify your domain
+            - name: DEFAULT_WORKSPACE
+              value: /mnt # Optional: Specify default workspace path
+          # volumeMounts:
+          #   - name: config-volume
+          #     mountPath: /config
+          ports:
+            - containerPort: 8443 # Port inside the container (code-server default is 8443)
+          # livenessProbe:
+          #   httpGet:
+          #     path: /healthz
+          #     port: 8443
+          #   periodSeconds: 10
+          # readinessProbe:
+          #   httpGet:
+          #     path: /healthz
+          #     port: 8443
+          #   periodSeconds: 10
+          volumeMounts:
+            - name: startup-script
+              mountPath: /custom-cont-init.d
+      volumes:
+        - name: startup-script
+          configMap:
+            name: startup-script
+            defaultMode: 0755 # Set the permissions for the files in the ConfigMap
+      restartPolicy: Always # Restart policy for the pod

--- a/kubernetes/apps/base/home/home/code-server/httproute.yaml
+++ b/kubernetes/apps/base/home/home/code-server/httproute.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: code
+  namespace: code-server
+  annotations:
+    item.homer.rajsingh.info/name: "Code Server"
+    item.homer.rajsingh.info/subtitle: "Web-based VS Code"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/code-server.png"
+    item.homer.rajsingh.info/keywords: "code, development, editor"
+
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-home"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "code.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: code-server
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: code
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: code
+  oidc:
+    provider:
+      issuer: "https://pocket-id.keiretsu.top"
+    clientID: "6e0ae47f-0ebe-4044-9aae-28e9da38ac3e"
+    clientSecret:
+      name: "code-server-secret"
+    redirectURL: "https://code.${CLUSTER_DOMAIN}/oauth2/callback"
+    logoutPath: "/logout"

--- a/kubernetes/apps/base/home/home/code-server/kustomization.yaml
+++ b/kubernetes/apps/base/home/home/code-server/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - secret.yaml
+configMapGenerator:
+  - name: startup-script
+    files:
+      - startup.sh

--- a/kubernetes/apps/base/home/home/code-server/secret.yaml
+++ b/kubernetes/apps/base/home/home/code-server/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: code-server-secret
+type: Opaque
+stringData:
+  password: ${DEFAULT_PASSWORD}
+  client-secret: ${CODE_SERVER_OIDC_CLIENT_SECRET}

--- a/kubernetes/apps/base/home/home/code-server/service.yaml
+++ b/kubernetes/apps/base/home/home/code-server/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: code-server
+  annotations:
+    tailscale.com/hostname: ${LOCATION}-code-server
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+spec:
+  selector:
+    app: code-server
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8443
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/home/home/code-server/startup.sh
+++ b/kubernetes/apps/base/home/home/code-server/startup.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+echo "Running prestart script..."
+echo ' ______     ______       __        ______     __     __   __     ______     __  __    '
+echo '/\  == \   /\  __ \     /\ \      /\  ___\   /\ \   /\ "-.\ \   /\  ___\   /\ \_\ \   '
+echo '\ \  __<   \ \  __ \   _\_\ \     \ \___  \  \ \ \  \ \ \-.  \  \ \ \__ \  \ \  __ \  '
+echo ' \ \_\ \_\  \ \_\ \_\ /\_____\     \/\_____\  \ \_\  \ \_\\"\_\  \ \_____\  \ \_\ \_\ '
+echo '  \/_/ /_/   \/_/\/_/ \/_____/      \/_____/   \/_/   \/_/ \/_/   \/_____/   \/_/\/_/ '
+                                                                                     
+# Add your startup commands here
+echo '------'
+echo 'Installing Kubectl'
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+kubectl completion bash | sudo tee /etc/bash_completion.d/kubectl > /dev/null
+sudo chmod a+r /etc/bash_completion.d/kubectl
+echo 'alias k=kubectl' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
+echo '------'
+apt update
+apt install dnsutils iputils-ping rsync wget iproute2 curl nfs-common -y

--- a/kubernetes/apps/base/home/home/dnsrecords/killinit-internal.yaml
+++ b/kubernetes/apps/base/home/home/dnsrecords/killinit-internal.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: killinit-internal
+spec:
+  endpoints:
+    - dnsName: k8s.killinit.internal
+      recordType: A
+      targets:
+        - 192.168.169.25

--- a/kubernetes/apps/base/home/home/dnsrecords/kustomization.yaml
+++ b/kubernetes/apps/base/home/home/dnsrecords/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - killinit-internal.yaml
+  - stpetersburg-internal.yaml
+  - robbinsdale-internal.yaml

--- a/kubernetes/apps/base/home/home/dnsrecords/robbinsdale-internal.yaml
+++ b/kubernetes/apps/base/home/home/dnsrecords/robbinsdale-internal.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: robbinsdale-internal
+spec:
+  endpoints:
+    - dnsName: k8s.robbinsdale.internal
+      recordType: A
+      targets:
+        - 192.168.50.25
+    - dnsName: stone.robbinsdale.internal
+      recordType: A
+      targets:
+        - 192.168.50.82
+    - dnsName: tank.robbinsdale.internal
+      recordType: A
+      targets:
+        - 192.168.50.51
+    - dnsName: titan.robbinsdale.internal
+      recordType: A
+      targets:
+        - 192.168.50.112

--- a/kubernetes/apps/base/home/home/dnsrecords/stpetersburg-internal.yaml
+++ b/kubernetes/apps/base/home/home/dnsrecords/stpetersburg-internal.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: stpetersburg-internal
+spec:
+  endpoints:
+    - dnsName: k8s.stpetersburg.internal
+      recordType: A
+      targets:
+        - 192.168.73.25
+    - dnsName: spark-0.stpetersburg.internal
+      recordType: A
+      targets:
+        - 192.168.73.206

--- a/kubernetes/apps/base/home/home/homer/dashboard-private.yaml
+++ b/kubernetes/apps/base/home/home/homer/dashboard-private.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: homer.rajsingh.info/v1alpha1
+kind: Dashboard
+metadata:
+  name: dashboard-private
+  labels:
+    app: homer-dashboard
+    tier: frontend
+spec:
+  replicas: 1
+  homerConfig:
+    title: "${LOCATION} cloud private" 
+    subtitle: "Infrastructure Dashboard"
+    logo: "https://raw.githubusercontent.com/rajsinghtech/homer-operator/main/homer/Homer-Operator.png"
+    header: true
+    footer: '<p>Powered by <strong>Homer-Operator</strong> | <a href="https://github.com/rajsinghtech/homer-operator">GitHub</a></p>'
+    colors:
+      light:
+        highlight-primary: "#d4a574"
+        highlight-secondary: "#c19660"
+        highlight-hover: "#b8885c"
+        background: "#faf8f5"
+        card-background: "#ffffff"
+        text: "#2d2424"
+        text-header: "#1a1515"
+        text-title: "#3d2f2f"
+        text-subtitle: "#6b5d5d"
+        card-shadow: rgba(139, 69, 19, 0.08)
+        link: "#b87333"
+        link-hover: "#8b4513"
+
+      dark:
+        highlight-primary: "#daa520"
+        highlight-secondary: "#cd9b1d"
+        highlight-hover: "#b8860b"
+        background: "#1a1612"
+        card-background: "#2e2621"
+        text: "#f5e6d3"
+        text-header: "#faf0e6"
+        text-title: "#f5deb3"
+        text-subtitle: "#d2b48c"
+        card-shadow: rgba(0, 0, 0, 0.3)
+        link: "#f4a460"
+        link-hover: "#ff8c00"
+
+    defaults:
+      layout: "list"
+      colorTheme: "auto"
+    links:
+    - name: "Kubernetes Manifests"
+      icon: "fab fa-github"
+      url: "https://github.com/keiretsu-labs/kubernetes-manifests"
+      target: "_blank"
+    services:
+    - parameters:
+        name: "Infrastructure"
+        icon: "fas fa-server"
+      items:
+      - parameters:
+          name: "Tailscale"
+          logo: "https://raw.githubusercontent.com/tailscale/tailscale/refs/heads/main/client/web/src/assets/icons/tailscale-icon.svg"
+          subtitle: "Private Mesh Network"
+          tagstyle: "is-info"
+          url: "https://login.tailscale.com/admin/machines"
+    - parameters:
+        name: "Talos Machine Logs"
+        icon: "fas fa-scroll"
+      items:
+      - parameters:
+          name: "All Talos Logs"
+          logo: "https://github.com/loganmarchione/homelab-svg-assets/raw/main/assets/victoriametrics-white.svg"
+          subtitle: "All machine-level logs"
+          tagstyle: "is-success"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3A*&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "kernel"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Kernel / dmesg logs"
+          tagstyle: "is-danger"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Akernel&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "machined"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Talos core daemon"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Amachined&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "apid"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Talos API daemon"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Aapid&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "kubelet"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Talos-level kubelet"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Akubelet&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "etcd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "etcd cluster logs"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Aetcd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "containerd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Container runtime"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Acontainerd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "trustd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Certificate management"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Atrustd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "udevd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Device manager"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Audevd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "cri"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Container runtime interface"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Acri&g0.range_input=5m&g0.relative_time=last_5_minutes"
+  gatewaySelector:
+    matchLabels:
+      gateway: private
+  ingressSelector:
+    matchLabels:
+      noexist: "true"
+  domainFilters:
+    - "${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/base/home/home/homer/dashboard-public.yaml
+++ b/kubernetes/apps/base/home/home/homer/dashboard-public.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: homer.rajsingh.info/v1alpha1
+kind: Dashboard
+metadata:
+  name: dashboard-public
+  labels:
+    app: homer-dashboard
+    tier: frontend
+spec:
+  replicas: 1
+  homerConfig:
+    title: "${LOCATION} Cloud" 
+    subtitle: "Infrastructure Dashboard"
+    logo: "https://raw.githubusercontent.com/rajsinghtech/homer-operator/main/homer/Homer-Operator.png"
+    header: true
+    message:
+      style: "is-info"
+      title: "Welcome to ${LOCATION} Cloud"
+      icon: "fa fa-info-circle"
+      content: "Server Hosted in ${LOCATION}."
+    footer: '<p>Powered by <strong>Homer-Operator</strong> | <a href="https://github.com/rajsinghtech/homer-operator">GitHub</a></p>'
+    colors:
+      light:
+        highlight-primary: "#d4a574"
+        highlight-secondary: "#c19660"
+        highlight-hover: "#b8885c"
+        background: "#faf8f5"
+        card-background: "#ffffff"
+        text: "#2d2424"
+        text-header: "#1a1515"
+        text-title: "#3d2f2f"
+        text-subtitle: "#6b5d5d"
+        card-shadow: rgba(139, 69, 19, 0.08)
+        link: "#b87333"
+        link-hover: "#8b4513"
+
+      dark:
+        highlight-primary: "#daa520"
+        highlight-secondary: "#cd9b1d"
+        highlight-hover: "#b8860b"
+        background: "#1a1612"
+        card-background: "#2e2621"
+        text: "#f5e6d3"
+        text-header: "#faf0e6"
+        text-title: "#f5deb3"
+        text-subtitle: "#d2b48c"
+        card-shadow: rgba(0, 0, 0, 0.3)
+        link: "#f4a460"
+        link-hover: "#ff8c00"
+
+    defaults:
+      layout: "list"
+      colorTheme: "auto"
+    links:
+    - name: "Kubernetes Manifests"
+      icon: "fab fa-github"
+      url: "https://github.com/keiretsu-labs/kubernetes-manifests"
+      target: "_blank"
+    services:
+    - parameters:
+        name: "Infrastructure"
+        icon: "fas fa-server"
+      items:
+      - parameters:
+          name: "GSLB Public Gateway"
+          logo: "https://raw.githubusercontent.com/k8gb-io/k8gb/refs/heads/master/docs/images/k8gb-icon-color.svg"
+          subtitle: "Public CDN round-robin"
+          tag: "k8gb"
+          tagstyle: "is-success"
+          url: "https://keiretsu.cdn.${COMMON_DOMAIN}/"
+      - parameters:
+          name: "GSLB TS Gateway"
+          logo: "https://raw.githubusercontent.com/k8gb-io/k8gb/refs/heads/master/docs/images/k8gb-icon-color.svg"
+          subtitle: "Tailscale CGNAT round-robin"
+          tag: "k8gb"
+          tagstyle: "is-info"
+          url: "https://keiretsu.ts.${COMMON_DOMAIN}/"
+    - parameters:
+        name: "Media"
+        icon: "fas fa-tv"
+      items:
+      - parameters:
+          name: "Jellyseerr"
+          subtitle: "Request Media"
+          tag: "requests"
+          tagstyle: "is-info"
+          url: "https://jellyseerr.rajsingh.info/"
+          logo: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/jellyseerr.svg"
+      - parameters:
+          name: "Jellyfin Client Desktop"
+          subtitle: "macOS/Windows"
+          url: "https://github.com/jellyfin/jellyfin-media-player/releases"
+          logo: "https://raw.githubusercontent.com/jellyfin/jellyfin-media-player/refs/heads/master/resources/images/icon.svg"
+      - parameters:
+          name: "Jellyfin Client Mobile"
+          subtitle: "iOS/Android"
+          url: "https://streamyfin.app/"
+          logo: "https://avatars.githubusercontent.com/u/193271640?s=280&v=4"
+  gatewaySelector:
+    matchLabels:
+      gateway: public
+  ingressSelector:
+    matchLabels:
+      noexist: "true"
+  domainFilters:
+    - "${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/base/home/home/homer/dashboard-ts.yaml
+++ b/kubernetes/apps/base/home/home/homer/dashboard-ts.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: homer.rajsingh.info/v1alpha1
+kind: Dashboard
+metadata:
+  name: dashboard-ts
+  labels:
+    app: homer-dashboard
+    tier: frontend
+spec:
+  replicas: 1
+  homerConfig:
+    title: "${LOCATION} cloud ts" 
+    subtitle: "Infrastructure Dashboard"
+    logo: "https://raw.githubusercontent.com/rajsinghtech/homer-operator/main/homer/Homer-Operator.png"
+    header: true
+    footer: '<p>Powered by <strong>Homer-Operator</strong> | <a href="https://github.com/rajsinghtech/homer-operator">GitHub</a></p>'
+    colors:
+      light:
+        highlight-primary: "#d4a574"
+        highlight-secondary: "#c19660"
+        highlight-hover: "#b8885c"
+        background: "#faf8f5"
+        card-background: "#ffffff"
+        text: "#2d2424"
+        text-header: "#1a1515"
+        text-title: "#3d2f2f"
+        text-subtitle: "#6b5d5d"
+        card-shadow: rgba(139, 69, 19, 0.08)
+        link: "#b87333"
+        link-hover: "#8b4513"
+
+      dark:
+        highlight-primary: "#daa520"
+        highlight-secondary: "#cd9b1d"
+        highlight-hover: "#b8860b"
+        background: "#1a1612"
+        card-background: "#2e2621"
+        text: "#f5e6d3"
+        text-header: "#faf0e6"
+        text-title: "#f5deb3"
+        text-subtitle: "#d2b48c"
+        card-shadow: rgba(0, 0, 0, 0.3)
+        link: "#f4a460"
+        link-hover: "#ff8c00"
+
+    defaults:
+      layout: "list"
+      colorTheme: "auto"
+    links:
+    - name: "Kubernetes Manifests"
+      icon: "fab fa-github"
+      url: "https://github.com/keiretsu-labs/kubernetes-manifests"
+      target: "_blank"
+    services:
+    - parameters:
+        name: "Infrastructure"
+        icon: "fas fa-server"
+      items:
+      - parameters:
+          name: "Tailscale"
+          logo: "https://raw.githubusercontent.com/tailscale/tailscale/refs/heads/main/client/web/src/assets/icons/tailscale-icon.svg"
+          subtitle: "Private Mesh Network"
+          tagstyle: "is-info"
+          url: "https://login.tailscale.com/admin/machines"
+      - parameters:
+          name: "GSLB TS Gateway"
+          logo: "https://raw.githubusercontent.com/k8gb-io/k8gb/refs/heads/master/docs/images/k8gb-icon-color.svg"
+          subtitle: "Tailscale CGNAT round-robin"
+          tag: "k8gb"
+          tagstyle: "is-success"
+          url: "https://keiretsu.ts.${COMMON_DOMAIN}/"
+      - parameters:
+          name: "GSLB Public Gateway"
+          logo: "https://raw.githubusercontent.com/k8gb-io/k8gb/refs/heads/master/docs/images/k8gb-icon-color.svg"
+          subtitle: "Public CDN round-robin"
+          tag: "k8gb"
+          tagstyle: "is-warning"
+          url: "https://keiretsu.cdn.${COMMON_DOMAIN}/"
+    - parameters:
+        name: "Talos Machine Logs"
+        icon: "fas fa-scroll"
+      items:
+      - parameters:
+          name: "All Talos Logs"
+          logo: "https://github.com/loganmarchione/homelab-svg-assets/raw/main/assets/victoriametrics-white.svg"
+          subtitle: "All machine-level logs"
+          tagstyle: "is-success"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3A*&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "kernel"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Kernel / dmesg logs"
+          tagstyle: "is-danger"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Akernel&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "machined"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Talos core daemon"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Amachined&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "apid"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Talos API daemon"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Aapid&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "kubelet"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Talos-level kubelet"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Akubelet&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "etcd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "etcd cluster logs"
+          tagstyle: "is-warning"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Aetcd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "containerd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Container runtime"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Acontainerd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "trustd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Certificate management"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Atrustd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "udevd"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Device manager"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Audevd&g0.range_input=5m&g0.relative_time=last_5_minutes"
+      - parameters:
+          name: "cri"
+          logo: "https://raw.githubusercontent.com/siderolabs/docs/main/public/images/talos.svg"
+          subtitle: "Container runtime interface"
+          tagstyle: "is-info"
+          url: "https://logs.${CLUSTER_DOMAIN}/select/vmui/#/?query=talos-service%3Acri&g0.range_input=5m&g0.relative_time=last_5_minutes"
+  gatewaySelector:
+    matchLabels:
+      external-dns: ts
+  ingressSelector:
+    matchLabels:
+      noexist: "true"
+  domainFilters:
+    - "${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/base/home/home/homer/httproute-private.yaml
+++ b/kubernetes/apps/base/home/home/homer/httproute-private.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dashboard-private
+  annotations:
+    item.homer.rajsingh.info/hide: "true"
+    item.homer.rajsingh.info/name: "Homer"
+    item.homer.rajsingh.info/subtitle: "Private Dashboard"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/homer.svg"
+    item.homer.rajsingh.info/keywords: "homer, operator, dashboard"
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "home.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: dashboard-private-homer
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home/home/homer/httproute-public.yaml
+++ b/kubernetes/apps/base/home/home/homer/httproute-public.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dashboard-public
+  annotations:
+    item.homer.rajsingh.info/hide: "true"
+    item.homer.rajsingh.info/name: "Homer"
+    item.homer.rajsingh.info/subtitle: "Public Dashboard"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/homer.svg"
+    item.homer.rajsingh.info/keywords: "homer, operator, dashboard"
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  hostnames:
+    - "home.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: dashboard-public-homer
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home/home/homer/httproute-ts.yaml
+++ b/kubernetes/apps/base/home/home/homer/httproute-ts.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dashboard-ts
+  annotations:
+    item.homer.rajsingh.info/hide: "true"
+    item.homer.rajsingh.info/name: "Homer"
+    item.homer.rajsingh.info/subtitle: "Gateway Dashboard"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/homer.svg"
+    item.homer.rajsingh.info/keywords: "homer, operator, dashboard"
+    service.homer.rajsingh.info/name: "Utilities"
+    service.homer.rajsingh.info/icon: "fas fa-tools"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "home.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: dashboard-ts-homer
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/home/home/homer/kustomization.yaml
+++ b/kubernetes/apps/base/home/home/homer/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - ./dashboard-private.yaml
+  - ./dashboard-public.yaml
+  - ./dashboard-ts.yaml
+  - ./httproute-private.yaml
+  - ./httproute-public.yaml
+  - ./httproute-ts.yaml

--- a/kubernetes/apps/base/home/home/local-gateway/certificate-agents.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/certificate-agents.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-agents-${COMMON_DOMAIN//./-}
+spec:
+  dnsNames:
+    - '*.agents.${COMMON_DOMAIN}'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: keiretsu-top
+  secretName: wildcard-agents-${COMMON_DOMAIN//./-}
+  usages:
+    - digital signature
+    - key encipherment

--- a/kubernetes/apps/base/home/home/local-gateway/certificate-s3.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/certificate-s3.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-s3-keiretsu-top
+spec:
+  dnsNames:
+    - '*.s3.keiretsu.top'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: keiretsu-top
+  secretName: wildcard-s3-keiretsu-top
+  usages:
+    - digital signature
+    - key encipherment

--- a/kubernetes/apps/base/home/home/local-gateway/clienttrafficpolicy.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/clienttrafficpolicy.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: wildcard-lan
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+  clientIPDetection:
+    xForwardedFor:
+      numTrustedHops: 1
+  timeout:
+    http:
+      requestReceivedTimeout: 0s 
+      idleTimeout: 3600s
+      streamIdleTimeout: 900s
+  headers:
+    requestID: PreserveOrGenerate  
+  http2:
+    initialStreamWindowSize: 64Ki 
+    initialConnectionWindowSize: 1Mi 
+    maxConcurrentStreams: 100

--- a/kubernetes/apps/base/home/home/local-gateway/envoyproxy-private.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoyproxy-private.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: private
+spec:
+  telemetry:
+    metrics:
+      prometheus:
+        compression:
+          type: Gzip
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 2
+      envoyService:
+        loadBalancerIP: ${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.10.14

--- a/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: public
+spec:
+  telemetry:
+    metrics:
+      prometheus:
+        compression:
+          type: Gzip
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 2
+      envoyService:
+        loadBalancerIP: ${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.10.15

--- a/kubernetes/apps/base/home/home/local-gateway/external-dns-unifi.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/external-dns-unifi.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-unifi
+spec:
+  interval: 5m
+  releaseName: external-dns-unifi
+  chart:
+    spec:
+      chart: external-dns
+      version: "1.21.1" 
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system 
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    serviceMonitor:
+      enabled: true
+    fullnameOverride: external-dns-unifi
+    logLevel: debug
+    provider:
+      name: webhook
+      webhook:
+        image:
+          repository: ghcr.io/kashalls/external-dns-unifi-webhook
+          # renovate: datasource=docker depName=ghcr.io/kashalls/external-dns-unifi-webhook
+          tag: v0.9.0
+        env:
+          - name: UNIFI_HOST
+            value: https://${LAN_GATEWAY_IP}
+          - name: UNIFI_EXTERNAL_CONTROLLER
+            value: "false"
+          - name: UNIFI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: external-dns-unifi-secret
+                key: api-key
+          - name: LOG_LEVEL
+            value: debug
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http-webhook
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: http
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: http
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+    extraArgs:
+      - --ignore-ingress-tls-spec
+      - --gateway-label-filter=external-dns==private
+      - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
+      - --crd-source-kind=DNSEndpoint
+    policy: sync
+    sources:
+      - crd
+      - gateway-httproute
+      - gateway-tlsroute
+      - gateway-tcproute
+      - gateway-udproute
+      - service
+    domainFilters:
+      - killinit.cc
+      - lukehouge.com
+      - rajsingh.info
+      - keiretsu.top
+      - killinit.internal
+      - stpetersburg.internal
+      - robbinsdale.internal
+    txtOwnerId: ${LOCATION}-${CLUSTER_DOMAIN//./-}
+    txtPrefix: k8s.${LOCATION}.

--- a/kubernetes/apps/base/home/home/local-gateway/gateway-private.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/gateway-private.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: private
+  labels:
+    external-dns: private
+    gateway: private
+spec:
+  gatewayClassName: private
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: wildcard-killinit-cc-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.killinit.cc"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-killinit-cc
+    - name: wildcard-lukehouge-com-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.lukehouge.com"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-lukehouge-com
+    - name: wildcard-rajsingh-info-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.rajsingh.info"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-rajsingh-info
+    - name: wildcard-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: forgejo-ssh
+      protocol: TCP
+      port: 22
+      allowedRoutes:
+        kinds:
+        - kind: TCPRoute
+        namespaces:
+          from: All
+    - name: neo4j-bolt
+      protocol: TLS
+      port: 7687
+      hostname: "cartography.${CLUSTER_DOMAIN}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-${CLUSTER_DOMAIN//./-}
+      allowedRoutes:
+        kinds:
+        - kind: TCPRoute
+        namespaces:
+          from: All

--- a/kubernetes/apps/base/home/home/local-gateway/gateway-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/gateway-public.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: public
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "${LOCATION}.${CLUSTER_DOMAIN}"
+  labels:
+    gateway: public
+spec:
+  gatewayClassName: public
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: wildcard-killinit-cc-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.killinit.cc"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-killinit-cc
+    - name: wildcard-lukehouge-com-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.lukehouge.com"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-lukehouge-com
+    - name: wildcard-rajsingh-info-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.rajsingh.info"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-rajsingh-info
+    - name: wildcard-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: wildcard-agents-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.agents.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-agents-${COMMON_DOMAIN//./-}
+    - name: wildcard-cdn-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.cdn.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-cdn-keiretsu-top
+    - name: wildcard-s3-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.s3.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-s3-keiretsu-top
+    - name: forgejo-ssh
+      protocol: TCP
+      port: 22
+      allowedRoutes:
+        kinds:
+        - kind: TCPRoute
+        namespaces:
+          from: All
+    - name: webrtc-tcp
+      protocol: TCP
+      port: 8555
+      allowedRoutes:
+        kinds:
+        - kind: TCPRoute
+        namespaces:
+          from: All
+    - name: webrtc-udp
+      protocol: UDP
+      port: 8555
+      allowedRoutes:
+        kinds:
+        - kind: UDPRoute
+        namespaces:
+          from: All

--- a/kubernetes/apps/base/home/home/local-gateway/gatewayclass-private.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/gatewayclass-private.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: private
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: private
+    namespace: home

--- a/kubernetes/apps/base/home/home/local-gateway/gatewayclass-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/gatewayclass-public.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: public
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: public
+    namespace: home

--- a/kubernetes/apps/base/home/home/local-gateway/kustomization.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - gatewayclass-private.yaml
+  - gatewayclass-public.yaml
+  - gateway-private.yaml
+  - gateway-public.yaml
+  - envoyproxy-private.yaml
+  - envoyproxy-public.yaml
+  - external-dns-unifi.yaml
+  - secret.yaml
+  - clienttrafficpolicy.yaml
+  - certificate-s3.yaml
+  - certificate-agents.yaml

--- a/kubernetes/apps/base/home/home/local-gateway/secret.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-dns-unifi-secret
+type: Opaque
+stringData:
+  api-key: ${UNIFI_API_KEY}

--- a/kubernetes/apps/base/home/home/tailscale-gateway/certificate-wildcard.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/certificate-wildcard.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-killinit-cc
+spec:
+  dnsNames:
+    - '*.killinit.cc'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: killinit-cc
+  secretName: wildcard-killinit-cc
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-lukehouge-com
+spec:
+  dnsNames:
+    - '*.lukehouge.com'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: lukehouge-com
+  secretName: wildcard-lukehouge-com
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-rajsingh-info
+spec:
+  dnsNames:
+    - '*.rajsingh.info'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: rajsingh-info
+  secretName: wildcard-rajsingh-info
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-keiretsu-top
+spec:
+  dnsNames:
+    - '*.keiretsu.top'
+    - 'keiretsu.top'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: keiretsu-top
+  secretName: wildcard-keiretsu-top
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-ts-keiretsu-top
+spec:
+  dnsNames:
+    - '*.ts.keiretsu.top'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: keiretsu-top
+  secretName: wildcard-ts-keiretsu-top
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-cdn-keiretsu-top
+spec:
+  dnsNames:
+    - '*.cdn.keiretsu.top'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: keiretsu-top
+  secretName: wildcard-cdn-keiretsu-top
+  usages:
+    - digital signature
+    - key encipherment

--- a/kubernetes/apps/base/home/home/tailscale-gateway/clienttrafficpolicy.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/clienttrafficpolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: wildcard-ts
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      sectionName: wildcard-${CLUSTER_DOMAIN//./-}-https
+  clientIPDetection:
+    xForwardedFor:
+      numTrustedHops: 1
+  timeout:
+    http:
+      requestReceivedTimeout: 0s  # No timeout for receiving requests
+      idleTimeout: 3600s  # 1 hour idle timeout
+      streamIdleTimeout: 900s  # 15 minutes for idle streams
+  headers:
+    requestID: PreserveOrGenerate  
+  http2:
+    initialStreamWindowSize: 64Ki 
+    initialConnectionWindowSize: 1Mi 
+    maxConcurrentStreams: 100

--- a/kubernetes/apps/base/home/home/tailscale-gateway/egress.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/egress.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-envoy-gateway 
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-home-envoy-gateway.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: dns-udp
+    port: 53
+    protocol: UDP
+---
+apiVersion: v1  
+kind: Service
+metadata:
+  name: ottawa-envoy-gateway
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-home-envoy-gateway.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: dns-udp
+    port: 53
+    protocol: UDP

--- a/kubernetes/apps/base/home/home/tailscale-gateway/envoyproxy.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/envoyproxy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: ts
+spec:
+  telemetry:
+    metrics:
+      prometheus:
+        compression:
+          type: Gzip
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 2
+      envoyService:
+        annotations:
+          tailscale.com/hostname: ${LOCATION}-home-envoy-gateway
+          tailscale.com/proxy-group: common-ingress
+        loadBalancerClass: tailscale

--- a/kubernetes/apps/base/home/home/tailscale-gateway/external-dns.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/external-dns.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ts-external-dns
+spec:
+  interval: 5m
+  releaseName: ts-external-dns
+  chart:
+    spec:
+      chart: external-dns
+      version: "1.21.1" 
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system 
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    serviceMonitor:
+      enabled: true
+    provider: pihole
+    env:
+      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: pihole
+            key: "password"
+    extraArgs:
+      - --ignore-ingress-tls-spec
+      - --pihole-server=http://ts-pihole-web.home
+      - --gateway-label-filter=external-dns==ts
+      - --pihole-api-version=6
+    policy: sync
+    sources:
+      - gateway-httproute
+      - gateway-tlsroute
+      - gateway-tcproute
+      - gateway-udproute
+      - service
+    domainFilters:
+      - killinit.cc
+      - lukehouge.com
+      - rajsingh.info
+      - keiretsu.top
+    txtOwnerId: ${LOCATION}-${CLUSTER_DOMAIN//./-}
+    txtPrefix: k8s.${LOCATION}.

--- a/kubernetes/apps/base/home/home/tailscale-gateway/gateway.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/gateway.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ts
+  labels:
+    external-dns: ts
+spec:
+  gatewayClassName: home-ts
+  listeners:
+    - name: wildcard-killinit-cc-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.killinit.cc"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-killinit-cc
+    - name: wildcard-lukehouge-com-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.lukehouge.com"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-lukehouge-com
+    - name: wildcard-rajsingh-info-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.rajsingh.info"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-rajsingh-info
+    - name: wildcard-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-keiretsu-top
+    - name: wildcard-ts-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.ts.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-ts-keiretsu-top
+    - name: http
+      port: 80
+      protocol: HTTP
+    - name: pihole-udp
+      protocol: UDP
+      port: 53
+      allowedRoutes:
+        kinds:
+        - kind: UDPRoute
+    - name: pihole-tcp
+      protocol: TCP
+      port: 53
+      allowedRoutes:
+        kinds:
+        - kind: TCPRoute
+    - name: forgejo-ssh
+      protocol: TCP
+      port: 22
+      allowedRoutes:
+        kinds:
+        - kind: TCPRoute
+        namespaces:
+          from: All
+    - name: neo4j-bolt
+      protocol: TLS
+      port: 7687
+      hostname: "cartography.${CLUSTER_DOMAIN}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-${CLUSTER_DOMAIN//./-}
+      allowedRoutes:
+        kinds:
+        - kind: TCPRoute
+        namespaces:
+          from: All

--- a/kubernetes/apps/base/home/home/tailscale-gateway/gatewayclass.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/gatewayclass.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: home-ts
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: ts
+    namespace: home

--- a/kubernetes/apps/base/home/home/tailscale-gateway/httproute.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/httproute.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ts-pihole-web
+  annotations:
+    item.homer.rajsingh.info/name: "Pi-hole Tailscale"
+    item.homer.rajsingh.info/subtitle: "DNS Ad Blocker"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pi-hole.png"
+    item.homer.rajsingh.info/keywords: "dns, ad blocker, network"
+
+    service.homer.rajsingh.info/name: "Home"
+    service.homer.rajsingh.info/icon: "fas fa-home"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "pihole.${CLUSTER_DOMAIN}"
+  rules:
+    # Redirect from / to /admin
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /admin
+            statusCode: 301
+    # Serve /admin and all subpaths
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /admin
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: ts-pihole-web
+          port: 80
+          weight: 1
+    # Serve other paths (API, etc)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: ts-pihole-web
+          port: 80
+          weight: 1

--- a/kubernetes/apps/base/home/home/tailscale-gateway/kustomization.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+# Envoy
+  - gatewayclass.yaml
+  - gateway.yaml
+  - envoyproxy.yaml
+  - certificate-wildcard.yaml
+  - redirect.yaml
+  - clienttrafficpolicy.yaml
+# DNS
+  - secret.yaml
+  - pihole.yaml
+  - external-dns.yaml
+  - httproute.yaml 
+  - tcproute.yaml
+  - udproute.yaml
+
+# Tailscale
+  - egress.yaml

--- a/kubernetes/apps/base/home/home/tailscale-gateway/pihole.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/pihole.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ts-pihole
+spec:
+  interval: 30m
+  releaseName: ts-pihole
+  chart:
+    spec:
+      chart: pihole
+      version: 2.35.0
+      sourceRef:
+        kind: HelmRepository
+        name: pihole
+        namespace: flux-system
+  install:
+    timeout: 15m
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 15m
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    admin:
+      existingSecret: "pihole"
+      passwordKey: password
+    strategyType: RollingUpdate
+    serviceWeb:
+      type: ClusterIP
+    hostname: "ts-pihole"
+    serviceDns:
+      annotations:
+        tailscale.com/hostname: ${LOCATION}-home-pihole
+        tailscale.com/proxy-group: common-ingress
+      externalTrafficPolicy: Cluster
+      loadBalancerClass: tailscale
+      mixedService: true
+      port: 53
+      # type: LoadBalancer
+    ingress:
+      enabled: false 
+    podDnsConfig:
+      enabled: false 

--- a/kubernetes/apps/base/home/home/tailscale-gateway/redirect.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/redirect.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tls-redirect
+  namespace: home
+spec:
+  parentRefs:
+    - name: ts
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/kubernetes/apps/base/home/home/tailscale-gateway/secret.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole
+type: Opaque
+stringData:
+  password: ${DEFAULT_PASSWORD}

--- a/kubernetes/apps/base/home/home/tailscale-gateway/tcproute.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/tcproute.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: ts-pihole-tcp
+spec:
+  parentRefs:
+  - name: ts
+    sectionName: pihole-tcp
+  rules:
+  - backendRefs:
+    - name: ts-pihole-dns
+      port: 53

--- a/kubernetes/apps/base/home/home/tailscale-gateway/udproute.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/udproute.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: ts-pihole-udp
+spec:
+  parentRefs:
+    - name: ts
+      sectionName: pihole-udp
+  rules:
+    - backendRefs:
+        - name: ts-pihole-dns
+          port: 53

--- a/kubernetes/apps/ottawa/home/home.yaml
+++ b/kubernetes/apps/ottawa/home/home.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-tailscale-gateway
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/tailscale-gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-homer
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/homer
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-code-server
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/code-server
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-local-gateway
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/local-gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-dnsrecords
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: home-local-gateway
+  path: ./kubernetes/apps/base/home/home/dnsrecords
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/home/home.yaml
+++ b/kubernetes/apps/robbinsdale/home/home.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-tailscale-gateway
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/tailscale-gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-homer
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/homer
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-code-server
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/code-server
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-local-gateway
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/local-gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-dnsrecords
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: home-local-gateway
+  path: ./kubernetes/apps/base/home/home/dnsrecords
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/home/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/home/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
   - ./grafana-redirect.yaml
   - ./home-robbinsdale.yaml
+  - ./home.yaml
+  - ./namespace.yaml

--- a/kubernetes/apps/stpetersburg/home/home.yaml
+++ b/kubernetes/apps/stpetersburg/home/home.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-tailscale-gateway
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/tailscale-gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-homer
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/homer
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-code-server
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/code-server
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-local-gateway
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway-system-install
+  path: ./kubernetes/apps/base/home/home/local-gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-dnsrecords
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: home-local-gateway
+  path: ./kubernetes/apps/base/home/home/dnsrecords
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/home/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/home/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./home-ottawa.yaml
-  - ./home.yaml
   - ./namespace.yaml
+  - ./home.yaml

--- a/kubernetes/apps/stpetersburg/home/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/home/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: home
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  annotations:
+    volsync.backube/privileged-movers: "true"

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./garage
   - ./gatus
   - ./gvisor
+  - ./home
   - ./home-assistant
   - ./homer-operator
   - ./jellyswarrm


### PR DESCRIPTION
## summary

PR-A of the wave-E common/home migration — the most load-bearing common app.

Verbatim copies 5 subdirs from `clusters/common/apps/home/` into `kubernetes/apps/base/home/home/` and registers pointer files on all three location trees. No content changes — only `spec.path` updated per CR, CR names preserved.

**CRs migrated (5):**
| CR | old path | new path |
|----|----------|----------|
| `home-tailscale-gateway` | `clusters/common/apps/home/tailscale-gateway` | `kubernetes/apps/base/home/home/tailscale-gateway` |
| `home-homer` | `clusters/common/apps/home/homer` | `kubernetes/apps/base/home/home/homer` |
| `home-code-server` | `clusters/common/apps/home/code-server` | `kubernetes/apps/base/home/home/code-server` |
| `home-local-gateway` | `clusters/common/apps/home/local-gateway` | `kubernetes/apps/base/home/home/local-gateway` |
| `home-dnsrecords` | `clusters/common/apps/home/dnsrecords` | `kubernetes/apps/base/home/home/dnsrecords` |

all three location trees (ottawa, robbinsdale, stpetersburg) get pointer files.

**verification:**
- `diff -r` on all 5 subdirs: no diff (byte-identical)
- `make test` ×3 clusters: 262+236+223 passed
- baseline hashes (old paths, ottawa):
  - home-tailscale-gateway: `476fab5f0c8f60c71ac536a5aeecdcb4`
  - home-homer: `6bfe074da1a3948db7cae88c72385793`
  - home-code-server: `a7abdb5d96db460c3030e7a0b37e5be4`
  - home-local-gateway: `3d9d3445e9858476c05712134e22f069`
  - home-dnsrecords: `445a59c1043f7571655eb8832107f730`

**post-merge verification gates (ALL THREE CLUSTERS):**
1. ownership labels flipped — `kubectl get kustomization home-tailscale-gateway home-homer home-code-server home-local-gateway home-dnsrecords -n flux-system` all show `kustomize.toolkit.fluxcd.io/name: kubernetes-apps`
2. pod startTimes unchanged — envoy pods, pihole, external-dns ×2
3. gateways Programmed — `kubectl get gateway -n home`
4. certs Ready — `kubectl get certificate -n home`
5. live traffic — `VIP=$(kubectl get gateway ts -n home -o jsonpath='{.status.addresses[?(@.type=="IPAddress")].value}' | awk '{print $1}'); curl -sk --resolve smoke.killinit.cc:443:$VIP https://smoke.killinit.cc -o /dev/null -w '%{http_code}'` → expect 404
6. DNS writers alive — `kubectl get pods -n home | grep external-dns` all Running

⚠️ if ANY gateway loses Programmed status or any cert flaps: STOP, do NOT proceed to PR-B, report immediately.

PR-B (release from clusters/) to follow only after all 6 gates pass on all 3 clusters.

closes part of #1553