### PR TITLE
migrate(wave-b/ottawa): adopt ottawa-specific apps (PR-A)

### DIFF
--- a/kubernetes/apps/base/garage/garage-config-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-config-ottawa/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: garage
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - pv.yaml

--- a/kubernetes/apps/base/garage/garage-config-ottawa/pv.yaml
+++ b/kubernetes/apps/base/garage/garage-config-ottawa/pv.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: smb.csi.k8s.io
+  name: data-garage-0
+spec:
+  capacity:
+    storage: 2Ti
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+    - retrans=10
+    - actimeo=5
+    - vers=3.0
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: smb-server.default.svc.cluster.local/media-share/garage
+    volumeAttributes:
+      source: //192.168.169.111/media-share/garage
+    nodeStageSecretRef:
+      name: csi-smbcreds
+      namespace: kube-system

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: garage
+resources:
+  - ottawa-garage-smb.yaml
+  - ottawa-garage-localpath-shiro.yaml
+  - ottawa-garage-localpath-kaji.yaml
+  - ottawa-garage-localpath-asuka.yaml
+  - ottawa-garage-localpath-rei.yaml
+  - service-ts-storage.yaml

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-asuka.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-asuka.yaml
@@ -1,0 +1,25 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: ottawa-garage-localpath-asuka
+  labels:
+    garage.rajsingh.info/cluster: garage
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 700Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "ottawa-garage-asuka.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 700Gi
+      storageClassName: local-path
+  nodeSelector:
+    kubernetes.io/hostname: asuka

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-kaji.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-kaji.yaml
@@ -1,0 +1,25 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: ottawa-garage-localpath-kaji
+  labels:
+    garage.rajsingh.info/cluster: garage
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 700Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "ottawa-garage-kaji.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 700Gi
+      storageClassName: local-path
+  nodeSelector:
+    kubernetes.io/hostname: kaji

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-rei.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-rei.yaml
@@ -1,0 +1,25 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: ottawa-garage-localpath-rei
+  labels:
+    garage.rajsingh.info/cluster: garage
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 700Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "ottawa-garage-rei.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 700Gi
+      storageClassName: local-path
+  nodeSelector:
+    kubernetes.io/hostname: rei

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-shiro.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-localpath-shiro.yaml
@@ -1,0 +1,35 @@
+---
+# Shiro storage node — 2nd storage node for Ottawa, adding LocalPath capacity
+# alongside the existing SMB-backed node.
+#
+# Backend = local-path, pinned to shiro (worker node, ~500GB NVMe).
+# Dynamic PVCs via spec.storage.{metadata,data}.size — no existingClaim needed
+# since this is a fresh node with no prior data to migrate.
+#
+# NodeSelector pins directly to shiro. The operator auto-discovers the nodeId
+# from the pod's Garage admin API on first connect, so nodeId is omitted here.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: ottawa-garage-localpath-shiro
+  labels:
+    garage.rajsingh.info/cluster: garage
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 200Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "ottawa-garage-shiro.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 200Gi
+      storageClassName: local-path
+  nodeSelector:
+    kubernetes.io/hostname: shiro

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-smb.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-smb.yaml
@@ -1,0 +1,32 @@
+---
+# Ottawa storage node, hand-managed (Manual). Data lives on SMB (schedulable,
+# node-fault-tolerant) and metadata on ceph-block-replicated — so the pod is
+# free to reschedule; no node pin. Named by the data backend (smb). Binds the
+# existing PVCs via existingClaim so node_key identity (Garage NodeID
+# 9107ef0e…) and all data are preserved across the Auto->Manual rename.
+#
+# spec.tags keep the EXACT existing layout-role tags (including the legacy
+# pod-name tag) so the rejoin is a zero-churn no-op (no layout version bump).
+# To move this array off SMB later, add a new node (e.g. ottawa-garage-cephrbd),
+# let it sync, then drain+remove this one.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: ottawa-garage-smb
+  labels:
+    garage.rajsingh.info/cluster: garage
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: 9107ef0ef2600c5d9968998c62f9954e8de419ab943d9476f142c86aef72390f
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-0-0
+  storage:
+    metadata:
+      existingClaim: metadata-garage-0
+    data:
+      existingClaim: data-garage-0

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/service-ts-storage.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-shiro
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-shiro-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: ottawa-garage-localpath-shiro-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-kaji
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-kaji-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: ottawa-garage-localpath-kaji-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-asuka
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-asuka-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: ottawa-garage-localpath-asuka-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-rei
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-rei-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: ottawa-garage-localpath-rei-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/k8gb/k8gb-dashboard-ottawa/dashboard-cdn.yaml
+++ b/kubernetes/apps/base/k8gb/k8gb-dashboard-ottawa/dashboard-cdn.yaml
@@ -1,0 +1,154 @@
+---
+# Multi-cluster dashboard served via GSLB.
+# Uses remoteClusters to discover HTTPRoutes across all 3 clusters
+# via Tailscale API server proxy. Shows a unified view of services
+# from all locations on a single dashboard.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-clusters-kubeconfig
+  namespace: keiretsu-top
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        server: https://ottawa-k8s-operator.keiretsu.ts.net
+      name: ottawa
+    - cluster:
+        server: https://robbinsdale-k8s-operator.keiretsu.ts.net
+      name: robbinsdale
+    - cluster:
+        server: https://stpetersburg-k8s-operator.keiretsu.ts.net
+      name: stpetersburg
+    contexts:
+    - context:
+        cluster: ottawa
+        user: tailscale-auth
+      name: ottawa
+    - context:
+        cluster: robbinsdale
+        user: tailscale-auth
+      name: robbinsdale
+    - context:
+        cluster: stpetersburg
+        user: tailscale-auth
+      name: stpetersburg
+    kind: Config
+    users:
+    - name: tailscale-auth
+      user:
+        token: unused
+---
+apiVersion: homer.rajsingh.info/v1alpha1
+kind: Dashboard
+metadata:
+  name: dashboard-cdn
+  namespace: keiretsu-top
+  labels:
+    app: homer-dashboard
+    tier: frontend
+spec:
+  replicas: 2
+  homerConfig:
+    title: "keiretsu cloud"
+    subtitle: "Multi-Cluster Dashboard"
+    logo: "https://raw.githubusercontent.com/rajsinghtech/homer-operator/main/homer/Homer-Operator.png"
+    header: true
+    footer: '<p>Powered by <strong>Homer-Operator</strong> | <a href="https://github.com/keiretsu-labs/kubernetes-manifests">GitHub</a></p>'
+    colors:
+      light:
+        highlight-primary: "#d4a574"
+        highlight-secondary: "#c19660"
+        highlight-hover: "#b8885c"
+        background: "#faf8f5"
+        card-background: "#ffffff"
+        text: "#2d2424"
+        text-header: "#1a1515"
+        text-title: "#3d2f2f"
+        text-subtitle: "#6b5d5d"
+        card-shadow: rgba(139, 69, 19, 0.08)
+        link: "#b87333"
+        link-hover: "#8b4513"
+      dark:
+        highlight-primary: "#daa520"
+        highlight-secondary: "#cd9b1d"
+        highlight-hover: "#b8860b"
+        background: "#1a1612"
+        card-background: "#2e2621"
+        text: "#f5e6d3"
+        text-header: "#faf0e6"
+        text-title: "#f5deb3"
+        text-subtitle: "#d2b48c"
+        card-shadow: rgba(0, 0, 0, 0.3)
+        link: "#f4a460"
+        link-hover: "#ff8c00"
+    defaults:
+      layout: "list"
+      colorTheme: "auto"
+    links:
+    - name: "Kubernetes Manifests"
+      icon: "fab fa-github"
+      url: "https://github.com/keiretsu-labs/kubernetes-manifests"
+      target: "_blank"
+    services:
+    - parameters:
+        name: "Infrastructure"
+        icon: "fas fa-server"
+      items:
+      - parameters:
+          name: "Tailscale"
+          logo: "https://raw.githubusercontent.com/tailscale/tailscale/refs/heads/main/client/web/src/assets/icons/tailscale-icon.svg"
+          subtitle: "Private Mesh Network"
+          tagstyle: "is-info"
+          url: "https://login.tailscale.com/admin/machines"
+  remoteClusters:
+  - name: ottawa
+    enabled: true
+    secretRef:
+      name: external-clusters-kubeconfig
+      key: kubeconfig
+    domainFilters:
+      - "cdn.keiretsu.top"
+      - "keiretsu.top"
+    gatewaySelector:
+      matchLabels:
+        gateway: public
+    ingressSelector:
+      matchLabels:
+        noexist: "true"
+  - name: robbinsdale
+    enabled: true
+    secretRef:
+      name: external-clusters-kubeconfig
+      key: kubeconfig
+    domainFilters:
+      - "cdn.keiretsu.top"
+      - "keiretsu.top"
+    gatewaySelector:
+      matchLabels:
+        gateway: public
+    ingressSelector:
+      matchLabels:
+        noexist: "true"
+  - name: stpetersburg
+    enabled: true
+    secretRef:
+      name: external-clusters-kubeconfig
+      key: kubeconfig
+    domainFilters:
+      - "cdn.keiretsu.top"
+      - "keiretsu.top"
+    gatewaySelector:
+      matchLabels:
+        gateway: public
+    ingressSelector:
+      matchLabels:
+        noexist: "true"
+  gatewaySelector:
+    matchLabels:
+      external-dns: keiretsu
+  ingressSelector:
+    matchLabels:
+      disable-local-cluster: "true"

--- a/kubernetes/apps/base/k8gb/k8gb-dashboard-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/k8gb/k8gb-dashboard-ottawa/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - dashboard-cdn.yaml

--- a/kubernetes/apps/base/loki/loki-ottawa/garage.yaml
+++ b/kubernetes/apps/base/loki/loki-ottawa/garage.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: loki
+  namespace: loki
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: loki
+  quotas:
+    maxSize: 200Gi
+    maxObjects: 50000000
+  keyPermissions:
+    - keyRef:
+        name: loki-key
+        namespace: loki
+      read: true
+      write: true
+      owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: loki-key
+  namespace: loki
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Loki Logs Key"
+  secretTemplate:
+    name: loki-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      endpoint: "http://${COMMON_S3_ENDPOINT}"
+      region: "garage"
+  bucketPermissions:
+    - bucketRef:
+        name: loki
+        namespace: loki
+      read: true
+      write: true

--- a/kubernetes/apps/base/loki/loki-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/loki/loki-ottawa/helmrelease.yaml
@@ -1,0 +1,184 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: loki
+      version: "7.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    deploymentMode: SimpleScalable
+
+    loki:
+      auth_enabled: true
+      analytics:
+        reporting_enabled: false
+      server:
+        log_level: info
+        http_listen_port: 3100
+        grpc_listen_port: 9095
+      commonConfig:
+        replication_factor: 1
+        path_prefix: /var/loki
+      schemaConfig:
+        configs:
+          - from: "2026-05-01"
+            store: tsdb
+            object_store: s3
+            schema: v13
+            index:
+              prefix: index_
+              period: 24h
+      storage:
+        type: s3
+        bucketNames:
+          chunks: loki
+          ruler: loki
+          admin: loki
+        s3:
+          endpoint: ${COMMON_S3_ENDPOINT}
+          region: garage
+          s3ForcePathStyle: true
+          insecure: true
+          # access key and secret pulled from loki-s3 secret via extraEnvFrom
+      limits_config:
+        retention_period: 24h
+        reject_old_samples: true
+        reject_old_samples_max_age: 168h
+        max_cache_freshness_per_query: 10m
+        split_queries_by_interval: 15m
+        ingestion_rate_mb: 16
+        ingestion_burst_size_mb: 32
+        max_global_streams_per_user: 50000
+        allow_structured_metadata: true
+        volume_enabled: true
+      compactor:
+        working_directory: /var/loki/compactor
+        retention_enabled: true
+        delete_request_store: s3
+        compaction_interval: 10m
+        retention_delete_delay: 2h
+      pattern_ingester:
+        enabled: true
+      ruler:
+        enable_api: false
+      ingester:
+        chunk_encoding: snappy
+        # Flush chunks aggressively to prevent WAL from filling the disk
+        chunk_idle_period: 5m
+        max_chunk_age: 30m
+        chunk_target_size: 1048576
+        wal:
+          disk_full_threshold: 0.85
+      tracing:
+        enabled: false
+      querier:
+        max_concurrent: 4
+      structuredConfig:
+        memberlist:
+          join_members:
+            - loki-memberlist
+        storage_config:
+          tsdb_shipper:
+            cache_ttl: 1h
+
+    serviceAccount:
+      create: true
+    global:
+      extraEnvFrom:
+        - secretRef:
+            name: loki-s3
+
+    read:
+      replicas: 2
+      persistence:
+        enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+
+    write:
+      replicas: 2
+      persistence:
+        enabled: true
+        size: 10Gi
+        storageClass: ceph-block-replicated
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+
+    backend:
+      replicas: 1
+      persistence:
+        enabled: true
+        size: 10Gi
+        storageClass: ceph-block-replicated
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+
+    gateway:
+      enabled: true
+      replicas: 1
+      service:
+        port: 80
+      basicAuth:
+        enabled: false
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    minio:
+      enabled: false
+    test:
+      enabled: false
+    lokiCanary:
+      enabled: false
+
+    monitoring:
+      dashboards:
+        enabled: false
+      rules:
+        enabled: false
+      serviceMonitor:
+        enabled: true
+        labels:
+          release: kube-prometheus-stack
+        metricsInstance:
+          enabled: false
+      selfMonitoring:
+        enabled: false
+        grafanaAgent:
+          installOperator: false
+      lokiCanary:
+        enabled: false

--- a/kubernetes/apps/base/loki/loki-ottawa/ingress-ts.yaml
+++ b/kubernetes/apps/base/loki/loki-ottawa/ingress-ts.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-ts
+  annotations:
+    tailscale.com/hostname: loki
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+spec:
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: gateway
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/kubernetes/apps/base/loki/loki-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/loki/loki-ottawa/kustomization.yaml
@@ -1,7 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: loki
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - garage.yaml
+  - helmrelease.yaml
+  - ingress-ts.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/egress.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/egress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mimir-gateway
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: mimir.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP

--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mimir
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: mimir-distributed
+      version: "6.0.6"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    rollout_operator:
+      enabled: false
+
+    minio:
+      enabled: false
+
+    kafka:
+      enabled: false
+
+    # Bundled Mimir AM disabled — upstream notify bug (mimir#2910), every notify
+    # fails with "invalid service state: Terminated" even for a no-op receiver.
+    # The ruler sends to the kube-prometheus-stack (Prometheus) Alertmanager.
+    alertmanager:
+      enabled: false
+
+    ruler:
+      enabled: true
+      replicas: 1
+
+    global:
+      extraEnvFrom:
+        - secretRef:
+            name: mimir-s3
+
+    mimir:
+      structuredConfig:
+        no_auth_tenant: talos-ottawa
+        multitenancy_enabled: true
+        tenant_federation:
+          enabled: true
+        ingest_storage:
+          enabled: false
+        frontend:
+          parallelize_shardable_queries: false
+        ingester:
+          push_grpc_method_enabled: true
+          ring:
+            replication_factor: 1
+        store_gateway:
+          sharding_ring:
+            replication_factor: 1
+        ruler:
+          # Ruler evaluates the rule groups loaded by mimir-config-loader and
+          # pushes firing alerts to the kube-prometheus-stack (Prometheus)
+          # Alertmanager — the bundled Mimir AM hits an upstream notify bug
+          # (mimir#2910). One ruler (ottawa) drives all tenants' alerts here.
+          alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093/
+          enable_api: true
+        ruler_storage:
+          # Shares the mimir bucket with blocks; distinct prefix avoids collision.
+          storage_prefix: ruler
+        common:
+          storage:
+            backend: s3
+            s3:
+              endpoint: ${COMMON_S3_ENDPOINT}
+              bucket_name: mimir
+              insecure: true
+        limits:
+          compactor_blocks_retention_period: 7d
+          ingestion_rate: 500000
+          ingestion_burst_size: 1000000
+          max_global_series_per_user: 10000000
+          max_label_names_per_series: 300
+          query_sharding_total_shards: 16
+          max_outstanding_per_tenant: 100
+
+    ingester:
+      replicas: 1
+      zoneAwareReplication:
+        enabled: false
+      persistentVolume:
+        enabled: false
+      extraArgs:
+        "-ingester.ring.replication-factor": "1"
+
+    store_gateway:
+      replicas: 1
+      zoneAwareReplication:
+        enabled: false
+      persistentVolume:
+        enabled: true
+        size: 2Gi
+      extraArgs:
+        "-store-gateway.sharding-ring.replication-factor": "1"
+
+    compactor:
+      replicas: 1
+      persistentVolume:
+        enabled: false
+
+    distributor:
+      replicas: 2
+
+    querier:
+      replicas: 2
+
+    query_frontend:
+      replicas: 1
+
+    query_scheduler:
+      replicas: 1
+
+    gateway:
+      nginxConfig:
+        serverSnippet: |
+          location /nginx_status {
+            stub_status on;
+            access_log off;
+          }
+          location /metrics {
+            proxy_pass http://localhost:9113/metrics;
+            access_log off;
+          }
+      extraContainers:
+        - name: nginx-exporter
+          image: nginx/nginx-prometheus-exporter:1.5
+          args:
+            - --nginx.scrape-uri=http://localhost:8080/nginx_status
+          ports:
+            - name: metrics
+              containerPort: 9113
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+
+    metaMonitoring:
+      serviceMonitor:
+        enabled: true
+        clusterLabel: ottawa

--- a/kubernetes/apps/base/mimir/mimir-ottawa/ingress-qf-ts.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/ingress-qf-ts.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mimir-qf-ts
+  annotations:
+    tailscale.com/hostname: mimir-qf
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/component: query-frontend
+  ports:
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP

--- a/kubernetes/apps/base/mimir/mimir-ottawa/ingress-ts.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/ingress-ts.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mimir-ts
+  annotations:
+    tailscale.com/hostname: mimir
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+spec:
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/component: gateway
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mimir
+resources:
+  - helmrelease.yaml
+  - ingress-ts.yaml
+  - ingress-qf-ts.yaml
+  - egress.yaml
+  - loader-job.yaml
+configMapGenerator:
+  # Hash-suffixed so any rule change rolls the mimir-config-loader Job
+  # (its volume ref changes), forcing a re-sync into the Mimir ruler.
+  - name: mimir-rules
+    files:
+      - rules/blackbox.yaml
+      - rules/flux.yaml
+      - rules/garage.yaml
+      - rules/k8gb.yaml
+      - rules/monitoring.yaml
+      - rules/smartctl.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -1,0 +1,51 @@
+---
+# Syncs the native rule groups into the Mimir ruler, once per tenant (each
+# cluster is a tenant). Recreated by Flux whenever the rules ConfigMap changes,
+# because the configMapGenerator hash suffix changes the Job's volume reference
+# and the force annotation lets Flux replace the otherwise-immutable Job.
+#
+# grafana/mimirtool is distroless (no /bin/sh), so each tenant sync runs the
+# mimirtool entrypoint directly instead of a shell loop. Alertmanager config is
+# NOT managed here — the ruler notifies the kube-prometheus-stack Alertmanager
+# (the bundled Mimir AM is disabled, mimir#2910).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mimir-config-loader
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: rules-ottawa
+          image: &mt docker.io/grafana/mimirtool:3.1.0
+          args:
+            - rules
+            - sync
+            - --address=http://mimir-gateway.mimir.svc.cluster.local:8080
+            - --id=talos-ottawa
+            - /rules/blackbox.yaml
+            - /rules/flux.yaml
+            - /rules/garage.yaml
+            - /rules/k8gb.yaml
+            - /rules/monitoring.yaml
+            - /rules/smartctl.yaml
+          volumeMounts: &rulesmount
+            - { name: rules, mountPath: /rules }
+          securityContext: &sc
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: rules
+          configMap:
+            name: mimir-rules

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/blackbox.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/blackbox.yaml
@@ -1,0 +1,48 @@
+# Ported from clusters/common/apps/blackbox-exporter/config/prometheusrule.yaml.
+namespace: blackbox
+groups:
+  - name: blackbox-exporter.rules
+    rules:
+      - alert: ProbeFailed
+        expr: probe_success == 0
+        for: 5m
+        annotations:
+          summary: >-
+            Probe failed for {{ $labels.instance }}
+          description: >-
+            The blackbox probe targeting {{ $labels.instance }} has been failing for 5 minutes.
+        labels:
+          severity: critical
+
+      - alert: ProbeSlowResponse
+        expr: probe_duration_seconds > 5
+        for: 10m
+        annotations:
+          summary: >-
+            Slow probe response for {{ $labels.instance }}
+          description: >-
+            The blackbox probe targeting {{ $labels.instance }} is responding slowly (>5s).
+        labels:
+          severity: warning
+
+      - alert: SSLCertExpiringSoon
+        expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 14
+        for: 1h
+        annotations:
+          summary: >-
+            SSL certificate expiring soon for {{ $labels.instance }}
+          description: >-
+            SSL certificate for {{ $labels.instance }} expires in less than 14 days.
+        labels:
+          severity: warning
+
+      - alert: SSLCertExpired
+        expr: probe_ssl_earliest_cert_expiry - time() < 0
+        for: 0m
+        annotations:
+          summary: >-
+            SSL certificate expired for {{ $labels.instance }}
+          description: >-
+            SSL certificate for {{ $labels.instance }} has expired.
+        labels:
+          severity: critical

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
@@ -1,0 +1,19 @@
+# Ported from clusters/common/apps/flux-system/flux-instance/app/prometheusrule.yaml.
+namespace: flux
+groups:
+  - name: flux-instance.rules
+    rules:
+      - alert: FluxInstanceAbsent
+        expr: absent(flux_instance_info{exported_namespace="flux-system",name="flux"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Flux instance is absent
+      - alert: FluxInstanceNotReady
+        expr: flux_instance_info{exported_namespace="flux-system",name="flux",ready!="True"}
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Flux instance is not ready

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/garage.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/garage.yaml
@@ -1,0 +1,40 @@
+# Ported from clusters/common/apps/garage/app/prometheusrule.yaml.
+namespace: garage
+groups:
+  - name: garage.rules
+    rules:
+      # probe_success==0 on the local serving probe means /health returned
+      # non-2xx (503 = a partition lost write-quorum) or the endpoint is
+      # unreachable. Scoped to target=local so a known-down remote region's
+      # cross-cluster probe doesn't fire this.
+      - alert: GarageServingUnavailable
+        expr: probe_success{service="garage", check="serving", target="local"} == 0
+        for: 3m
+        annotations:
+          summary: Garage cannot serve writes in this region ({{ $labels.instance }})
+          description: >-
+            The Garage /health serving probe has been non-2xx for 3m
+            (503 Unavailable = a partition lost its write-quorum of up storage
+            nodes, or the admin endpoint is unreachable). Reads may still work
+            in degraded mode, but writes are failing. With replication.factor=2
+            this is one storage node away from a full write outage — restore the
+            missing storage node or add write headroom.
+        labels:
+          severity: critical
+
+      # The gateway tier is the S3 client path (COMMON_S3_ENDPOINT ->
+      # garage-gateway svc). Fires when the gateway Service has no reachable
+      # endpoint — clients fail — even when storage is up.
+      - alert: GarageGatewayUnreachable
+        expr: probe_success{service="garage", tier="gateway", check="port-open", target="local"} == 0
+        for: 2m
+        annotations:
+          summary: Garage gateway tier unreachable in this region ({{ $labels.instance }})
+          description: >-
+            The garage-gateway Service has had no reachable endpoint for 2m.
+            In-cluster S3 clients reach Garage through it (COMMON_S3_ENDPOINT),
+            so they are failing. Check the gateway pods (garage-gateway-N) and
+            their readiness — storage may still be up (this won't show in the
+            storage probes).
+        labels:
+          severity: critical

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/k8gb.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/k8gb.yaml
@@ -1,0 +1,68 @@
+# Ported from clusters/common/apps/k8gb/config/prometheusrules.yaml.
+namespace: k8gb
+groups:
+  - name: k8gb.rules
+    rules:
+      - alert: K8gbGslbUnhealthy
+        expr: |
+          k8gb_gslb_ingress_hosts_per_status{status="Unhealthy"} > 0
+        for: 5m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} has {{ $value }}
+            unhealthy host(s).
+        labels:
+          severity: warning
+
+      - alert: K8gbGslbNotFound
+        expr: |
+          k8gb_gslb_ingress_hosts_per_status{status="NotFound"} > 0
+        for: 5m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} has {{ $value }}
+            host(s) in NotFound status.
+        labels:
+          severity: critical
+
+      - alert: K8gbHighErrorRate
+        expr: |
+          sum(rate(k8gb_gslb_errors_total[5m])) by (namespace, name) > 0.1
+        for: 10m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} is generating
+            errors at {{ printf "%.2f" $value }}/s.
+        labels:
+          severity: warning
+
+      - alert: K8gbReconciliationStalled
+        expr: |
+          rate(k8gb_gslb_reconciliation_loops_total{name!="init"}[15m]) == 0
+        for: 15m
+        annotations:
+          summary: >-
+            k8gb reconciliation has stalled - no successful loops in 15 minutes.
+        labels:
+          severity: critical
+
+      - alert: K8gbNoHealthyRecords
+        expr: |
+          k8gb_gslb_healthy_records{name!="init"} == 0
+        for: 5m
+        annotations:
+          summary: >-
+            GSLB {{ $labels.name }} in {{ $labels.namespace }} has zero healthy
+            DNS records.
+        labels:
+          severity: critical
+
+      - alert: K8gbEndpointNoTargets
+        expr: |
+          k8gb_endpoint_status_num{name!="init"} == 0
+        for: 5m
+        annotations:
+          summary: >-
+            DNS endpoint {{ $labels.dns_name }} has zero targets.
+        labels:
+          severity: warning

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
@@ -1,0 +1,204 @@
+# Ported from clusters/common/apps/monitoring/config/prometheusrules.yaml.
+# Mimir ruler evaluates these per tenant; the PrometheusRule CRs are no longer
+# evaluated now that Prometheus runs in agent mode.
+namespace: monitoring
+groups:
+  - name: container.rules
+    rules:
+      - alert: OomKilled
+        expr: |
+          (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1)
+          and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1
+        for: 0m
+        annotations:
+          summary: >-
+            Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }}
+            has been OOMKilled {{ $value }} times in the last 10 minutes.
+        labels:
+          severity: critical
+
+      - alert: ContainerHighCpuUtilization
+        expr: |
+          (sum(rate(container_cpu_usage_seconds_total{container!="",pod!=""}[5m])) by (pod, container, namespace)
+          / sum(kube_pod_container_resource_limits{resource="cpu",container!=""}) by (pod, container, namespace)) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }}
+            is using {{ printf "%.0f" $value }}% of its CPU limit.
+        labels:
+          severity: warning
+
+      - alert: ContainerHighMemoryUtilization
+        expr: |
+          (sum(container_memory_working_set_bytes{container!="",pod!=""}) by (pod, container, namespace)
+          / sum(kube_pod_container_resource_limits{resource="memory",container!=""}) by (pod, container, namespace)) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }}
+            is using {{ printf "%.0f" $value }}% of its memory limit.
+        labels:
+          severity: warning
+
+  - name: node.rules
+    rules:
+      - alert: NodeHighCpuUsage
+        expr: |
+          (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Node {{ $labels.instance }} has high CPU usage ({{ printf "%.0f" $value }}%).
+        labels:
+          severity: warning
+
+      - alert: NodeHighMemoryUsage
+        expr: |
+          (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 90
+        for: 15m
+        annotations:
+          summary: >-
+            Node {{ $labels.instance }} has high memory usage ({{ printf "%.0f" $value }}%).
+        labels:
+          severity: warning
+
+      - alert: NodeDiskPressure
+        expr: |
+          (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) * 100 > 85
+        for: 15m
+        annotations:
+          summary: >-
+            Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} is {{ printf "%.0f" $value }}% full.
+        labels:
+          severity: warning
+
+      - alert: NodeDiskCritical
+        expr: |
+          (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) * 100 > 95
+        for: 5m
+        annotations:
+          summary: >-
+            Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} is {{ printf "%.0f" $value }}% full.
+        labels:
+          severity: critical
+
+      - alert: NodeNotReady
+        expr: |
+          kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 5m
+        annotations:
+          summary: >-
+            Node {{ $labels.node }} is not ready.
+        labels:
+          severity: critical
+
+  - name: kubernetes.rules
+    rules:
+      - alert: KubeAPILatencyHigh
+        expr: |
+          histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!~"WATCH|CONNECT"}[5m])) by (le, verb, resource)) > 4
+        for: 10m
+        annotations:
+          summary: >-
+            Kubernetes API server has high latency for {{ $labels.verb }} {{ $labels.resource }} requests (p99 > 4s).
+        labels:
+          severity: warning
+
+      - alert: KubeAPIErrorsHigh
+        expr: |
+          sum(rate(apiserver_request_total{code=~"5.."}[5m])) by (resource, verb)
+          / sum(rate(apiserver_request_total[5m])) by (resource, verb) * 100 > 5
+        for: 10m
+        annotations:
+          summary: >-
+            Kubernetes API server has high error rate ({{ printf "%.1f" $value }}%) for {{ $labels.verb }} {{ $labels.resource }}.
+        labels:
+          severity: warning
+
+      - alert: PodCrashLooping
+        expr: |
+          increase(kube_pod_container_status_restarts_total[1h]) > 5
+        for: 15m
+        annotations:
+          summary: >-
+            Pod {{ $labels.namespace }}/{{ $labels.pod }} is crash looping ({{ $value }} restarts in the last hour).
+        labels:
+          severity: warning
+
+      - alert: PodNotReady
+        expr: |
+          sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown"}) > 0
+        for: 15m
+        annotations:
+          summary: >-
+            Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 15 minutes.
+        labels:
+          severity: warning
+
+      - alert: DeploymentReplicasMismatch
+        expr: |
+          kube_deployment_spec_replicas != kube_deployment_status_replicas_available
+        for: 15m
+        annotations:
+          summary: >-
+            Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has {{ $value }} replicas mismatch.
+        labels:
+          severity: warning
+
+  - name: dockerhub.rules
+    rules:
+      - alert: DockerhubRateLimitRisk
+        expr: |
+          count(time() - container_last_seen{image=~"(docker.io).*",container!=""} < 30) > 100
+        for: 5m
+        annotations:
+          summary: >-
+            There are {{ $value }} containers pulling from Dockerhub. This may lead to rate limiting.
+        labels:
+          severity: warning
+
+  - name: prometheus.rules
+    rules:
+      - alert: PrometheusTargetDown
+        expr: |
+          up == 0
+        for: 10m
+        annotations:
+          summary: >-
+            Prometheus target {{ $labels.job }}/{{ $labels.instance }} is down.
+        labels:
+          severity: warning
+
+  - name: kubelet.rules
+    rules:
+      # Override of the upstream kube-prometheus-stack KubeletDown rule, kept
+      # from the agent-mode migration. Joins on `node` because our kubelet
+      # ServiceMonitor's synthetic `up` series has an empty `cluster` label.
+      - alert: KubeletDown
+        expr: |
+          absent(up{job="kubelet"} == 1) or
+          (
+            count by (node) (up{job="kubelet"} == 0)
+            and on (node) kube_node_info
+          ) > 0
+        for: 15m
+        annotations:
+          summary: >-
+            Kubelet on {{ $labels.node }} is down or unreachable.
+        labels:
+          severity: critical
+
+  - name: watchdog.rules
+    rules:
+      # Dead man's switch: always-firing heartbeat that drives the Gatus
+      # heartbeat receiver. Replaces the kube-prometheus-stack Watchdog default
+      # rule, which is no longer created (defaultRules.create=false).
+      - alert: Watchdog
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: >-
+            This is an always-firing alert used as an end-to-end liveness check
+            for the alerting pipeline.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/smartctl.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/smartctl.yaml
@@ -1,0 +1,66 @@
+# Ported from clusters/*/apps/smartctl-exporter/config/prometheusrule.yaml.
+# Loaded into every tenant; inert where smartctl_* metrics are absent
+# (e.g. stpetersburg has no smartctl-exporter).
+namespace: smartctl
+groups:
+  - name: smartctl-exporter.rules
+    rules:
+      - alert: SmartDeviceHighTemperature
+        expr: |-
+          smartctl_device_temperature{temperature_type="current"} > 65
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has a temperature higher than 65°C
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceTestFailed
+        expr: |-
+          (smartctl_device_smart_status != 1 or smartctl_device_status != 1)
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} did not pass its SMART test
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceCriticalWarning
+        expr: |-
+          smartctl_device_critical_warning != 0
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} is in a critical state
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceMediaErrors
+        expr: |-
+          smartctl_device_media_errors != 0
+        for: 5m
+        annotations:
+          summary: >-
+            Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has media errors
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceAvailableSpareUnderThreshold
+        expr: |-
+          smartctl_device_available_spare_threshold > smartctl_device_available_spare
+        for: 5m
+        annotations:
+          summary: >-
+            Device {{ $labels.device }} on instance {{ $labels.instance }} is under available spare threshold
+        labels:
+          severity: critical
+
+      - alert: SmartDeviceInterfaceSlow
+        expr: |-
+          smartctl_device_interface_speed{speed_type="current"} != on(device, instance, namespace, pod) smartctl_device_interface_speed{speed_type="max"}
+        for: 5m
+        annotations:
+          summary: >-
+            Device {{ $labels.device }} on instance {{ $labels.instance }} interface is slower than it should be
+        labels:
+          severity: critical

--- a/kubernetes/apps/base/monitoring/monitoring-nagato-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-nagato-ottawa/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: monitoring
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - scrapeconfig.yaml
+  - opencost-scrapeconfig.yaml

--- a/kubernetes/apps/base/monitoring/monitoring-nagato-ottawa/opencost-scrapeconfig.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-nagato-ottawa/opencost-scrapeconfig.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: opencost
+spec:
+  honorLabels: true
+  scrapeInterval: 1m
+  scrapeTimeout: 10s
+  metricsPath: /metrics
+  staticConfigs:
+    - targets:
+        - opencost.opencost:9003
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: opencost

--- a/kubernetes/apps/base/monitoring/monitoring-nagato-ottawa/scrapeconfig.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-nagato-ottawa/scrapeconfig.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: node-exporter-nagato
+spec:
+  staticConfigs:
+    - targets:
+        - nagato:9100
+  metricsPath: /metrics
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: node-exporter
+    - action: replace
+      targetLabel: node
+      replacement: nagato

--- a/kubernetes/apps/base/open-cluster-management/ocm-grpc-lb-ottawa/grpc-ts-service.yaml
+++ b/kubernetes/apps/base/open-cluster-management/ocm-grpc-lb-ottawa/grpc-ts-service.yaml
@@ -1,0 +1,21 @@
+---
+# Expose OCM gRPC registration server on the tailnet
+# Klusterlets connect here instead of raw k8s API — OCM manages TLS, no Talos CA needed
+apiVersion: v1
+kind: Service
+metadata:
+  name: ocm-grpc-ts
+  namespace: open-cluster-management-hub
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "ocm-grpc-hub"
+    tailscale.com/proxy-class: "common"
+spec:
+  type: ClusterIP
+  selector:
+    app: cluster-manager-grpc-server
+  ports:
+    - name: grpc
+      port: 443
+      targetPort: 8090
+      protocol: TCP

--- a/kubernetes/apps/base/open-cluster-management/ocm-grpc-lb-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/open-cluster-management/ocm-grpc-lb-ottawa/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - grpc-ts-service.yaml

--- a/kubernetes/apps/base/open-cluster-management/ocm-ottawa/bootstrap-token.yaml
+++ b/kubernetes/apps/base/open-cluster-management/ocm-ottawa/bootstrap-token.yaml
@@ -1,0 +1,12 @@
+---
+# Long-lived token for the OCM bootstrap ServiceAccount
+# Klusterlets on remote clusters use this to register with the hub
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ocm-bootstrap-token
+  namespace: open-cluster-management
+  annotations:
+    kubernetes.io/service-account.name: agent-registration-bootstrap
+type: kubernetes.io/service-account-token

--- a/kubernetes/apps/base/open-cluster-management/ocm-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/open-cluster-management/ocm-ottawa/helmrelease.yaml
@@ -1,0 +1,46 @@
+---
+# OCM Hub (cluster-manager) — lightweight multi-cluster control plane
+# Provides Placement API for cluster selection + health-based failover
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ocm-cluster-manager
+  namespace: open-cluster-management
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: cluster-manager
+      version: "1.3.1"
+      sourceRef:
+        kind: HelmRepository
+        name: ocm
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    clusterManager:
+      registrationConfiguration:
+        featureGates:
+          - feature: DefaultClusterSet
+            mode: Enable
+          - feature: ManagedClusterAutoApproval
+            mode: Enable
+        registrationDrivers:
+          - authType: csr
+          - authType: grpc
+            grpc:
+              autoApprovedIdentities:
+                - system:serviceaccount:open-cluster-management:agent-registration-bootstrap
+      serverConfiguration:
+        endpointsExposure:
+          - protocol: grpc
+            grpc:
+              type: hostname
+              hostname:
+                host: ocm-grpc-hub.keiretsu.ts.net

--- a/kubernetes/apps/base/open-cluster-management/ocm-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/open-cluster-management/ocm-ottawa/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - helmrelease.yaml
+  - bootstrap-token.yaml

--- a/kubernetes/apps/base/open-cluster-management/ocm-ottawa/managed-clusters.yaml
+++ b/kubernetes/apps/base/open-cluster-management/ocm-ottawa/managed-clusters.yaml
@@ -1,0 +1,36 @@
+---
+# Pre-accept all member clusters so registration is fully automated
+# The klusterlet registers, creates ManagedCluster with hubAcceptsClient=false,
+# then this manifest patches it to true — no manual clusteradm accept needed
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: talos-ottawa
+  labels:
+    location: ottawa
+    cloud: onprem
+    vendor: Talos
+spec:
+  hubAcceptsClient: true
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: talos-robbinsdale
+  labels:
+    location: robbinsdale
+    cloud: onprem
+    vendor: Talos
+spec:
+  hubAcceptsClient: true
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: talos-stpetersburg
+  labels:
+    location: stpetersburg
+    cloud: onprem
+    vendor: Talos
+spec:
+  hubAcceptsClient: true

--- a/kubernetes/apps/base/opencost/opencost-ottawa/dashboard.yaml
+++ b/kubernetes/apps/base/opencost/opencost-ottawa/dashboard.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: opencost-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Cost
+  grafanaCom:
+    id: 22208

--- a/kubernetes/apps/base/opencost/opencost-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/opencost/opencost-ottawa/helmrelease.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opencost
+  namespace: opencost
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: opencost
+      version: 2.5.23
+      sourceRef:
+        kind: HelmRepository
+        name: opencost
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    opencost:
+      exporter:
+        defaultClusterId: ottawa
+        extraArgs:
+          - log-level=info
+        prometheusDataSource:
+          queryResolutionSeconds: 900
+      metrics:
+        serviceMonitor:
+          enabled: true
+          additionalLabels:
+            release: prometheus
+      prometheus:
+        external:
+          enabled: true
+          url: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus
+        internal:
+          enabled: false
+      customPricing:
+        enabled: true
+        createConfigmap: true
+        provider: custom
+        costModel:
+          description: Market-based pricing (AWS c6i/m6i comparable)
+          CPU: 0.04
+          spotCPU: 0.012
+          RAM: 0.008
+          spotRAM: 0.0024
+          GPU: 1.50
+          storage: 0.08
+          zoneNetworkEgress: 0.01
+          regionNetworkEgress: 0.01
+          internetNetworkEgress: 0.09

--- a/kubernetes/apps/base/opencost/opencost-ottawa/httproute.yaml
+++ b/kubernetes/apps/base/opencost/opencost-ottawa/httproute.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opencost
+  namespace: opencost
+  annotations:
+    item.homer.rajsingh.info/name: "OpenCost"
+    item.homer.rajsingh.info/subtitle: "Cost Monitoring"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/opencost.svg"
+    item.homer.rajsingh.info/keywords: "cost, monitoring, kubernetes"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "opencost.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: opencost
+          port: 9090
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/opencost/opencost-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/opencost/opencost-ottawa/kustomization.yaml
@@ -1,7 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: opencost
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - helmrelease.yaml
+  - httproute.yaml
+  - dashboard.yaml

--- a/kubernetes/apps/base/pocket-id/pocket-id-ottawa/deployment.yaml
+++ b/kubernetes/apps/base/pocket-id/pocket-id-ottawa/deployment.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pocket-id
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pocket-id
+  template:
+    metadata:
+      labels:
+        app: pocket-id
+    spec:
+      containers:
+        - name: pocket-id
+          image: ghcr.io/pocket-id/pocket-id:v2.8.0
+          env:
+            - name: APP_URL
+              value: "https://pocket-id.${COMMON_DOMAIN}"
+            - name: TRUST_PROXY
+              value: "true"
+            - name: MAXMIND_LICENSE_KEY
+              value: ""
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: ENCRYPTION_KEY
+              value: "${POCKETID_ENCRYPTION_KEY}"
+            - name: ANALYTICS_DISABLED
+              value: "true"
+          ports:
+            - containerPort: 1411
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          livenessProbe:
+            exec:
+              command:
+                - /app/pocket-id
+                - healthcheck
+            initialDelaySeconds: 10
+            periodSeconds: 90
+            timeoutSeconds: 5
+            failureThreshold: 2
+          readinessProbe:
+            exec:
+              command:
+                - /app/pocket-id
+                - healthcheck
+            initialDelaySeconds: 10
+            periodSeconds: 90
+            timeoutSeconds: 5
+            failureThreshold: 2
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: pocket-id
+      restartPolicy: Always

--- a/kubernetes/apps/base/pocket-id/pocket-id-ottawa/httproute.yaml
+++ b/kubernetes/apps/base/pocket-id/pocket-id-ottawa/httproute.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pocket-id
+  namespace: pocket-id
+  annotations:
+    item.homer.rajsingh.info/name: "Pocket ID"
+    item.homer.rajsingh.info/subtitle: "Identity and Authentication"
+    item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/pocket-id-light.svg"
+    item.homer.rajsingh.info/keywords: "authentication, identity, sso"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-id-card"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "pocket-id.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: pocket-id
+          port: 1411
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/pocket-id/pocket-id-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/pocket-id/pocket-id-ottawa/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pocket-id
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc-config.yaml
+  - httproute.yaml
+  - referencegrant.yaml

--- a/kubernetes/apps/base/pocket-id/pocket-id-ottawa/pvc-config.yaml
+++ b/kubernetes/apps/base/pocket-id/pocket-id-ottawa/pvc-config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pocket-id
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/base/pocket-id/pocket-id-ottawa/referencegrant.yaml
+++ b/kubernetes/apps/base/pocket-id/pocket-id-ottawa/referencegrant.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: pocket-id-cdn
+  namespace: pocket-id
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: keiretsu-top
+  to:
+    - group: ""
+      kind: Service
+      name: pocket-id

--- a/kubernetes/apps/base/pocket-id/pocket-id-ottawa/service.yaml
+++ b/kubernetes/apps/base/pocket-id/pocket-id-ottawa/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pocket-id
+spec:
+  selector:
+    app: pocket-id
+  ports:
+    - name: http
+      protocol: TCP
+      port: 1411
+      targetPort: 1411
+  type: ClusterIP

--- a/kubernetes/apps/base/zot/zot-cache-ottawa/dragonfly.yaml
+++ b/kubernetes/apps/base/zot/zot-cache-ottawa/dragonfly.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  # Operator creates a Service of the same name. Keep distinct from the
+  # 'zot-cache' ExternalName in common/apps/zot to avoid a name collision.
+  name: dragonfly-zot
+spec:
+  replicas: 2
+  args:
+    - --maxmemory=2G
+    - --proactor_threads=2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 1Gi
+    limits:
+      memory: 2.5Gi

--- a/kubernetes/apps/base/zot/zot-cache-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/zot/zot-cache-ottawa/kustomization.yaml
@@ -1,7 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: zot
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - dragonfly.yaml
+  - service-local.yaml
+  - service-ts.yaml

--- a/kubernetes/apps/base/zot/zot-cache-ottawa/service-local.yaml
+++ b/kubernetes/apps/base/zot/zot-cache-ottawa/service-local.yaml
@@ -1,0 +1,18 @@
+---
+# Local in-cluster alias so Ottawa zot reaches Dragonfly directly without
+# hairpin-routing through Tailscale. Other clusters use a per-cluster
+# ExternalName (see talos-robbinsdale/apps/zot-cache-egress and
+# talos-stpetersburg/apps/zot-cache-egress).
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-cache
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    app: dragonfly-zot

--- a/kubernetes/apps/base/zot/zot-cache-ottawa/service-ts.yaml
+++ b/kubernetes/apps/base/zot/zot-cache-ottawa/service-ts.yaml
@@ -1,0 +1,22 @@
+---
+# Tailscale LB so peer zots in Ottawa and StPetersburg can dial Dragonfly
+# at zot-cache.keiretsu.ts.net:6379 via their common-egress ProxyGroups.
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot-cache-ts
+  annotations:
+    tailscale.com/hostname: zot-cache
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+    tailscale.com/proxy-group: common-ingress
+spec:
+  publishNotReadyAddresses: true
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    app: dragonfly-zot

--- a/kubernetes/apps/ottawa/garage/garage-cluster.yaml
+++ b/kubernetes/apps/ottawa/garage/garage-cluster.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-exporter
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-exporter
+  path: ./kubernetes/apps/base/garage/garage-exporter
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-config
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage-config-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# Per-location hand-managed storage GarageNode CRs (Manual). The cluster CR
+# (from clusters/common) is per-tier Manual for storage via
+# GARAGE_STORAGE_LAYOUT_POLICY, so the operator ejects its Auto storage node and
+# these take over. Gateway tier stays Auto.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-nodes
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/garage/garage-nodes-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/k8gb/k8gb-dashboard.yaml
+++ b/kubernetes/apps/ottawa/k8gb/k8gb-dashboard.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app k8gb-dashboard
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: k8gb-config
+    - name: homer-operator-install
+  path: ./kubernetes/apps/base/k8gb/k8gb-dashboard-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/k8gb/kustomization.yaml
+++ b/kubernetes/apps/ottawa/k8gb/kustomization.yaml
@@ -1,7 +1,4 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
-  - ./namespace.yaml
+  - ./k8gb-dashboard.yaml

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -25,18 +25,24 @@ resources:
   - ./hermes
   - ./home
   - ./homer-operator
+  - ./hubble-ui
   - ./immich
+  - ./k8gb
   - ./kener
   - ./kro-system
   - ./kube-system
+  - ./lan
+  - ./loki
+  - ./media
+  - ./mimir
+  - ./open-cluster-management
+  - ./open-cluster-management-agent
+  - ./opencost
+  - ./pocket-id
   - ./searxng
+  - ./snapshot-controller
   - ./spegel
+  - ./tailscale-examples
   - ./volsync
   - ./zot
   - ./external-secrets
-  - ./hubble-ui
-  - ./open-cluster-management-agent
-  - ./snapshot-controller
-  - ./media
-  - ./lan
-  - ./tailscale-examples

--- a/kubernetes/apps/ottawa/loki/kustomization.yaml
+++ b/kubernetes/apps/ottawa/loki/kustomization.yaml
@@ -1,7 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
   - ./namespace.yaml
+  - ./loki.yaml

--- a/kubernetes/apps/ottawa/loki/loki.yaml
+++ b/kubernetes/apps/ottawa/loki/loki.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app loki
+  namespace: flux-system
+spec:
+  targetNamespace: loki
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/loki/loki-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/kubernetes/apps/ottawa/loki/namespace.yaml
+++ b/kubernetes/apps/ottawa/loki/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loki
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/mimir/kustomization.yaml
+++ b/kubernetes/apps/ottawa/mimir/kustomization.yaml
@@ -1,7 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
   - ./namespace.yaml
+  - ./mimir.yaml

--- a/kubernetes/apps/ottawa/mimir/mimir.yaml
+++ b/kubernetes/apps/ottawa/mimir/mimir.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mimir
+  namespace: flux-system
+spec:
+  targetNamespace: mimir
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/mimir/mimir-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/kubernetes/apps/ottawa/mimir/namespace.yaml
+++ b/kubernetes/apps/ottawa/mimir/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mimir
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/monitoring/kustomization.yaml
+++ b/kubernetes/apps/ottawa/monitoring/kustomization.yaml
@@ -2,9 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kromgo.yaml
-  - ./unpoller.yaml
-  - ./blackbox-exporter.yaml
   - ./blackbox-exporter-ottawa.yaml
+  - ./blackbox-exporter.yaml
   - ./grafana.yaml
+  - ./kromgo.yaml
+  - ./monitoring-nagato.yaml
   - ./smartctl-exporter.yaml
+  - ./unpoller.yaml

--- a/kubernetes/apps/ottawa/monitoring/monitoring-nagato.yaml
+++ b/kubernetes/apps/ottawa/monitoring/monitoring-nagato.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: monitoring-nagato
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: monitoring-nagato
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/monitoring/monitoring-nagato-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/open-cluster-management/kustomization.yaml
+++ b/kubernetes/apps/ottawa/open-cluster-management/kustomization.yaml
@@ -1,7 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
   - ./namespace.yaml
+  - ./ocm.yaml

--- a/kubernetes/apps/ottawa/open-cluster-management/namespace.yaml
+++ b/kubernetes/apps/ottawa/open-cluster-management/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-cluster-management
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/open-cluster-management/ocm.yaml
+++ b/kubernetes/apps/ottawa/open-cluster-management/ocm.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ocm
+  namespace: flux-system
+spec:
+  targetNamespace: open-cluster-management
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/open-cluster-management/ocm-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ocm-grpc-lb
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: ocm-grpc-lb
+  path: ./kubernetes/apps/base/open-cluster-management/ocm-grpc-lb-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/opencost/kustomization.yaml
+++ b/kubernetes/apps/ottawa/opencost/kustomization.yaml
@@ -1,7 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
   - ./namespace.yaml
+  - ./opencost.yaml

--- a/kubernetes/apps/ottawa/opencost/namespace.yaml
+++ b/kubernetes/apps/ottawa/opencost/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opencost
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/opencost/opencost.yaml
+++ b/kubernetes/apps/ottawa/opencost/opencost.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app opencost
+  namespace: flux-system
+spec:
+  targetNamespace: opencost
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: monitoring
+  path: ./kubernetes/apps/base/opencost/opencost-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/pocket-id/kustomization.yaml
+++ b/kubernetes/apps/ottawa/pocket-id/kustomization.yaml
@@ -1,7 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./garage-cluster.yaml
-  - ./garage.yaml
   - ./namespace.yaml
+  - ./pocket-id.yaml

--- a/kubernetes/apps/ottawa/pocket-id/namespace.yaml
+++ b/kubernetes/apps/ottawa/pocket-id/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pocket-id
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled 

--- a/kubernetes/apps/ottawa/pocket-id/pocket-id.yaml
+++ b/kubernetes/apps/ottawa/pocket-id/pocket-id.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pocket-id
+  namespace: flux-system
+spec:
+  targetNamespace: pocket-id
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/pocket-id/pocket-id-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/zot/kustomization.yaml
+++ b/kubernetes/apps/ottawa/zot/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
+  - ./zot-cache.yaml
   - ./zot.yaml

--- a/kubernetes/apps/ottawa/zot/zot-cache.yaml
+++ b/kubernetes/apps/ottawa/zot/zot-cache.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zot-cache
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: dragonfly-operator-system
+  targetNamespace: zot
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/zot/zot-cache-ottawa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

Adopt wave-b ottawa-only apps to the `kubernetes/` tree. PR-A (adopt) only — touches `kubernetes/` not `clusters/`.

**apps migrated (12 CRs):**
- `loki` — `kubernetes/apps/base/loki/loki-ottawa` + `kubernetes/apps/ottawa/loki/` (namespace moves here)
- `mimir` — `kubernetes/apps/base/mimir/mimir-ottawa` + `kubernetes/apps/ottawa/mimir/` (namespace moves here)
- `opencost` — `kubernetes/apps/base/opencost/opencost-ottawa` + `kubernetes/apps/ottawa/opencost/` (namespace moves)
- `pocket-id` — `kubernetes/apps/base/pocket-id/pocket-id-ottawa` + `kubernetes/apps/ottawa/pocket-id/` (namespace moves)
- `k8gb-dashboard` — `kubernetes/apps/base/k8gb/k8gb-dashboard-ottawa` + `kubernetes/apps/ottawa/k8gb/`
- `zot-cache` — `kubernetes/apps/base/zot/zot-cache-ottawa` + pointer added to `kubernetes/apps/ottawa/zot/`
- `ocm` + `ocm-grpc-lb` — `kubernetes/apps/base/open-cluster-management/{ocm,ocm-grpc-lb}-ottawa` + `kubernetes/apps/ottawa/open-cluster-management/` (namespace moves)
- `monitoring-nagato` — `kubernetes/apps/base/monitoring/monitoring-nagato-ottawa` + pointer added to `kubernetes/apps/ottawa/monitoring/`
- `garage-exporter` — already pointed to base; CR pointer added to `kubernetes/apps/ottawa/garage/garage-cluster.yaml`
- `garage-config` + `garage-nodes` — `kubernetes/apps/base/garage/{garage-config,garage-nodes}-ottawa` + pointers in `garage-cluster.yaml`

**recipe compliance:**
- verbatim copy only — no variable cleanup, no refactors
- base-name collisions (loki, mimir): `-ottawa` suffix per README rule
- CR `metadata.name` unchanged (adoption key)
- namespace.yaml moved with its owning CR, keeping `prune: disabled` labels
- flate byte-identical: all 12 CRs verified
- make test: 223 passed x3

**after merge:** reconcile `kubernetes-apps` on ottawa-k8s-operator.keiretsu.ts.net, verify ownership label flips to `kubernetes-apps`, pod start times unchanged. Then open PR-B (release) to `git rm -r` the clusters/ source dirs.