### PR TITLE
migrate(wave-f/tailscale-system): adopt tailscale-system-app into kubernetes/ tree (PR-A)

### DIFF
--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service-0.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/secret.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ts-kartik
+type: Opaque
+stringData:
+  TS_AUTHKEY:

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/service-0.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/service-0.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-kartik
+  annotations:
+    tailscale.com/hostname: ai-kartik
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+spec:
+  ports:
+  - name: http-web
+    port: 80  
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: ts-kartik
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/statefulset.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-kartik/statefulset.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ts-kartik
+spec:
+  replicas: 1
+  serviceName: ts-kartik
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ts-kartik
+  template:
+    metadata:
+      labels:
+        app: ts-kartik
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:v1.98.4"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:v1.98.4"
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        - name: relay
+          containerPort: 6969
+          protocol: UDP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: $(POD_NAME)
+        - name: TS_STATE
+          value: kube:$(POD_NAME)
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-kartik
+              key: TS_AUTHKEY
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: 0.0.0.0:9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: nftables
+        - name: TS_TAILNET_TARGET_FDQN
+          value: ai.tsjustworks.ts.net

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service-0.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/secret.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ts-raj
+type: Opaque
+stringData:
+  TS_AUTHKEY:

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/service-0.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/service-0.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-raj
+  annotations:
+    tailscale.com/hostname: ai-raj
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+spec:
+  ports:
+  - name: http-web
+    port: 80  
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: ts-raj
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-global
+  annotations:
+    tailscale.com/hostname: ai
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s"
+spec:
+  ports:
+  - name: http-web
+    port: 80  
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: ts-raj
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/statefulset.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ai-raj/statefulset.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ts-raj
+spec:
+  replicas: 1
+  serviceName: ts-raj
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ts-raj
+  template:
+    metadata:
+      labels:
+        app: ts-raj
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:v1.98.4"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:v1.98.4"
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        - name: relay
+          containerPort: 6969
+          protocol: UDP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: $(POD_NAME)
+        - name: TS_STATE
+          value: kube:$(POD_NAME)
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-raj
+              key: TS_AUTHKEY
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: 0.0.0.0:9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: nftables
+        - name: TS_TAILNET_TARGET_IP
+          value: 100.81.69.95

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/derp-client/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/derp-client/ciliumnetworkpolicy.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ${LOCATION}-derp-client-drop-wireguard
+spec:
+  endpointSelector:
+    matchLabels:
+      app: ${LOCATION}-derp-client
+  ingressDeny:
+    - fromEntities:
+        - world
+        - cluster
+      toPorts:
+        - ports:
+            - port: "41641"
+              protocol: UDP

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/derp-client/deployment.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/derp-client/deployment.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${LOCATION}-derp-client
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-derp-client
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-derp-client
+    spec:
+      serviceAccountName: "tailscale"
+      containers:
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:v1.98.4"
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_STATE
+          value: kube:$(POD_NAME)
+        - name: TS_USERSPACE
+          value: "true"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --ssh"
+        - name: TS_TAILSCALED_EXTRA_ARGS
+          value: "--port=41641"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: 0.0.0.0:9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/derp-client/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/derp-client/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - ciliumnetworkpolicy.yaml

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ds/daemonset.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ds/daemonset.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tailscale
+spec:
+  selector:
+    matchLabels:
+      app: tailscale
+  template:
+    metadata:
+      labels:
+        app: tailscale
+    spec:
+      serviceAccountName: "tailscale"
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      containers:
+      - name: tailscale
+        imagePullPolicy: Always
+        image: "ghcr.io/tailscale/tailscale:latest"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: TS_KUBE_SECRET
+          value: $(NODE_NAME)
+        - name: TS_STATE
+          value: kube:$(NODE_NAME)
+        - name: TS_USERSPACE
+          value: "true"
+        - name: TS_OUTBOUND_HTTP_PROXY_LISTEN
+          value: ""
+        - name: TS_SOCKS5_SERVER
+          value: ""
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: auto
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/ds/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/ds/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./daemonset.yaml

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.yaml
+  - ./rbac.yaml
+  - ./peer-relay
+  - ./testing
+  - ./ds
+  - ./tsddns
+  - ./derp-client
+  - ./log-streaming

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/log-streaming/configmap.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/log-streaming/configmap.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tailscale-log-streaming-script
+data:
+  # $$ escapes are required because Flux envsubst processes this manifest
+  # before it lands in-cluster; bare $ would be eaten. Flux is single-pass,
+  # so $$ becomes $ and the shell sees the variables as intended.
+  sync.sh: |
+    #!/bin/sh
+    set -eu
+
+    : "$${TAILNET:?}"
+    : "$${S3_URL:?}"
+    : "$${S3_BUCKET:?}"
+    : "$${S3_REGION:?}"
+    : "$${COMPRESSION:?}"
+    : "$${UPLOAD_PERIOD_MINUTES:?}"
+    : "$${TS_CLIENT_ID:?}"
+    : "$${TS_CLIENT_SECRET:?}"
+    : "$${TAILSCALE_LOGS_S3_ACCESS_KEY:?}"
+    : "$${TAILSCALE_LOGS_S3_SECRET_KEY:?}"
+
+    API="https://api.tailscale.com/api/v2"
+
+    echo "Minting OAuth access token..."
+    TOKEN_JSON="$$(curl -sf -u "$${TS_CLIENT_ID}:$${TS_CLIENT_SECRET}" \
+        -d 'grant_type=client_credentials' \
+        "$${API}/oauth/token")"
+    ACCESS_TOKEN="$$(printf '%s' "$$TOKEN_JSON" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')"
+    if [ -z "$$ACCESS_TOKEN" ]; then
+        echo "Failed to obtain access token" >&2
+        printf '%s\n' "$$TOKEN_JSON" >&2
+        exit 1
+    fi
+
+    configure_stream() {
+        log_type="$$1"
+        prefix="$$2"
+        echo "Configuring log stream: $${log_type} -> s3://$${S3_BUCKET}/$${prefix}"
+        body=$$(printf '%s' \
+            '{' \
+            '"destinationType":"s3",' \
+            "\"url\":\"$${S3_URL}\"," \
+            "\"s3Bucket\":\"$${S3_BUCKET}\"," \
+            "\"s3Region\":\"$${S3_REGION}\"," \
+            "\"s3KeyPrefix\":\"$${prefix}\"," \
+            '"s3AuthenticationType":"accesskey",' \
+            "\"s3AccessKeyId\":\"$${TAILSCALE_LOGS_S3_ACCESS_KEY}\"," \
+            "\"s3SecretAccessKey\":\"$${TAILSCALE_LOGS_S3_SECRET_KEY}\"," \
+            "\"compressionFormat\":\"$${COMPRESSION}\"," \
+            "\"uploadPeriodMinutes\":$${UPLOAD_PERIOD_MINUTES}" \
+            '}')
+        http_status=$$(curl -s -o /tmp/resp -w '%{http_code}' -X PUT \
+            -u "$${ACCESS_TOKEN}:" \
+            -H 'Content-Type: application/json' \
+            --data "$$body" \
+            "$${API}/tailnet/$${TAILNET}/logging/$${log_type}/stream")
+        if [ "$$http_status" != "200" ] && [ "$$http_status" != "204" ]; then
+            echo "  $${log_type}: PUT failed (HTTP $${http_status})" >&2
+            cat /tmp/resp >&2
+            echo >&2
+            return 1
+        fi
+        echo "  $${log_type}: configured (HTTP $${http_status})"
+    }
+
+    configure_stream "network" "network/"
+    configure_stream "configuration" "audit/"
+    echo "Done."

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/log-streaming/cronjob.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/log-streaming/cronjob.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tailscale-log-streaming-sync
+spec:
+  schedule: "17 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app: tailscale-log-streaming-sync
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sync
+              image: curlimages/curl:8.20.0
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/sync.sh"]
+              env:
+                - name: TAILNET
+                  value: "keiretsu.ts.net"
+                - name: S3_URL
+                  value: "https://s3.keiretsu.top"
+                - name: S3_BUCKET
+                  value: "tailscale-logs"
+                - name: S3_REGION
+                  value: "garage"
+                - name: COMPRESSION
+                  value: "zstd"
+                - name: UPLOAD_PERIOD_MINUTES
+                  value: "5"
+                - name: TS_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: ts-oauth
+                      key: client_id
+                - name: TS_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ts-oauth
+                      key: client_secret
+              envFrom:
+                - secretRef:
+                    name: tailscale-logs-s3-auth
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+          volumes:
+            - name: script
+              configMap:
+                name: tailscale-log-streaming-script
+                defaultMode: 0555

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/log-streaming/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/log-streaming/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/peer-relay/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/peer-relay/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service-0.yaml

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/peer-relay/service-0.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/peer-relay/service-0.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${LOCATION}-peer-relay-0
+spec:
+  type: LoadBalancer
+  selector:
+    app: ${LOCATION}-peer-relay
+    statefulset.kubernetes.io/pod-name: ${LOCATION}-peer-relay-0
+  ports:
+  - name: relay
+    port: 6969
+    targetPort: 6969
+    protocol: UDP
+  - name: metrics
+    port: 9002
+    targetPort: 9002
+    protocol: TCP
+  loadBalancerIP: ${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.100.100

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/peer-relay/statefulset.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/peer-relay/statefulset.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${LOCATION}-peer-relay
+spec:
+  replicas: 1
+  serviceName: ${LOCATION}-peer-relay
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-peer-relay
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-peer-relay
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:v1.98.4"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:v1.98.4"
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        - name: relay
+          containerPort: 6969
+          protocol: UDP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: $(POD_NAME)
+        - name: TS_STATE
+          value: kube:$(POD_NAME)
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh --advertise-exit-node"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: 0.0.0.0:9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10 && tailscale set --relay-server-port=6969 --relay-server-static-endpoints=${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.100.100:6969"]

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/rbac.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "update", "patch", "create"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale
+subjects:
+- kind: ServiceAccount
+  name: "tailscale"
+roleRef:
+  kind: Role
+  name: tailscale
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/secret.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/secret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ts-authkey
+type: Opaque
+stringData:
+  TS_AUTHKEY: ${TS_AUTHKEY}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ts-oauth
+type: Opaque
+stringData:
+  client_id: ${TS_OAUTH_CLIENT_ID}
+  client_secret: ${TS_OAUTH_CLIENT_SECRET}
+  TS_AUTHKEY_EPHEMERAL: ${TS_OAUTH_CLIENT_SECRET}?ephemeral=true&preauthorized=true
+  TS_AUTHKEY: ${TS_OAUTH_CLIENT_SECRET}?ephemeral=false&preauthorized=true

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # - ts-pinger.yaml
+  # - ts-digger.yaml
+  # - ts-iperf-client.yaml
+  # - ts-iperf-server.yaml
+  - ts-coredns.yaml

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-coredns.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-coredns.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${LOCATION}-sidecar-coredns
+data:
+  Corefile: |
+    .:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        forward . 100.100.100.100
+        prometheus :9253
+        health :8080
+        ready :8181
+    }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${LOCATION}-sidecar-coredns
+spec:
+  replicas: 1
+  serviceName: ${LOCATION}-sidecar-coredns
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-coredns
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-sidecar-coredns
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: coredns
+        image: coredns/coredns:latest
+        imagePullPolicy: IfNotPresent
+        args: ["-conf", "/etc/coredns/Corefile"]
+        ports:
+        - name: dns
+          containerPort: 53
+          protocol: UDP
+        - name: dns-tcp
+          containerPort: 53
+          protocol: TCP
+        - name: dns-metrics
+          containerPort: 9253
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: coredns-config
+          mountPath: /etc/coredns
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_STATE_DIR
+          value: "/dev/shm"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: $(POD_IP):9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+      volumes:
+      - name: coredns-config
+        configMap:
+          name: ${LOCATION}-sidecar-coredns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${LOCATION}-sidecar-coredns
+spec:
+  selector:
+    app: ${LOCATION}-sidecar-coredns
+  ports:
+  - name: dns
+    port: 53
+    targetPort: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    targetPort: 53
+    protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${LOCATION}-sidecar-coredns
+spec:
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-coredns
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+      action: replace
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+      action: replace
+  - port: dns-metrics
+    interval: 15s
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+      action: replace
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+      action: replace

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-digger.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-digger.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sidecar-digger
+spec:
+  replicas: 1
+  serviceName: sidecar-digger
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: sidecar-digger
+  template:
+    metadata:
+      labels:
+        app: sidecar-digger
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+
+      - name: tailscale-digger
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: tailscale-state
+          mountPath: /var/lib/tailscale
+        env:
+        - name: TS_STATE_DIR
+          value: "/var/lib/tailscale"
+        - name: TS_SOCKET
+          value: "/var/lib/tailscale/tailscaled.sock"
+        command: ["/bin/sh","-c"]
+        args:
+        - |
+          set -eu
+          TARGET="k8s.killinit.internal"
+          SOCK="/var/lib/tailscale/tailscaled.sock"
+          echo "Waiting for tailscale to be up + logged in..."
+          # Wait until tailscaled is reachable and authenticated
+          until tailscale --socket="$SOCK" status >/dev/null 2>&1; do
+            echo "[$(date)] tailscale not ready yet"
+            sleep 1
+          done
+          echo "[$(date)] tailscale ready; starting dns query loop for $TARGET"
+          while true; do
+            echo "[$(date)] tailscale dns query $TARGET"
+            tailscale --socket="$SOCK" dns query "$TARGET" 2>&1 || true
+            sleep 1
+          done
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: tailscale-state
+          mountPath: /var/lib/tailscale
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_STATE_DIR
+          value: "/var/lib/tailscale"
+        - name: TS_SOCKET
+          value: "/var/lib/tailscale/tailscaled.sock"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: $(POD_IP):9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+      volumes:
+      - name: tailscale-state
+        emptyDir: {}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: sidecar-digger
+spec:
+  selector:
+    matchLabels:
+      app: sidecar-digger
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+      action: replace
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+      action: replace

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-iperf-client-server.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-iperf-client-server.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${LOCATION}-sidecar-iperf
+spec:
+  replicas: 1
+  serviceName: ${LOCATION}-sidecar-iperf
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-iperf
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-sidecar-iperf
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: iperf-server
+        image: nicolaka/netshoot:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "iperf3 -s"]
+      # - name: iperf-client
+      #   image: nicolaka/netshoot:latest
+      #   imagePullPolicy: IfNotPresent
+      #   command:
+      #   - /bin/sh
+      #   - -c
+      #   - |
+      #     set +e
+      #     TARGET_HOST=$(echo $POD_NAME | sed "s/${LOCATION}/${FAILOVER}/")
+      #     echo "Will continuously test to $TARGET_HOST"
+      #     while true; do
+      #       echo "[$(date)] Connecting to $TARGET_HOST..."
+      #       iperf3 -c $TARGET_HOST -t 300 2>&1 || echo "Connection failed, retrying..."
+      #     done
+      #   env:
+      #   - name: POD_NAME
+      #     valueFrom:
+      #       fieldRef:
+      #         fieldPath: metadata.name
+      #   - name: LOCATION
+      #     value: "${LOCATION}"
+      #   - name: FAILOVER
+      #     value: "${FAILOVER}"
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_STATE_DIR
+          value: "/dev/shm"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: $(POD_IP):9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${LOCATION}-sidecar-iperf
+spec:
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-iperf
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+      action: replace
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+      action: replace

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-iperf-client.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-iperf-client.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${LOCATION}-sidecar-iperf-client
+spec:
+  replicas: 1
+  serviceName: ${LOCATION}-sidecar-iperf-client
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-iperf-client
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-sidecar-iperf-client
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: iperf-client
+        image: nicolaka/netshoot:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set +e
+          TARGET_HOST="ottawa-sidecar-iperf-server.tailscale-system.svc.cluster.local"
+          echo "Will continuously test to $TARGET_HOST"
+          while true; do
+            # Check DNS resolution first
+            RESOLVED_IP=$(dig +short "$TARGET_HOST" 2>/dev/null | head -1)
+            if [ -z "$RESOLVED_IP" ]; then
+              echo "[$(date)] WARNING: DNS resolution failed for $TARGET_HOST"
+              echo "[$(date)] Trying nslookup..."
+              nslookup "$TARGET_HOST" 2>&1 || true
+              sleep 1
+              continue
+            fi
+            echo "[$(date)] Resolved $TARGET_HOST -> $RESOLVED_IP"
+            echo "[$(date)] Connecting to $TARGET_HOST..."
+            iperf3 -c $TARGET_HOST -t 10 2>&1 || echo "Connection failed, retrying..."
+          done
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: LOCATION
+          value: "${LOCATION}"
+        - name: FAILOVER
+          value: "${FAILOVER}"
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_STATE_DIR
+          value: "/dev/shm"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: $(POD_IP):9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${LOCATION}-sidecar-iperf-client
+spec:
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-iperf-client
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+      action: replace
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+      action: replace

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-iperf-server.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-iperf-server.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${LOCATION}-sidecar-iperf-server
+spec:
+  replicas: 1
+  serviceName: ${LOCATION}-sidecar-iperf-server
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-iperf-server
+  template:
+    metadata:
+      labels:
+        app: ${LOCATION}-sidecar-iperf-server
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+      - name: iperf-server
+        image: nicolaka/netshoot:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "iperf3 -s"]
+        ports:
+        - name: iperf
+          containerPort: 5201
+          protocol: TCP
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_STATE_DIR
+          value: "/dev/shm"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: $(POD_IP):9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${LOCATION}-sidecar-iperf-server
+spec:
+  selector:
+    app: ${LOCATION}-sidecar-iperf-server
+  ports:
+  - name: iperf
+    port: 5201
+    targetPort: 5201
+    protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${LOCATION}-sidecar-iperf-server
+spec:
+  selector:
+    matchLabels:
+      app: ${LOCATION}-sidecar-iperf-server
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+      action: replace
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+      action: replace

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-pinger.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/testing/ts-pinger.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sidecar-pinger
+spec:
+  replicas: 1
+  serviceName: sidecar-pinger
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: sidecar-pinger
+  template:
+    metadata:
+      labels:
+        app: sidecar-pinger
+    spec:
+      serviceAccountName: "tailscale"
+      initContainers:
+      - args:
+        - sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding;
+          then sysctl -w net.ipv6.conf.all.forwarding=1; fi
+        command:
+        - /bin/sh
+        - -c
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        name: sysctler
+        securityContext:
+          privileged: true
+      containers:
+
+      - name: tailscale-pinger
+        image: "ghcr.io/tailscale/tailscale:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: tailscale-state
+          mountPath: /var/lib/tailscale
+        env:
+        - name: TS_STATE_DIR
+          value: "/var/lib/tailscale"
+        - name: TS_SOCKET
+          value: "/var/lib/tailscale/tailscaled.sock"
+        command: ["/bin/sh","-c"]
+        args:
+        - |
+          set -eu
+          TARGET="10.4.0.10"
+          SOCK="/var/lib/tailscale/tailscaled.sock"
+          echo "Waiting for tailscale to be up + logged in..."
+          # Wait until tailscaled is reachable and authenticated
+          until tailscale --socket="$SOCK" status >/dev/null 2>&1; do
+            echo "[$(date)] tailscale not ready yet"
+            sleep 1
+          done
+          echo "[$(date)] tailscale ready; starting ping loop to $TARGET"
+          while true; do
+            echo "[$(date)] tailscale ping $TARGET"
+            tailscale --socket="$SOCK" ping "$TARGET" 2>&1 || true
+            sleep 1
+          done
+      - name: tailscale
+        imagePullPolicy: IfNotPresent
+        image: "ghcr.io/tailscale/tailscale:latest"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: tailscale-state
+          mountPath: /var/lib/tailscale
+        ports:
+        - name: metrics
+          containerPort: 9002
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_STATE_DIR
+          value: "/var/lib/tailscale"
+        - name: TS_SOCKET
+          value: "/var/lib/tailscale/tailscaled.sock"
+        - name: TS_AUTHKEY
+          valueFrom:
+            secretKeyRef:
+              name: ts-oauth
+              key: TS_AUTHKEY_EPHEMERAL
+              optional: true
+        - name: TS_ACCEPT_DNS
+          value: "true"
+        - name: TS_EXTRA_ARGS
+          value: "--advertise-tags=tag:k8s,tag:${LOCATION} --accept-routes --ssh"
+        - name: TS_ENABLE_METRICS
+          value: "true"
+        - name: TS_LOCAL_ADDR_PORT
+          value: $(POD_IP):9002
+        - name: TS_HOSTNAME
+          value: $(POD_NAME)
+      volumes:
+      - name: tailscale-state
+        emptyDir: {}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: sidecar-pinger
+spec:
+  selector:
+    matchLabels:
+      app: sidecar-pinger
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+      action: replace
+    - sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+      action: replace

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/tsddns/config.json
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/tsddns/config.json
@@ -1,0 +1,38 @@
+{
+    "ts.keiretsu.top": [
+      "svc:ottawa-k8gb-coredns"
+    ],
+    "keiretsu.top": [
+      "1.1.1.1"
+    ],
+    "rajsingh.info": [
+      "svc:stpetersburg-home-envoy-gateway"
+    ],
+    "cdn.rajsingh.info": [
+      "1.1.1.1"
+    ],
+    "cdn.keiretsu.top": [
+      "1.1.1.1"
+    ],
+    "stpetersburg.internal": [
+        "192.168.73.1"
+    ],
+
+    "killinit.cc": [
+        "svc:ottawa-home-envoy-gateway"
+      ],
+    "killinit.internal": [
+        "192.168.169.1"
+    ],
+
+    "lukehouge.com": [
+        "svc:robbinsdale-home-envoy-gateway"
+      ],
+    "robbinsdale.lan": [
+        "192.168.50.1",
+        "device:robbinsdale-udm-pro"
+    ],
+    "tailscale-system.svc.cluster.local": [
+        "10.2.0.10"
+    ]
+}

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/tsddns/cronjob.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/tsddns/cronjob.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tsddns
+  namespace: tailscale-examples
+spec:
+  schedule: "*/45 * * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: tsddns
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: tsddns
+            image: ghcr.io/rajsinghtech/tsddns:latest
+            imagePullPolicy: Always
+            args:
+            - "--config"
+            - "/config/config.json"
+            env:
+            - name: TAILSCALE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ts-oauth
+                  key: client_id
+            - name: TAILSCALE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ts-oauth
+                  key: client_secret
+            volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            resources:
+              requests:
+                memory: "64Mi"
+                cpu: "100m"
+              limits:
+                memory: "128Mi"
+                cpu: "200m"
+          volumes:
+          - name: config
+            configMap:
+              name: tsddns-config

--- a/kubernetes/apps/base/tailscale-system/tailscale-system-app/tsddns/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale-system/tailscale-system-app/tsddns/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml
+configMapGenerator:
+  - name: tsddns-config
+    files:
+      - config.json

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -46,3 +46,4 @@ resources:
   - ./volsync
   - ./zot
   - ./external-secrets
+  - ./tailscale-system

--- a/kubernetes/apps/ottawa/tailscale-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tailscale-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale-system-app.yaml

--- a/kubernetes/apps/ottawa/tailscale-system/namespace.yaml
+++ b/kubernetes/apps/ottawa/tailscale-system/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/ottawa/tailscale-system/tailscale-system-app.yaml
+++ b/kubernetes/apps/ottawa/tailscale-system/tailscale-system-app.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-system-app
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale-system/tailscale-system-app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -36,3 +36,4 @@ resources:
   - ./media
   - ./strimzi
   - ./tailscale-examples
+  - ./tailscale-system

--- a/kubernetes/apps/robbinsdale/tailscale-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale-system-app.yaml

--- a/kubernetes/apps/robbinsdale/tailscale-system/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-system/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/robbinsdale/tailscale-system/tailscale-system-app.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-system/tailscale-system-app.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-system-app
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale-system/tailscale-system-app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -34,3 +34,4 @@ resources:
   - ./open-cluster-management-agent
   - ./snapshot-controller
   - ./tailscale-examples
+  - ./tailscale-system

--- a/kubernetes/apps/stpetersburg/tailscale-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale-system-app.yaml

--- a/kubernetes/apps/stpetersburg/tailscale-system/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-system/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/stpetersburg/tailscale-system/tailscale-system-app.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-system/tailscale-system-app.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-system-app
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale-system/tailscale-system-app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## summary

verbatim copy of `clusters/common/apps/tailscale-system/app` →
`kubernetes/apps/base/tailscale-system/tailscale-system-app`

contains: tsddns CronJob, log-streaming, peer-relay StatefulSet, ds DaemonSet,
testing workloads, ai-kartik/ai-raj StatefulSets, derp-client.

pointer files + namespace.yaml for all 3 clusters. wave-f sequential app 2/4.

## gates

- make test ×3: 262/236/223 passed
- byte-identical dir diff confirmed
- PR-A touches only kubernetes/

## next

PR-B: remove clusters/common/apps/tailscale-system after verify.
after PR-B: verify tsddns CronJob still exists and last run state unchanged.

refs #1553