### PR TITLE
feat(tailscale): adopt operator/resources/csi-provider to kubernetes/ tree (PR-A)

### DIFF
--- a/kubernetes/apps/base/tailscale/operator/helmrelease.yaml
+++ b/kubernetes/apps/base/tailscale/operator/helmrelease.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: tailscale-operator
+      version: 1.98.4
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale
+        # name: tailscale-unstable
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    apiServerProxyConfig:
+      allowImpersonation: "true"
+      mode: "true"
+    operatorConfig:
+      # extraEnv:
+      #   - name: "TS_EXPERIMENTAL_KUBE_API_EVENTS"
+      #     value: "true"
+      # image:
+      #   repo: ghcr.io/rajsinghtech/tailscale/k8s-operator
+      #   tag: "80"
+      hostname: "${LOCATION}-k8s-operator"
+      logging: "info" # info, debug, dev
+      priorityClassName: "infra-critical"
+      defaultTags:
+        - "tag:${LOCATION}"
+        - "tag:k8s-operator"
+    proxyConfig:
+      defaultTags: "tag:k8s,tag:${LOCATION}"
+      # image:
+      #   repo: ghcr.io/rajsinghtech/tailscale/tailscale
+      #   tag: "80"

--- a/kubernetes/apps/base/tailscale/operator/secret.yaml
+++ b/kubernetes/apps/base/tailscale/operator/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: operator-oauth
+  namespace: tailscale
+type: Opaque
+stringData:
+  client_id: ${TS_OAUTH_CLIENT_ID}
+  client_secret: ${TS_OAUTH_CLIENT_SECRET}

--- a/kubernetes/apps/base/tailscale/resources/connector.yaml
+++ b/kubernetes/apps/base/tailscale/resources/connector.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: &name ${LOCATION}-subnetrouter
+spec:
+  replicas: 2
+  proxyClass: common
+  tags:
+    - tag:k8s
+    - tag:${LOCATION}
+  hostnamePrefix: *name
+  # exitNode: true
+  subnetRouter:
+    advertiseRoutes:
+      - "${LAN_CIDR}" # LAN
+      - "${CLUSTER_SERVICE_CIDR}" # K8s Services
+      - "${CLUSTER_POD_CIDR}" # K8s Pods
+      - "${CLUSTER_LOAD_BALANCER_CIDR}" # Tailscale
+      - fd7a:115c:a1e0:b1a:0:${SITE_ID}::/96 # 4via6
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: &name ${LOCATION}-appconnector
+spec:
+  replicas: 2
+  proxyClass: common
+  tags:
+    - tag:k8s
+    - tag:${LOCATION}
+  hostnamePrefix: *name
+  appConnector:
+    routes:
+      - "fd7a:115c:a1e0:b1a:0:${SITE_ID}::/96"

--- a/kubernetes/apps/base/tailscale/resources/dnsconfig.yaml
+++ b/kubernetes/apps/base/tailscale/resources/dnsconfig.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: DNSConfig
+metadata:
+  name: ts-dns
+spec:
+  nameserver:
+    replicas: 2
+    image:
+      # repo: ghcr.io/rajsinghtech/k8s-nameserver
+      tag: unstable
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-dns
+  namespace: tailscale
+spec:
+  ports:
+  - name: udp
+    port: 53
+    protocol: UDP
+    targetPort: 1053
+  - name: tcp
+    port: 53
+    protocol: TCP
+    targetPort: 1053
+  selector:
+    app: nameserver
+  sessionAffinity: None
+  type: LoadBalancer
+  loadBalancerIP: ${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.69.50 

--- a/kubernetes/apps/base/tailscale/resources/egress.yaml
+++ b/kubernetes/apps/base/tailscale/resources/egress.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-k8s-operator
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-k8s-operator.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ottawa-k8s-operator
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-k8s-operator.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: https
+    port: 443 
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-k8s-operator
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-k8s-operator.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-ottawa
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: kubernetes-ottawa.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+---
+# OCM gRPC registration server on Ottawa hub
+# Used by klusterlets on all clusters to reach the OCM gRPC server via Tailscale
+apiVersion: v1
+kind: Service
+metadata:
+  name: ocm-grpc-hub
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ocm-grpc-hub.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: grpc
+    port: 443
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-smb
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-ip: "192.168.50.115"
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+  - name: smb
+    port: 445
+    protocol: TCP

--- a/kubernetes/apps/base/tailscale/resources/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale/resources/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./connector.yaml
+  - ./proxyclass.yaml
+  - ./dnsconfig.yaml
+  - ./proxygroup.yaml
+  - ./recorder.yaml
+  - ./egress.yaml
+  - ./priorityclasses.yaml
+  - ./tailnet.yaml
+  # - ./tsjustworks-proxygroup.yaml
+  # Dashboards
+  - ./network-metrics.yaml

--- a/kubernetes/apps/base/tailscale/resources/network-metrics.yaml
+++ b/kubernetes/apps/base/tailscale/resources/network-metrics.yaml
@@ -1,0 +1,1173 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: tailscale-network-metrics
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: Tailscale
+  json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Dashboard for monitoring Tailscale health, connectivity, and performance in Kubernetes environments. Shows metrics for subnet routers, health messages, and network traffic for Tailscale proxies deployed by the Kubernetes operator.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Number of active Tailscale nodes",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "id": 15,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "count(count by(ts_proxy_parent_name) (tailscaled_health_messages{namespace=\"tailscale\", ts_proxy_type=~\"$proxy_type\"}))",
+              "legendFormat": "Active Nodes",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Active Tailscale Nodes",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Shows ACL and error dropped packets for incoming and outgoing traffic",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "packets/second",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "pps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 6,
+            "y": 0
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "sum by(reason)(rate(tailscaled_inbound_dropped_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", reason=\"acl\"}[$__rate_interval]))",
+              "legendFormat": "Inbound - {{reason}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "sum by(reason)(rate(tailscaled_outbound_dropped_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", reason=\"acl\"}[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "Outbound - {{reason}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "sum by(reason)(rate(tailscaled_inbound_dropped_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", reason=\"error\"}[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "Inbound - {{reason}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "sum by(reason)(rate(tailscaled_outbound_dropped_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", reason=\"error\"}[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "Outbound - {{reason}}",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "ACL and Error Dropped Packets",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Health statuses reported by Tailscale nodes",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 3
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 4
+          },
+          "id": 11,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "tailscaled_health_messages{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}",
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Health Messages",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "mode": "reduceRow",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Route approval percentage (% of advertised routes that are approved)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 50
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 8
+          },
+          "id": 30,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "100 * sum(tailscaled_approved_routes{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}) / sum(tailscaled_advertised_routes{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"})",
+              "legendFormat": "Approval Rate",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Route Approval Rate",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Inbound/outbound bytes/sec per interface",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*trans.*/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 6,
+            "y": 8
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "irate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", path=~\"$path\"}[$__rate_interval])*8",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{ts_proxy_parent_name}} recv {{path}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "irate(tailscaled_outbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", path=~\"$path\"}[$__rate_interval])*8",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{ts_proxy_parent_name}} trans {{path}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Network Traffic",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Advertised and approved subnet routes",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 12
+          },
+          "id": 12,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "tailscaled_advertised_routes{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}",
+              "legendFormat": "Advertised Routes",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "tailscaled_approved_routes{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Approved Routes",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Subnet Router",
+          "transformations": [
+            {
+              "filter": {
+                "id": "byRefId",
+                "options": "A"
+              },
+              "id": "calculateField",
+              "options": {
+                "alias": "Advertised Routes",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Advertised Routes"
+                  ],
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            },
+            {
+              "filter": {
+                "id": "byRefId",
+                "options": "B"
+              },
+              "id": "calculateField",
+              "options": {
+                "alias": "Approved Routes",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Approved Routes"
+                  ],
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "packets out (-) / in (+)",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "pps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*trans*//"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "rate(tailscaled_inbound_dropped_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{ts_proxy_parent_name}} recv {{reason}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "rate(tailscaled_outbound_dropped_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{ts_proxy_parent_name}} trans {{reason}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Network Dropped Packets",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "packets out (-) / in (+)",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "pps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*trans.*/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "rate(tailscaled_inbound_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{ts_proxy_parent_name}} recv {{path}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "rate(tailscaled_outbound_packets_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{ts_proxy_parent_name}} trans {{path}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Network Traffic by Packets",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Displays the distribution of connection types (DERP relays vs. direct IPv4/IPv6)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 0,
+            "y": 24
+          },
+          "id": 14,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", path=\"direct_ipv4\"}[$__rate_interval]))",
+              "legendFormat": "Direct IPv4",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", path=\"direct_ipv6\"}[$__rate_interval]))",
+              "legendFormat": "Direct IPv6",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", path=\"derp\"}[$__rate_interval]))",
+              "legendFormat": "DERP Relay",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Connection Types Distribution",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir-local"
+          },
+          "description": "Traffic efficiency - percentage of traffic going through direct connections vs DERP relays",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 30
+                  },
+                  {
+                    "color": "green",
+                    "value": 70
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 19,
+            "x": 5,
+            "y": 24
+          },
+          "id": 31,
+          "options": {
+            "displayMode": "gradient",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "maxVizHeight": 300,
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "100 * sum(rate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", path=~\"direct.*\"}[$__rate_interval])) / sum(rate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}[$__rate_interval]))",
+              "legendFormat": "Direct Connection %",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir-local"
+              },
+              "editorMode": "code",
+              "expr": "100 * sum(rate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\", path=\"derp\"}[$__rate_interval])) / sum(rate(tailscaled_inbound_bytes_total{namespace=\"tailscale\", ts_proxy_parent_name=~\"$node\", ts_proxy_type=~\"$proxy_type\"}[$__rate_interval]))",
+              "hide": false,
+              "legendFormat": "DERP Relay %",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Connection Efficiency",
+          "type": "bargauge"
+        }
+      ],
+      "preload": false,
+      "schemaVersion": 40,
+      "tags": [
+        "tailscale"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "definition": "label_values(tailscaled_health_messages{namespace=\"tailscale\"}, ts_proxy_parent_name)",
+            "includeAll": true,
+            "label": "Tailscale Node",
+            "name": "node",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(tailscaled_health_messages{namespace=\"tailscale\"}, ts_proxy_parent_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {},
+            "definition": "label_values(tailscaled_health_messages{namespace=\"tailscale\"}, ts_proxy_type)",
+            "includeAll": true,
+            "label": "Proxy Type",
+            "name": "proxy_type",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(tailscaled_health_messages{namespace=\"tailscale\"}, ts_proxy_type)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {},
+            "definition": "label_values(tailscaled_inbound_bytes_total{namespace=\"tailscale\"}, path)",
+            "includeAll": true,
+            "label": "Connection Path",
+            "name": "path",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(tailscaled_inbound_bytes_total{namespace=\"tailscale\"}, path)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Tailscale Network Metrics",
+      "uid": "de9fpk1payv40c",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/kubernetes/apps/base/tailscale/resources/priorityclasses.yaml
+++ b/kubernetes/apps/base/tailscale/resources/priorityclasses.yaml
@@ -1,0 +1,26 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: infra-critical
+value: 1000000000
+globalDefault: false
+description: "Critical infrastructure — Tailscale proxies, CNI, cert-manager, Flux controllers. Preempts lower-priority workloads during resource contention."
+preemptionPolicy: PreemptLowerPriority
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: infra-high
+value: 800000000
+globalDefault: false
+description: "Important platform services — Garage storage, monitoring, ingress gateways, database operators."
+preemptionPolicy: PreemptLowerPriority
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: infra-default
+value: 500000000
+globalDefault: false
+description: "Standard workloads that should not preempt critical infrastructure."
+preemptionPolicy: PreemptLowerPriority

--- a/kubernetes/apps/base/tailscale/resources/proxyclass.yaml
+++ b/kubernetes/apps/base/tailscale/resources/proxyclass.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: common
+spec:
+  metrics:
+    enable: true
+    serviceMonitor:
+      enable: true
+  statefulSet:
+    pod:
+      priorityClassName: "infra-high"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              tailscale.com/managed: "true"
+          matchLabelKeys:
+            - tailscale.com/parent-resource
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: common-accept-routes
+spec:
+  tailscale:
+    acceptRoutes: true
+  metrics:
+    enable: true
+    serviceMonitor:
+      enable: true
+  statefulSet:
+    pod:
+      priorityClassName: "infra-high"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              tailscale.com/managed: "true"
+          matchLabelKeys:
+            - tailscale.com/parent-resource
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: common-userspace
+spec:
+  statefulSet:
+    pod:
+      tailscaleContainer:
+        env:
+          - name: TS_USERSPACE
+            value: "true"
+        securityContext:
+          privileged: false
+          capabilities:
+            drop:
+              - ALL
+      tailscaleInitContainer:
+        securityContext:
+          privileged: false
+          capabilities:
+            drop:
+              - ALL
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: k8s-proxy-l4-test
+spec:
+  statefulSet:
+    pod:
+      tailscaleContainer:
+        image: ghcr.io/rajsinghtech/tailscale/k8s-proxy:81
+  metrics:
+    enable: true
+    serviceMonitor:
+      enable: true

--- a/kubernetes/apps/base/tailscale/resources/proxygroup.yaml
+++ b/kubernetes/apps/base/tailscale/resources/proxygroup.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: common-egress
+spec:
+  hostnamePrefix: ${LOCATION}-common-egress
+  tags:
+    - tag:k8s
+    - tag:${LOCATION}
+  proxyClass: common-accept-routes
+  type: egress
+  replicas: 3
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: common-ingress
+spec:
+  hostnamePrefix: ${LOCATION}-common-ingress
+  tags:
+    - tag:k8s
+    - tag:${LOCATION}
+  proxyClass: common
+  type: ingress
+  replicas: 3
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: ${LOCATION}-k8s
+spec:
+  type: kube-apiserver
+  replicas: 2
+  proxyClass: common
+  tags:
+    - tag:k8s-operator
+    - tag:${LOCATION}
+  kubeAPIServer:
+    mode: auth

--- a/kubernetes/apps/base/tailscale/resources/rbac.yaml
+++ b/kubernetes/apps/base/tailscale/resources/rbac.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tailnet-readers-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: tailnet-readers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tailnet-readers-ops
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["patch", "update"]
+- apiGroups: ["apps"]
+  resources: ["deployments/scale"]
+  verbs: ["patch", "update"]
+- apiGroups: ["source.toolkit.fluxcd.io"]
+  resources: ["gitrepositories", "helmrepositories", "ocirepositories"]
+  verbs: ["patch"]
+- apiGroups: ["kustomize.toolkit.fluxcd.io"]
+  resources: ["kustomizations"]
+  verbs: ["patch"]
+- apiGroups: ["helm.toolkit.fluxcd.io"]
+  resources: ["helmreleases"]
+  verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tailnet-readers-ops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tailnet-readers-ops
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: tailnet-readers 

--- a/kubernetes/apps/base/tailscale/resources/recorder.yaml
+++ b/kubernetes/apps/base/tailscale/resources/recorder.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Recorder
+metadata:
+  name: ${LOCATION}-recorder
+spec:
+  replicas: 1
+  statefulSet:
+    pod:
+      container:
+        image: docker.io/tailscale/tsrecorder:v1.98.4
+        env:
+          - name: TSRECORDER_SECURE
+            value: "false"
+  enableUI: true
+  tags:
+    - "tag:k8s"
+    - "tag:k8s-recorder"
+    - "tag:${LOCATION}"
+  # storage:
+  #   s3:
+  #     endpoint: garage.garage.svc.cluster.local:3900
+  #     bucket: tailscale-recorder
+  #     credentials:
+  #       secret:
+  #         name: s3-auth

--- a/kubernetes/apps/base/tailscale/resources/tailnet.yaml
+++ b/kubernetes/apps/base/tailscale/resources/tailnet.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tsjustworks-oauth
+  namespace: tailscale
+type: Opaque
+stringData:
+  client_id: ${TSJUSTWORKS_TS_OAUTH_CLIENT_ID}
+  client_secret: ${TSJUSTWORKS_TS_OAUTH_CLIENT_SECRET}
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Tailnet
+metadata:
+  name: tsjustworks
+spec:
+  credentials:
+    secretName: tsjustworks-oauth

--- a/kubernetes/apps/base/tailscale/resources/tsjustworks-proxygroup.yaml
+++ b/kubernetes/apps/base/tailscale/resources/tsjustworks-proxygroup.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: tsjustworks-egress
+spec:
+  hostnamePrefix: ${LOCATION}-egress
+  tags:
+    - tag:k8s
+    - tag:${LOCATION}
+  proxyClass: common-accept-routes
+  type: egress
+  tailnet: tsjustworks
+  replicas: 2
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: tsjustworks-ingress
+spec:
+  hostnamePrefix: ${LOCATION}-ingress
+  tags:
+    - tag:k8s
+    - tag:${LOCATION}
+  proxyClass: common
+  type: ingress
+  tailnet: tsjustworks
+  replicas: 2

--- a/kubernetes/apps/base/tailscale/tailscale-csi-provider/daemonset.yaml
+++ b/kubernetes/apps/base/tailscale/tailscale-csi-provider/daemonset.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tailscale-csi-provider
+  namespace: tailscale
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-csi-provider
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailscale-csi-provider
+    spec:
+      containers:
+        - name: tailscale-csi-provider
+          image: ghcr.io/rajsinghtech/tailscale/tailscale-csi-provider:dev
+          args:
+            - --socket=/var/run/secrets-store-csi-providers/tailscale.sock
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: "/var/run/secrets-store-csi-providers"
+              name: provider
+              mountPropagation: None
+              readOnly: false
+          env:
+            - name: TS_TAILNET
+              value: "-"
+          envFrom:
+            - secretRef:
+                name: tailscale-csi-provider
+      volumes:
+        - name: provider
+          hostPath:
+            path: /var/run/secrets-store-csi-providers
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/kubernetes/apps/base/tailscale/tailscale-csi-provider/examples/sidecar.yaml
+++ b/kubernetes/apps/base/tailscale/tailscale-csi-provider/examples/sidecar.yaml
@@ -1,0 +1,78 @@
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resourceNames: ["tailscale-auth"]
+    resources: ["secrets"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: "tailscale"
+roleRef:
+  kind: Role
+  name: tailscale
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  serviceAccountName: "tailscale"
+  containers:
+    - name: nginx
+      image: nginx
+    - name: ts-sidecar
+      imagePullPolicy: IfNotPresent
+      image: "ghcr.io/tailscale/tailscale:latest"
+      volumeMounts:
+        - name: authkey
+          mountPath: "/var/run/tailscale"
+          readOnly: true
+      env:
+        - name: TS_KUBE_SECRET
+          value: ""
+        - name: TS_USERSPACE
+          value: "false"
+        - name: TS_DEBUG_FIREWALL_MODE
+          value: auto
+        - name: TS_EXTRA_ARGS
+          value: --auth-key=file:/var/run/tailscale/authkey
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+      securityContext:
+        privileged: true
+  volumes:
+    - name: authkey
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: tailscale

--- a/kubernetes/apps/base/tailscale/tailscale-csi-provider/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale/tailscale-csi-provider/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secretproviderclass.yaml
+  # - daemonset.yaml
+  # - secret.yaml
+  # - examples/sidecar.yaml

--- a/kubernetes/apps/base/tailscale/tailscale-csi-provider/secret.yaml
+++ b/kubernetes/apps/base/tailscale/tailscale-csi-provider/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-csi-provider
+  namespace: tailscale
+type: Opaque
+stringData:
+  TS_API_CLIENT_ID: ${TS_OAUTH_CLIENT_ID}
+  TS_API_CLIENT_SECRET: ${TS_OAUTH_CLIENT_SECRET}

--- a/kubernetes/apps/base/tailscale/tailscale-csi-provider/secretproviderclass.yaml
+++ b/kubernetes/apps/base/tailscale/tailscale-csi-provider/secretproviderclass.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: tailscale
+spec:
+  provider: tailscale

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -53,3 +53,4 @@ resources:
   - ./envoy-gateway-system
   - ./flux-system
   - ./node-feature-discovery
+  - ./tailscale

--- a/kubernetes/apps/ottawa/tailscale/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tailscale/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale.yaml

--- a/kubernetes/apps/ottawa/tailscale/namespace.yaml
+++ b/kubernetes/apps/ottawa/tailscale/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/ottawa/tailscale/tailscale.yaml
+++ b/kubernetes/apps/ottawa/tailscale/tailscale.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-operator
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-operator-resources
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/resources
+  dependsOn:
+    - name: tailscale-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-csi-provider
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/tailscale-csi-provider
+  dependsOn:
+    - name: tailscale-operator
+    - name: csi-secrets-store-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -44,3 +44,4 @@ resources:
   - ./node-feature-discovery
   - ./tailscale-examples
   - ./tailscale-system
+  - ./tailscale

--- a/kubernetes/apps/robbinsdale/tailscale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale.yaml

--- a/kubernetes/apps/robbinsdale/tailscale/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/robbinsdale/tailscale/tailscale.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale/tailscale.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-operator
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-operator-resources
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/resources
+  dependsOn:
+    - name: tailscale-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-csi-provider
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/tailscale-csi-provider
+  dependsOn:
+    - name: tailscale-operator
+    - name: csi-secrets-store-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -43,3 +43,4 @@ resources:
   - ./node-feature-discovery
   - ./tailscale-examples
   - ./tailscale-system
+  - ./tailscale

--- a/kubernetes/apps/stpetersburg/tailscale/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tailscale.yaml

--- a/kubernetes/apps/stpetersburg/tailscale/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/stpetersburg/tailscale/tailscale.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale/tailscale.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-operator
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-operator-resources
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/resources
+  dependsOn:
+    - name: tailscale-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-csi-provider
+  namespace: flux-system
+spec:
+  targetNamespace: tailscale
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/tailscale/tailscale-csi-provider
+  dependsOn:
+    - name: tailscale-operator
+    - name: csi-secrets-store-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Adopt `clusters/common/apps/tailscale` (operator, resources, csi-provider) into the `kubernetes/` tree. Three CRs in a single multi-document pointer file per location. Verbatim base copy — byte-identical to source. PR-B will remove the `clusters/common/apps/tailscale` dir after adoption is verified on all 3 clusters.

**Migration gates after merge (all 3 clusters):**
- tailscale-operator pod startTime unchanged
- connectors/proxygroups all present and ready
- kubectl context still works (API proxy)
- ts-dns LB IP unchanged

Part of #1553.