### PR TITLE
migrate(wave-d): adopt storage and node-plumbing apps to kubernetes/ tree (PR-A)

### DIFF
--- a/kubernetes/apps/base/cert-manager/cert-manager-issuers-robbinsdale/issuers/luke-clusterissuer.yaml
+++ b/kubernetes/apps/base/cert-manager/cert-manager-issuers-robbinsdale/issuers/luke-clusterissuer.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: luke-issuer
+spec:
+  acme:
+    email: lukehouge@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-key
+    solvers:
+    - dns01:
+        cloudflare:
+          email: lukehouge@gmail.com
+          apiTokenSecretRef:
+            name: cloudflare-luke
+            key: cert-manager-api-token

--- a/kubernetes/apps/base/cert-manager/cert-manager-issuers-robbinsdale/issuers/raj-clusterissuer.yaml
+++ b/kubernetes/apps/base/cert-manager/cert-manager-issuers-robbinsdale/issuers/raj-clusterissuer.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: rajsingh-info
+spec:
+  acme:
+    email: rajsinghcpre@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-key
+    solvers:
+    - dns01:
+        cloudflare:
+          email: rajsinghcpre@gmail.com
+          apiTokenSecretRef:
+            name: cloudflare-raj
+            key: cert-manager-api-token

--- a/kubernetes/apps/base/cert-manager/cert-manager-issuers-robbinsdale/issuers/secret.yaml
+++ b/kubernetes/apps/base/cert-manager/cert-manager-issuers-robbinsdale/issuers/secret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-raj
+  namespace: cert-manager
+type: Opaque
+stringData:
+  cert-manager-api-token: ${RAJSINGH_INFO_CLOUDFLARE_API_TOKEN}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-luke
+  namespace: cert-manager
+type: Opaque
+stringData:
+  cert-manager-api-token: ${LUKEHOUGE_COM_CERTMANAGER_API_TOKEN}

--- a/kubernetes/apps/base/cloudflare/cloudflare-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare-stpetersburg/app/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: cloudflare
 resources:
-  - ./namespace.yaml
-  - ./cert-manager.yaml
-  - ./cert-manager-issuers.yaml
+  - openwebui.yaml

--- a/kubernetes/apps/base/cloudflare/cloudflare-stpetersburg/app/openwebui.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare-stpetersburg/app/openwebui.yaml
@@ -1,0 +1,37 @@
+# ---
+# apiVersion: helm.toolkit.fluxcd.io/v2
+# kind: HelmRelease
+# metadata:
+#   name: open-webui
+# spec:
+#   interval: 1m
+#   chart:
+#     spec:
+#       chart: open-webui
+#       version: "10.2.1"
+#       sourceRef:
+#         kind: HelmRepository
+#         name: open-webui
+#         namespace: flux-system
+#       interval: 1m
+#   releaseName: open-webui
+#   values:
+#     ollama:
+#       enabled: false
+
+#     ollamaUrls:
+#       - "http://stpetersburg-ollama.ai:11434"
+
+#     extraEnvVars:
+#       - name: WEBUI_AUTH_TRUSTED_EMAIL_HEADER
+#         value: Cf-Access-Authenticated-User-Email
+#       - name: ENABLE_RAG_WEB_SEARCH
+#         value: "True"
+#       - name: RAG_WEB_SEARCH_ENGINE
+#         value: "searxng"
+#       - name: RAG_WEB_SEARCH_RESULT_COUNT
+#         value: "3"
+#       - name: RAG_WEB_SEARCH_CONCURRENT_REQUESTS
+#         value: "10"
+#       - name: SEARXNG_QUERY_URL
+#         value: "http://searxng:8080/search?q=<query>"

--- a/kubernetes/apps/base/cloudflare/cloudflared-robbinsdale/cloudflared/cloudflared-luke.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflared-robbinsdale/cloudflared/cloudflared-luke.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cloudflared-luke
+  name: cloudflared-luke
+  namespace: cloudflared
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      pod: cloudflared-luke
+  template:
+    metadata:
+      labels:
+        pod: cloudflared-luke
+    spec:
+      containers:
+        - command:
+            - cloudflared
+            - tunnel
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+          args:
+            - --token
+            - $(token)
+          image: cloudflare/cloudflared:latest
+          name: cloudflared
+          env:
+            - name: token
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared
+                  key: "cloudflared-k8s-tunnel-token-lukehouge-com"
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: "0.5"
+              memory: "256Mi"
+            requests:
+              cpu: "0.2"
+              memory: "128Mi"
+      # dnsPolicy: None
+      # dnsConfig:
+      #   nameservers:
+      #     - 10.50.10.50
+      #     - 10.50.69.10
+      #   options:
+      #     - name: ndots
+      #       value: "2"

--- a/kubernetes/apps/base/cloudflare/cloudflared-robbinsdale/cloudflared/kustomization.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflared-robbinsdale/cloudflared/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: cloudflare
 resources:
-  - ./namespace.yaml
-  - ./cert-manager.yaml
-  - ./cert-manager-issuers.yaml
+  - cloudflared-luke.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/cloudflare/cloudflared-robbinsdale/cloudflared/secret.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflared-robbinsdale/cloudflared/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflared
+  namespace: cloudflare
+type: Opaque
+stringData:
+  cloudflared-k8s-tunnel-token-lukehouge-com: ${CLOUDFLARED_TUNNEL_TOKEN_LUKEHOUGE_COM}
+  cloudflared-k8s-tunnel-token-rajsingh-info: ${RAJSINGH_INFO_CLOUDFLARED_TOKEN}

--- a/kubernetes/apps/base/csi-addons/csi-addons-config-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/csi-addons/csi-addons-config-ottawa/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./networkfenceclass.yaml

--- a/kubernetes/apps/base/csi-addons/csi-addons-config-ottawa/app/networkfenceclass.yaml
+++ b/kubernetes/apps/base/csi-addons/csi-addons-config-ottawa/app/networkfenceclass.yaml
@@ -1,0 +1,18 @@
+---
+# NetworkFenceClass tells CephCSI how to fence a failed node's RBD client.
+# When a node is tainted node.kubernetes.io/out-of-service=...:NoExecute, the
+# CephCSI driver auto-creates a NetworkFence referencing this class, which
+# blocklists the dead node in Ceph (breaking its exclusive-lock) so RWO volumes
+# can immediately reattach on a healthy node instead of waiting out the kubelet
+# force-detach timeout + a stale Ceph lock.
+# Secret + clusterID match the rook-csi-rbd-provisioner used by the StorageClass.
+apiVersion: csiaddons.openshift.io/v1alpha1
+kind: NetworkFenceClass
+metadata:
+  name: ceph-rbd-network-fence
+spec:
+  provisioner: rook-ceph.rbd.csi.ceph.com
+  parameters:
+    clusterID: rook-ceph
+    csiaddons.openshift.io/networkfence-secret-name: rook-csi-rbd-provisioner
+    csiaddons.openshift.io/networkfence-secret-namespace: rook-ceph

--- a/kubernetes/apps/base/csi-addons/csi-addons-config-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/csi-addons/csi-addons-config-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./networkfenceclass.yaml

--- a/kubernetes/apps/base/csi-addons/csi-addons-config-robbinsdale/app/networkfenceclass.yaml
+++ b/kubernetes/apps/base/csi-addons/csi-addons-config-robbinsdale/app/networkfenceclass.yaml
@@ -1,0 +1,18 @@
+---
+# NetworkFenceClass tells CephCSI how to fence a failed node's RBD client.
+# When a node is tainted node.kubernetes.io/out-of-service=...:NoExecute, the
+# CephCSI driver auto-creates a NetworkFence referencing this class, which
+# blocklists the dead node in Ceph (breaking its exclusive-lock) so RWO volumes
+# can immediately reattach on a healthy node instead of waiting out the kubelet
+# force-detach timeout + a stale Ceph lock.
+# Secret + clusterID match the rook-csi-rbd-provisioner used by the StorageClass.
+apiVersion: csiaddons.openshift.io/v1alpha1
+kind: NetworkFenceClass
+metadata:
+  name: ceph-rbd-network-fence
+spec:
+  provisioner: rook-ceph.rbd.csi.ceph.com
+  parameters:
+    clusterID: rook-ceph
+    csiaddons.openshift.io/networkfence-secret-name: rook-csi-rbd-provisioner
+    csiaddons.openshift.io/networkfence-secret-namespace: rook-ceph

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: csi-driver-smb
+  namespace: csi-driver-smb
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: csi-driver-smb
+      version: 1.20.1
+      sourceRef:
+        kind: HelmRepository
+        name: csi-driver-smb
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values: {}

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - secret.yaml
+  - storageclass.yaml 

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/secret.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-smbcreds
+stringData:
+  username: ${SMB_USERNAME}
+  password: ${SMB_PASSWORD}

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/storageclass.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app/storageclass.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nagato-smb
+provisioner: smb.csi.k8s.io
+parameters:
+  source: //192.168.169.111/media-share
+  # if csi.storage.k8s.io/provisioner-secret is provided, will create a sub directory
+  # with PV name under source
+  csi.storage.k8s.io/provisioner-secret-name: csi-smbcreds
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-smbcreds
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+reclaimPolicy: Delete  # available values: Delete, Retain
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+mountOptions:
+  - dir_mode=0777
+  - file_mode=0777
+  - uid=1001
+  - gid=1001
+  - retrans=3 

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/helmrelease.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: csi-driver-smb
+  namespace: csi-driver-smb
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: csi-driver-smb
+      version: 1.20.1
+      sourceRef:
+        kind: HelmRepository
+        name: csi-driver-smb
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3 
+  values:
+    windows:
+      enabled: false

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - secret.yaml
+  - storageclass.yaml 

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/secret.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-smbcreds
+  namespace: kube-system
+type: Opaque
+stringData:
+  username: ${SMB_USERNAME}
+  password: ${SMB_PASSWORD}

--- a/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/storageclass.yaml
+++ b/kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app/storageclass.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: unas-smb
+provisioner: smb.csi.k8s.io
+parameters:
+  source: //192.168.50.115/k8s_shortsnap
+  # if csi.storage.k8s.io/provisioner-secret is provided, will create a sub directory
+  # with PV name under source
+  csi.storage.k8s.io/provisioner-secret-name: csi-smbcreds
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-smbcreds
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+reclaimPolicy: Delete  # available values: Delete, Retain
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+mountOptions:
+  - dir_mode=0777
+  - file_mode=0777
+  - uid=1001
+  - gid=1001

--- a/kubernetes/apps/base/flux-system/flux-system-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/flux-system-stpetersburg/app/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: flux-system
 resources:
-  - ./namespace.yaml
-  - ./cert-manager.yaml
-  - ./cert-manager-issuers.yaml
+  - ./networkpolicy-monitoring.yaml

--- a/kubernetes/apps/base/flux-system/flux-system-stpetersburg/app/networkpolicy-monitoring.yaml
+++ b/kubernetes/apps/base/flux-system/flux-system-stpetersburg/app/networkpolicy-monitoring.yaml
@@ -1,0 +1,23 @@
+---
+# Allow Prometheus in the monitoring namespace to scrape Flux controller
+# metrics endpoints (port 8080). The common `allow-gatus` NP only opens
+# port 9090 from the gatus namespace, leaving Prometheus blocked which
+# trips PrometheusTargetDown on every flux controller. Robbinsdale and
+# Ottawa don't see this regression; add the policy explicitly on StP.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: flux-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 8080
+          protocol: TCP

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Applied by the cluster-apps Kustomization (which recursively builds
+# clusters/talos-stpetersburg/apps). `namespace` pins these namespaced GarageNode
+# CRs to the garage namespace — without it cluster-apps applies them with no
+# namespace and fails ("namespace not specified").
+namespace: garage
+resources:
+  - stpetersburg-garage-localpath-spark-0.yaml
+  - stpetersburg-garage-localpath-spark-1.yaml
+  - stpetersburg-garage-localpath-orin-0.yaml
+  - service-ts-storage.yaml

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/service-ts-storage.yaml
@@ -1,0 +1,72 @@
+---
+# Per-storage-pod Tailscale LB for cross-region RPC connectivity.
+# Each stpetersburg storage pod needs its own routable address so other
+# regions' Garage nodes can ConnectClusterNodes() to a specific peer.
+# The shared garage-ts LB (service-ts.yaml) only routes to ONE storage pod
+# at a time, leaving the second pod permanently "Not connected" from the
+# perspective of remote regions — this breaks write quorum (RF=2 requires
+# both storage nodes reachable) and causes S3 multipart uploads like
+# Tailscale log streaming to fail with "Could not reach quorum of 2."
+#
+# Each of these per-pod LBs pins to exactly one storage pod via
+# statefulset.kubernetes.io/pod-name.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: stpetersburg-garage-spark-0
+    tailscale.com/tags: "tag:k8s,tag:stpetersburg"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-spark-0-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: stpetersburg-garage-localpath-spark-0-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: stpetersburg-garage-spark-1
+    tailscale.com/tags: "tag:k8s,tag:stpetersburg"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-spark-1-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: stpetersburg-garage-localpath-spark-1-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+# Per-pod Tailscale LB for the 3rd storage node on orin-0.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: stpetersburg-garage-orin-0
+    tailscale.com/tags: "tag:k8s,tag:stpetersburg"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-orin-0-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: stpetersburg-garage-localpath-orin-0-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/stpetersburg-garage-localpath-orin-0.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/stpetersburg-garage-localpath-orin-0.yaml
@@ -1,0 +1,34 @@
+---
+# Orin-0 storage node — 3rd storage node for St. Petersburg, adding capacity
+# to bring us from RF=2 to RF=3 replication tolerance.
+#
+# Backend = local-path, pinned to orin-0 (jetson-orin-nano-super, 512GB NVMe).
+# Dynamic PVCs via spec.storage.{metadata,data}.size — no existingClaim needed
+# since this is a fresh node with no prior data to migrate.
+#
+# NodeSelector overrides the GarageCluster default (dgx-spark) to target orin-0.
+# The operator auto-discovers the nodeId from the pod's Garage admin API on
+# first connect, so nodeId is omitted here.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: stpetersburg-garage-localpath-orin-0
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 200Gi
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+  network:
+    rpcPublicAddr: "stpetersburg-garage-orin-0.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      size: 1Gi
+      storageClassName: local-path
+    data:
+      size: 200Gi
+      storageClassName: local-path
+  nodeSelector:
+    node.kubernetes.io/instance-type: jetson-orin-nano-super

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/stpetersburg-garage-localpath-spark-0.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/stpetersburg-garage-localpath-spark-0.yaml
@@ -1,0 +1,36 @@
+---
+# Spark-0 storage node (renamed from garage-storage-0 to the descriptive
+# <location>-garage-<backend>-<node> convention). Backend = local-path, pinned
+# to spark-0. node_key/identity 5b58bb8e… and all data are preserved via
+# existingClaim (same metadata + data PVCs). spec.tags keep the legacy
+# garage-storage-0-0 layout-role tag verbatim so the rename is a zero-churn
+# no-op (the layout tag is decoupled from the CR name).
+#
+# Created suspended for the staged rename cutover: local-path RWO is not
+# kernel-enforced across same-node pods, so the old garage-storage-0 is deleted
+# (skip-drain, identity role retained in layout) before this node is unsuspended
+# onto the freed PVCs. Reverted in the same change that removes garage-storage-0.
+#
+# Per-Spark "storage array" hook: add spec.storage.dataPaths[] here for a
+# multi-disk array on spark-0 without touching the other Spark or common config.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: stpetersburg-garage-localpath-spark-0
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: 5b58bb8e679ba9689288b12814e788b5ec8f5217a9bb556d175e33de35762e66
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-0-0
+  network:
+    rpcPublicAddr: "stpetersburg-garage-spark-0.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      existingClaim: metadata-garage-0
+    data:
+      existingClaim: data-garage-0

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/stpetersburg-garage-localpath-spark-1.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/stpetersburg-garage-localpath-spark-1.yaml
@@ -1,0 +1,33 @@
+---
+# Spark-1 storage node (renamed from garage-storage-1). Backend = local-path,
+# pinned to spark-1. node_key/identity f863543b… and all data preserved via
+# existingClaim. spec.tags keep the legacy garage-storage-1-0 layout-role tag
+# verbatim so the rename is a zero-churn no-op.
+#
+# Created suspended for the staged rename cutover (see spark-0 for the runbook):
+# old garage-storage-1 deleted skip-drain, then this node unsuspended onto the
+# freed PVCs.
+#
+# Add spec.storage.dataPaths[] here to describe a multi-disk array on spark-1
+# independently of spark-0.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageNode
+metadata:
+  name: stpetersburg-garage-localpath-spark-1
+spec:
+  clusterRef:
+    name: garage
+  zone: "${LOCATION}"
+  capacity: 2Ti
+  nodeId: f863543b50d70a7b516c3092520908f90162720a82fd6a5ccfe06069ef0c82b7
+  tags:
+    - cluster:garage/garage
+    - tier:storage
+    - garage-storage-1-0
+  network:
+    rpcPublicAddr: "stpetersburg-garage-spark-1.keiretsu.ts.net:3901"
+  storage:
+    metadata:
+      existingClaim: metadata-garage-1
+    data:
+      existingClaim: data-garage-1

--- a/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/dcgm.yaml
+++ b/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/dcgm.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: nvidia-dcgm
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: NVIDIA
+  url: https://raw.githubusercontent.com/NVIDIA/dcgm-exporter/main/grafana/dcgm-exporter-dashboard.json

--- a/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/gpu-metrics.yaml
+++ b/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/gpu-metrics.yaml
@@ -1,0 +1,2178 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: nvidia-gpu-metrics
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: NVIDIA
+  json: |
+    {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "Prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__elements": {},
+      "__requires": [
+        {
+          "type": "panel",
+          "id": "bargauge",
+          "name": "Bar gauge",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "gauge",
+          "name": "Gauge",
+          "version": ""
+        },
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "11.1.0"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "stat",
+          "name": "Stat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Nvidia GPU Metrics based on the prometheus metrics from github.com/utkuozdemir/nvidia_gpu_exporter",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "gnetId": 14574,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The official product name of the GPU. This is an alphanumeric string. For all products.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 0,
+            "y": 0
+          },
+          "id": 23,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_gpu_info{uuid=\"$gpu\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Name",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The current performance state for the GPU. States range from P0 (maximum performance) to P12 (minimum performance).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "": {
+                      "text": ""
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "prefix:P"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 4,
+            "y": 0
+          },
+          "id": 22,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_pstate{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "P-State",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Percent of time over the past sample period during which one or more kernels was executing on the GPU.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 6,
+            "y": 0
+          },
+          "id": 6,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_utilization_gpu_ratio{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Utilization %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The last measured power draw for the entire board, in watts. Only available if power management is supported. This reading is accurate to within +/- 5 watts / The software power limit in watts.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 9,
+            "y": 0
+          },
+          "id": 21,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_power_draw_watts{uuid=\"$gpu\"} / nvidia_smi_power_default_limit_watts{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Power Draw %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The fan speed value is the percent of the product's maximum noise tolerance fan speed that the device's fan is currently intended to run at. This value may exceed 100% in certain cases. Note: The reported speed is the intended fan speed. If the fan is physically blocked and unable to spin, this output will not match the actual fan speed. Many parts do not report fan speeds because they rely on cooling via fans in the surrounding enclosure.\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 12,
+            "y": 0
+          },
+          "id": 4,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_fan_speed_ratio{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Fan Speed %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Core GPU temperature. in degrees C.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 15,
+            "y": 0
+          },
+          "id": 16,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_temperature_gpu{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Temperature",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Percent of time over the past sample period during which global (device) memory was being read or written.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line+area"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_utilization_memory_ratio{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Utilization %",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The version of the installed NVIDIA display driver. This is an alphanumeric string.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 0,
+            "y": 3
+          },
+          "id": 14,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_gpu_info{uuid=\"$gpu\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{driver_version}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Driver Version",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The BIOS of the GPU board.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 3,
+            "y": 3
+          },
+          "id": 34,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_gpu_info{uuid=\"$gpu\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{vbios_version}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Vbios Version",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Information about factors that are reducing the frequency of clocks. If all throttle reasons are returned as \"Not Active\" it means that clocks are running as high as possible.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "text": "Not Active"
+                    },
+                    "1": {
+                      "text": "Active"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 5
+          },
+          "id": 32,
+          "options": {
+            "displayMode": "gradient",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_throttle_reasons_gpu_idle{uuid=\"$gpu\"}",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Idle",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown{uuid=\"$gpu\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "HW Thermal Slowdown",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_throttle_reasons_sw_power_cap{uuid=\"$gpu\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "SW Power Cap",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_throttle_reasons_applications_clocks_setting{uuid=\"$gpu\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "App Clocks Setting",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown{uuid=\"$gpu\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "HW Power Brake",
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown{uuid=\"$gpu\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "SW Thermal Slowdown",
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_throttle_reasons_sync_boost{uuid=\"$gpu\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Sync Boost",
+              "refId": "G"
+            }
+          ],
+          "title": "Throttle Reasons",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Current frequency of graphics (shader) clock\n/\nMaximum frequency of graphics (shader) clock.\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 6,
+            "y": 5
+          },
+          "id": 20,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_current_graphics_clock_hz{uuid=\"$gpu\"} / nvidia_smi_clocks_max_graphics_clock_hz{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Clock Speed %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Current frequency of memory clock / Maximum frequency of memory clock",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 9,
+            "y": 5
+          },
+          "id": 33,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_current_memory_clock_hz{uuid=\"$gpu\"} / nvidia_smi_clocks_max_memory_clock_hz{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Clock Speed %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Total memory allocated by active contexts / Total installed GPU memory.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 12,
+            "y": 5
+          },
+          "id": 25,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_memory_used_bytes{uuid=\"$gpu\"} / nvidia_smi_memory_total_bytes{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Allocation %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Percent of time over the past sample period during which global (device) memory was being read or written.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 15,
+            "y": 5
+          },
+          "id": 7,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_utilization_memory_ratio{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Utilization %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Percent of time over the past sample period during which one or more kernels was executing on the GPU.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line+area"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 5
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_utilization_gpu_ratio{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Utilization %",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Total memory allocated by active contexts.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 10
+          },
+          "id": 17,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_memory_used_bytes{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Allocation",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Core GPU temperature. in degrees C.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line+area"
+                }
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 10
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_temperature_gpu{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Temperature",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The last measured power draw for the entire board, in watts. Only available if power management is supported. This reading is accurate to within +/- 5 watts",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 10
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_power_draw_watts{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Power Draw",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The fan speed value is the percent of the product's maximum noise tolerance fan speed that the device's fan is currently intended to run at. This value may exceed 100% in certain cases. Note: The reported speed is the intended fan speed. If the fan is physically blocked and unable to spin, this output will not match the actual fan speed. Many parts do not report fan speeds because they rely on cooling via fans in the surrounding enclosure.\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line+area"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 10
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_fan_speed_ratio{uuid=\"$gpu\"}",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Fan Speed %",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Current frequency of graphics (shader) clock.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "hertz"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 15
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_current_graphics_clock_hz{uuid=\"$gpu\"}",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Graphics Clock Speed",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Current frequency of video encoder/decoder clock.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "hertz"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 15
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_current_video_clock_hz{uuid=\"$gpu\"}",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Video Clock Speed",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Current frequency of SM (Streaming Multiprocessor) clock.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "hertz"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 15
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_current_sm_clock_hz{uuid=\"$gpu\"}",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "SM Clock Speed",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Current frequency of memory clock.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "hertz"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 15
+          },
+          "id": 18,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "nvidia_smi_clocks_current_memory_clock_hz{uuid=\"$gpu\"}",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{uuid}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Clock Speed",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 39,
+      "tags": [
+        "nvidia",
+        "nvidia-smi",
+        "nvidia_gpu_exporter",
+        "prometheus"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "label_values(nvidia_smi_index, uuid)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "GPU",
+            "multi": false,
+            "name": "gpu",
+            "options": [],
+            "query": {
+              "query": "label_values(nvidia_smi_index, uuid)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Nvidia GPU Metrics",
+      "uid": "vlvPlrgnk",
+      "version": 7,
+      "weekStart": ""
+    }

--- a/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gpu-operator
+  namespace: gpu-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gpu-operator
+      version: "v26.3.2"
+      sourceRef:
+        kind: HelmRepository
+        name: nvidia
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Talos provides NVIDIA driver and container-toolkit via system extensions
+    # (nonfree-kmod-nvidia-lts, nvidia-container-toolkit-lts). gpu-operator
+    # only needs to deploy the userspace bits.
+    driver:
+      enabled: false
+    toolkit:
+      enabled: false
+    # Where Talos's nvidia extension installs runtime binaries (ext-nvidia-cdi-gen
+    # writes CDI specs here, and gpu-operator's validator needs nvidia-ctk reachable).
+    hostPaths:
+      driverInstallDir: /run/nvidia/driver
+    operator:
+      defaultRuntime: containerd
+      runtimeClass: nvidia
+    devicePlugin:
+      enabled: true
+      # No time-slicing — default replicas: 1 per GPU. Single vLLM consumer per
+      # spark doesn't benefit from fictitious slot multiplication (research 2026-05-11).
+    # NFD already deployed separately at node-feature-discovery namespace
+    nfd:
+      enabled: false
+    # MIG not supported on GB10 (consumer-grade SoC, no firmware path)
+    mig:
+      strategy: none
+    # GPU Feature Discovery: adds nvidia.com/gpu.* labels for scheduling
+    gfd:
+      enabled: true
+    # DCGM exporter for Prometheus metrics
+    dcgmExporter:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    nodeStatusExporter:
+      enabled: true
+    # GPU operator's validator runs nvidia-smi after device-plugin DS
+    # is ready; WITH_WORKLOAD=false skips a CUDA test pod (no spare GPU)
+    validator:
+      plugin:
+        env:
+          - name: WITH_WORKLOAD
+            value: "false"

--- a/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Note: gpu-operator chart manages the `nvidia` RuntimeClass via its
+  # ClusterPolicy CR; standalone runtimeclass.yaml removed to avoid conflict.
+  # No time-slicing — each spark has 1 vLLM consumer; default replicas: 1.
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/nebius.yaml
+++ b/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/nebius.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: nvidia-nebius
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  folder: NVIDIA
+  grafanaCom:
+    id: 23423

--- a/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/servicemonitor.yaml
+++ b/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/servicemonitor.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: gpu-operator
+  labels:
+    app: nvidia-dcgm-exporter
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter
+  endpoints:
+    - port: gpu-metrics
+      interval: 30s
+      path: /metrics

--- a/kubernetes/apps/base/k8s-gpu-dra-driver/k8s-gpu-dra-driver-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/k8s-gpu-dra-driver/k8s-gpu-dra-driver-ottawa/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: k8s-gpu-dra-driver
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.1.0
+  url: oci://ghcr.io/buroa/helm/k8s-gpu-dra-driver
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: k8s-gpu-dra-driver
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: k8s-gpu-dra-driver
+  interval: 1h
+  values:
+    cdi:
+      dynamicPath: /var/cdi/dynamic
+    image:
+      repository: ghcr.io/buroa/k8s-gpu-dra-driver
+      tag: v0.1.0@sha256:6aad2f4bfedf894981bdad2bcbf164b8696e1073ca87f7d06ce952feb38d9d89
+    kubeletPlugin:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: extensions.talos.dev/amdgpu
+                    operator: Exists

--- a/kubernetes/apps/base/k8s-gpu-dra-driver/k8s-gpu-dra-driver-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/k8s-gpu-dra-driver/k8s-gpu-dra-driver-ottawa/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/base/local-path-storage/local-path-storage-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/local-path-storage/local-path-storage-ottawa/app/kustomization.yaml
@@ -1,0 +1,48 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - local-path-provisioner.yaml
+patches:
+  - patch: |-
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: local-path-config
+        namespace: local-path-storage
+      data:
+        config.json: |-
+          {
+                  "nodePathMap":[
+                  {
+                          "node":"shiro",
+                          "paths":["/var/local-path-provisioner"]
+                  },
+                  {
+                          "node":"kaji",
+                          "paths":["/var/local-path-provisioner"]
+                  },
+                  {
+                          "node":"asuka",
+                          "paths":["/var/local-path-provisioner"]
+                  },
+                  {
+                          "node":"rei",
+                          "paths":["/var/local-path-provisioner"]
+                  }
+                  ]
+          }
+  - patch: |-
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: local-path
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "false"
+      allowVolumeExpansion: true
+  - patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: local-path-storage
+        labels:
+          pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/base/local-path-storage/local-path-storage-ottawa/app/local-path-provisioner.yaml
+++ b/kubernetes/apps/base/local-path-storage/local-path-storage-ottawa/app/local-path-provisioner.yaml
@@ -1,0 +1,191 @@
+# Vendored from github.com/rancher/local-path-provisioner/deploy?ref=v0.0.36
+# re-render with: kustomize build 'github.com/rancher/local-path-provisioner/deploy?ref=v0.0.36'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumeclaims
+  - configmaps
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: v1
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: docker.io/library/busybox
+        imagePullPolicy: IfNotPresent
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+kind: ConfigMap
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      containers:
+      - command:
+        - local-path-provisioner
+        - --debug
+        - start
+        - --config
+        - /etc/config/config.json
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_MOUNT_PATH
+          value: /etc/config/
+        image: docker.io/rancher/local-path-provisioner:v0.0.36
+        imagePullPolicy: IfNotPresent
+        name: local-path-provisioner
+        volumeMounts:
+        - mountPath: /etc/config/
+          name: config-volume
+      serviceAccountName: local-path-provisioner-service-account
+      volumes:
+      - configMap:
+          name: local-path-config
+        name: config-volume

--- a/kubernetes/apps/base/local-path-storage/local-path-storage-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/local-path-storage/local-path-storage-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - local-path-provisioner.yaml
+patches:
+  - patch: |-
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: local-path-config
+        namespace: local-path-storage
+      data:
+        config.json: |-
+          {
+                  "nodePathMap":[
+                  {
+                          "node":"stone",
+                          "paths":["/var/local-path-provisioner"]
+                  },
+                  {
+                          "node":"tank",
+                          "paths":["/var/local-path-provisioner"]
+                  },
+                  {
+                          "node":"titan",
+                          "paths":["/var/local-path-provisioner"]
+                  }
+                  ]
+          }
+  - patch: |-
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: local-path
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "false"
+      allowVolumeExpansion: true
+  - patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: local-path-storage
+        labels:
+          pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/base/local-path-storage/local-path-storage-robbinsdale/app/local-path-provisioner.yaml
+++ b/kubernetes/apps/base/local-path-storage/local-path-storage-robbinsdale/app/local-path-provisioner.yaml
@@ -1,0 +1,191 @@
+# Vendored from github.com/rancher/local-path-provisioner/deploy?ref=v0.0.36
+# re-render with: kustomize build 'github.com/rancher/local-path-provisioner/deploy?ref=v0.0.36'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumeclaims
+  - configmaps
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: v1
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: docker.io/library/busybox
+        imagePullPolicy: IfNotPresent
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+kind: ConfigMap
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      containers:
+      - command:
+        - local-path-provisioner
+        - --debug
+        - start
+        - --config
+        - /etc/config/config.json
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_MOUNT_PATH
+          value: /etc/config/
+        image: docker.io/rancher/local-path-provisioner:v0.0.36
+        imagePullPolicy: IfNotPresent
+        name: local-path-provisioner
+        volumeMounts:
+        - mountPath: /etc/config/
+          name: config-volume
+      serviceAccountName: local-path-provisioner-service-account
+      volumes:
+      - configMap:
+          name: local-path-config
+        name: config-volume

--- a/kubernetes/apps/base/local-path-storage/local-path-storage-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/local-path-storage/local-path-storage-stpetersburg/app/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - local-path-provisioner.yaml
+patches:
+  - patch: |-
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: local-path-config
+        namespace: local-path-storage
+      data:
+        config.json: |-
+          {
+                  "nodePathMap":[
+                  {
+                          "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                          "paths":["/var/local-path-provisioner"]
+                  }
+                  ]
+          }
+  - patch: |-
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: local-path
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "true"
+      allowVolumeExpansion: true
+  - patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: local-path-storage
+        labels:
+          pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/base/local-path-storage/local-path-storage-stpetersburg/app/local-path-provisioner.yaml
+++ b/kubernetes/apps/base/local-path-storage/local-path-storage-stpetersburg/app/local-path-provisioner.yaml
@@ -1,0 +1,191 @@
+# Vendored from github.com/rancher/local-path-provisioner/deploy?ref=v0.0.36
+# re-render with: kustomize build 'github.com/rancher/local-path-provisioner/deploy?ref=v0.0.36'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumeclaims
+  - configmaps
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: v1
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: docker.io/library/busybox
+        imagePullPolicy: IfNotPresent
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+kind: ConfigMap
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      containers:
+      - command:
+        - local-path-provisioner
+        - --debug
+        - start
+        - --config
+        - /etc/config/config.json
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_MOUNT_PATH
+          value: /etc/config/
+        image: docker.io/rancher/local-path-provisioner:v0.0.36
+        imagePullPolicy: IfNotPresent
+        name: local-path-provisioner
+        volumeMounts:
+        - mountPath: /etc/config/
+          name: config-volume
+      serviceAccountName: local-path-provisioner-service-account
+      volumes:
+      - configMap:
+          name: local-path-config
+        name: config-volume

--- a/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/configmap.yaml
+++ b/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/configmap.yaml
@@ -1,0 +1,32 @@
+---
+# NOTE: k8s-rdma-shared-dev-plugin v1.5.3 currently reports "0 devices exposed"
+# on this hardware despite the kernel exposing the 4 ConnectX-7 mlx5 devices
+# correctly (verified via `rdma link` — mlx5_1 ACTIVE on eth2). Tried selectors
+# {vendors+deviceIDs}, {ifNames+linkTypes}, {devices: ["eth2"]}, {vendors only}
+# — all return 0. The kernel + verbs API + /dev/infiniband are fully working.
+#
+# Workaround for vLLM multi-node: skip the device plugin and run vLLM pods
+# with privileged + hostNetwork (or Multus host-device CNI) + direct
+# /dev/infiniband and /sys/class/infiniband mounts. Scheduling is fine via
+# nodeSelector (one pod per spark; no resource contention).
+#
+# TODO: file an upstream issue with plugin debug logs once we have time.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rdma-devices
+  namespace: rdma-system
+data:
+  config.json: |
+    {
+      "periodicUpdateInterval": 60,
+      "configList": [
+        {
+          "resourceName": "hca_shared_devices_a",
+          "rdmaHcaMax": 64,
+          "selectors": {
+            "vendors": ["15b3"]
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/daemonset.yaml
+++ b/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/daemonset.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rdma-shared-dp
+  namespace: rdma-system
+  labels:
+    app.kubernetes.io/name: rdma-shared-dp
+    app.kubernetes.io/component: device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rdma-shared-dp
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rdma-shared-dp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        node.kubernetes.io/instance-type: dgx-spark
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      serviceAccountName: rdma-shared-dp
+      containers:
+        - name: rdma-shared-dp
+          image: ghcr.io/mellanox/k8s-rdma-shared-dev-plugin:v1.5.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - SYS_RESOURCE
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /k8s-rdma-shared-dev-plugin
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: plugins-registry
+              mountPath: /var/lib/kubelet/plugins_registry
+            - name: log-dir
+              mountPath: /var/log
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: config
+          configMap:
+            name: rdma-devices
+            items:
+              - key: config.json
+                path: config.json
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+        - name: log-dir
+          hostPath:
+            path: /var/log
+        - name: dev
+          hostPath:
+            path: /dev

--- a/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rdma-system
+resources:
+  - ./configmap.yaml
+  - ./rbac.yaml
+  - ./daemonset.yaml

--- a/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/rbac.yaml
+++ b/kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app/rbac.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rdma-shared-dp
+  namespace: rdma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rdma-shared-dp
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rdma-shared-dp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rdma-shared-dp
+subjects:
+  - kind: ServiceAccount
+    name: rdma-shared-dp
+    namespace: rdma-system

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: rook-ceph
+      version: v1.19.5
+      sourceRef:
+        kind: HelmRepository
+        name: rook-ceph-charts
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    monitoring:
+      enabled: true
+      createPrometheusRules: true
+    toolbox:
+      enabled: true
+    csi:
+      # Deploy the csi-addons sidecar into the RBD provisioner + nodeplugin pods.
+      # Required for automatic RBD network fencing on hard node loss: when a node
+      # is tainted node.kubernetes.io/out-of-service, CephCSI uses the sidecar +
+      # NetworkFenceClass (clusters/talos-ottawa/apps/csi-addons) to blocklist the
+      # dead node in Ceph, breaking its RBD exclusive-lock so RWO volumes reattach
+      # on a healthy node immediately instead of waiting out the force-detach timeout.
+      # The csi-addons CONTROLLER + CRDs are installed by the csi-addons app.
+      # Proven on robbinsdale (PR #1464) before this prod rollout.
+      csiAddons:
+        enabled: true 

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml 

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/blockpool.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/blockpool.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: ceph-blockpool-replicated
+  namespace: rook-ceph
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  failureDomain: host
+  enableCrushUpdates: true
+  replicated:
+    size: 3

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/cluster.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/cluster.yaml
@@ -1,0 +1,397 @@
+#################################################################################################################
+# Define the settings for the rook-ceph cluster with common settings for a production cluster.
+# All nodes with available raw devices will be used for the Ceph cluster. At least three nodes are required
+# in this example. See the documentation for more details on storage settings available.
+
+# For example, to create the cluster:
+#   kubectl create -f crds.yaml -f common.yaml -f operator.yaml
+#   kubectl create -f cluster.yaml
+#################################################################################################################
+---
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook
+  namespace: rook-ceph # namespace:cluster
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  # Ceph configuration overrides for NVMe optimization
+  cephConfig:
+    global:
+      # NVMe discard/trim support
+      bdev_enable_discard: "true"
+      # bdev_async_discard: "true"
+      bdev_async_discard_threads: "1"
+      device_failure_prediction_mode: local
+      # Disable class update on start to avoid unnecessary overhead
+      osd_class_update_on_start: "false"
+    mds:
+      mds_wipe_ino_prealloc: "true"
+    mon:
+      mon_osd_down_out_interval: "300"
+      mon_osd_auto_mark_in: "true"
+      # NVMe optimized allocation size (4KB for NVMe)
+      # bluestore_min_alloc_size: "4096"
+      # Force more aggressive space reclamation
+      # bluestore_prefer_deferred_size: "0"
+      # bluestore_deferred_batch_ops: "16"
+  cephVersion:
+    # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
+    # v18 is Reef, v19 is Squid
+    # RECOMMENDATION: In production, use a specific version tag instead of the general v19 flag, which pulls the latest release and could result in different
+    # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
+    # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v18.2.4-20240724
+    # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
+    image: quay.io/ceph/ceph:v20.2.1
+    # Whether to allow unsupported versions of Ceph. Currently Reef, Squid, and Tentacle are supported.
+    allowUnsupported: false
+  # The path on the host where configuration files will be persisted. Must be specified. If there are multiple clusters, the directory must be unique for each cluster.
+  # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
+  # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
+  dataDirHostPath: /var/lib/rook
+  # Whether or not upgrade should continue even if a check fails
+  # This means Ceph's status could be degraded and we don't recommend upgrading but you might decide otherwise
+  # Use at your OWN risk
+  # To understand Rook's upgrade process of Ceph, read https://rook.io/docs/rook/latest/ceph-upgrade.html#ceph-version-upgrades
+  skipUpgradeChecks: false
+  # Whether or not continue if PGs are not clean during an upgrade
+  continueUpgradeAfterChecksEvenIfNotHealthy: false
+  # WaitTimeoutForHealthyOSDInMinutes defines the time (in minutes) the operator would wait before an OSD can be stopped for upgrade or restart.
+  # If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
+  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would
+  # continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+  # The default wait timeout is 10 minutes.
+  waitTimeoutForHealthyOSDInMinutes: 10
+  # Whether or not requires PGs are clean before an OSD upgrade. If set to `true` OSD upgrade process won't start until PGs are healthy.
+  # This configuration will be ignored if `skipUpgradeChecks` is `true`.
+  # Default is false.
+  upgradeOSDRequiresHealthyPGs: false
+  mon:
+    # Set the number of mons to be started. Generally recommended to be 3.
+    # For highest availability, an odd number of mons should be specified.
+    count: 3
+    # The mons should be on unique nodes. For production, at least 3 nodes are recommended for this reason.
+    # Mons should only be allowed on the same node for test environments where data loss is acceptable.
+    # allowMultiplePerNode: true
+  mgr:
+    # When higher availability of the mgr is needed, increase the count to 2.
+    # In that case, one mgr will be active and one in standby. When Ceph updates which
+    # mgr is active, Rook will update the mgr services to match the active mgr.
+    count: 2
+    allowMultiplePerNode: false
+    modules:
+      # List of modules to optionally enable or disable.
+      # Note the "dashboard" and "monitoring" modules are already configured by other settings in the cluster CR.
+      - name: diskprediction_local
+        enabled: true
+      - name: insights
+        enabled: true
+      - name: pg_autoscaler
+        enabled: true
+      - name: rook
+        enabled: true
+        settings:
+          balancerMode: upmap
+      
+  # enable the ceph dashboard for viewing cluster status
+  dashboard:
+    enabled: true
+    # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
+    # urlPrefix: /ceph-dashboard
+    # serve the dashboard at the given port.
+    # port: 8443
+    # serve the dashboard using SSL
+    ssl: false
+    # The url of the Prometheus instance
+    # prometheusEndpoint: <protocol>://<prometheus-host>:<port>
+    # Whether SSL should be verified if the Prometheus server is using https
+    # prometheusEndpointSSLVerify: false
+  # enable prometheus alerting for cluster
+  monitoring:
+    # requires Prometheus to be pre-installed
+    enabled: true
+    # Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
+    # If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+    metricsDisabled: false
+    # Ceph exporter metrics config.
+    exporter:
+      # Specifies which performance counters are exported.
+      # Corresponds to --prio-limit Ceph exporter flag
+      # 0 - all counters are exported
+      perfCountersPrioLimit: 5
+      # Time to wait before sending requests again to exporter server (seconds)
+      # Corresponds to --stats-period Ceph exporter flag
+      statsPeriodSeconds: 5
+  network:
+    connections:
+      # Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network.
+      # The default is false. When encryption is enabled, all communication between clients and Ceph daemons, or between Ceph daemons will be encrypted.
+      # When encryption is not enabled, clients still establish a strong initial authentication and data integrity is still validated with a crc check.
+      # IMPORTANT: Encryption requires the 5.11 kernel for the latest nbd and cephfs drivers. Alternatively for testing only,
+      # you can set the "mounter: rbd-nbd" in the rbd storage class, or "mounter: fuse" in the cephfs storage class.
+      # The nbd and fuse drivers are *not* recommended in production since restarting the csi driver pod will disconnect the volumes.
+      encryption:
+        enabled: false
+      # Whether to compress the data in transit across the wire. The default is false.
+      # See the kernel requirements above for encryption.
+      compression:
+        enabled: false
+      # Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
+      # and clients will be required to connect to the Ceph cluster with the v2 port (3300).
+      # Requires a kernel that supports msgr v2 (kernel 5.11 or CentOS 8.4 or newer).
+      requireMsgr2: true
+    # enable host networking
+    provider: host
+    addressRanges:
+      public: ["192.168.169.0/24"]
+      cluster: ["192.168.169.0/24"]
+    # enable the Multus network provider
+    # provider: multus
+    # selectors:
+    #   public: rook-ceph/rook-public-nw
+      # cluster: rook-ceph/rook-cluster-nw
+    #  The selector keys are required to be `public` and `cluster`.
+    #  Based on the configuration, the operator will do the following:
+    #    1. if only the `public` selector key is specified both public_network and cluster_network Ceph settings will listen on that interface
+    #    2. if both `public` and `cluster` selector keys are specified the first one will point to 'public_network' flag and the second one to 'cluster_network'
+    #
+    #  In order to work, each selector value must match a NetworkAttachmentDefinition object in Multus
+    #
+    #  public: public-conf --> NetworkAttachmentDefinition object name in Multus
+    #  cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
+    # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
+    #ipFamily: "IPv6"
+    # Ceph daemons to listen on both IPv4 and Ipv6 networks
+    #dualStack: false
+    # Enable multiClusterService to export the mon and OSD services to peer cluster.
+    # This is useful to support RBD mirroring between two clusters having overlapping CIDRs.
+    # Ensure that peer clusters are connected using an MCS API compatible application, like Globalnet Submariner.
+    #multiClusterService:
+    #  enabled: false
+
+  # enable the crash collector for ceph daemon crash collection
+  crashCollector:
+    disable: false
+    # Uncomment daysToRetain to prune ceph crash entries older than the
+    # specified number of days.
+    #daysToRetain: 30
+  # enable log collector, daemons will log on files and rotate
+  logCollector:
+    enabled: true
+    periodicity: daily # one of: hourly, daily, weekly, monthly
+    maxLogSize: 500M # SUFFIX may be 'M' or 'G'. Must be at least 1M.
+  # automate [data cleanup process](https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/ceph-teardown.md#delete-the-data-on-hosts) in cluster destruction.
+  # cleanupPolicy:
+  #   # Since cluster cleanup is destructive to data, confirmation is required.
+  #   # To destroy all Rook data on hosts during uninstall, confirmation must be set to "yes-really-destroy-data".
+  #   # This value should only be set when the cluster is about to be deleted. After the confirmation is set,
+  #   # Rook will immediately stop configuring the cluster and only wait for the delete command.
+  #   # If the empty string is set, Rook will not destroy any data on hosts during uninstall.
+  #   confirmation: "yes-really-destroy-data"
+  #   # sanitizeDisks represents settings for sanitizing OSD disks on cluster deletion
+  #   sanitizeDisks:
+  #     # method indicates if the entire disk should be sanitized or simply ceph's metadata
+  #     # in both case, re-install is possible
+  #     # possible choices are 'complete' or 'quick' (default)
+  #     method: quick
+  #     # dataSource indicate where to get random bytes from to write on the disk
+  #     # possible choices are 'zero' (default) or 'random'
+  #     # using random sources will consume entropy from the system and will take much more time then the zero source
+  #     dataSource: zero
+  #     # iteration overwrite N times instead of the default (1)
+  #     # takes an integer value
+  #     iteration: 1
+  #   # allowUninstallWithVolumes defines how the uninstall should be performed
+  #   # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
+  #   allowUninstallWithVolumes: true
+  # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
+  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
+  # tolerate taints with a key of 'storage-node'.
+  # placement:
+  #   all:
+  #     nodeAffinity:
+  #       requiredDuringSchedulingIgnoredDuringExecution:
+  #         nodeSelectorTerms:
+  #         - matchExpressions:
+  #           - key: role
+  #             operator: In
+  #             values:
+  #             - storage-node
+  #     podAffinity:
+  #     podAntiAffinity:
+  #     topologySpreadConstraints:
+  #     tolerations:
+  #     - key: storage-node
+  #       operator: Exists
+  # The above placement information can also be specified for mon, osd, and mgr components
+  #   mon:
+  # Monitor deployments may contain an anti-affinity rule for avoiding monitor
+  # collocation on the same node. This is a required rule when host network is used
+  # or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
+  # preferred rule with weight: 50.
+  #   osd:
+  #    prepareosd:
+  #    mgr:
+  #    cleanup:
+  annotations:
+  #   all:
+  #   mon:
+  #   mgr:
+  #   osd:
+  #   exporter:
+  #   crashcollector:
+  #   cleanup:
+  #   prepareosd:
+  # cmdreporter is for jobs to detect ceph and csi versions, and check network status
+  #   cmdreporter:
+  # clusterMetadata annotations will be applied to only `rook-ceph-mon-endpoints` configmap and the `rook-ceph-mon` and `rook-ceph-admin-keyring` secrets.
+  # And clusterMetadata annotations will not be merged with `all` annotations.
+  #    clusterMetadata:
+  #       kubed.appscode.com/sync: "true"
+  # If no mgr annotations are set, prometheus scrape annotations will be set by default.
+  #   mgr:
+  labels:
+  #   all:
+  #   mon:
+  #   osd:
+  #   cleanup:
+  #   mgr:
+  #   prepareosd:
+  # These labels are applied to ceph-exporter servicemonitor only
+  #   exporter:
+  # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
+  # These labels can be passed as LabelSelector to Prometheus
+  #   monitoring:
+  #   crashcollector:
+  resources:
+    #The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
+    mgr:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+    # The above example requests/limits can also be added to the other components
+    mon:
+      requests:
+        cpu: 50m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+    osd:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        memory: 8Gi
+  # For OSD it also is a possible to specify requests/limits based on device class
+  #   osd-hdd:
+  #   osd-ssd:
+  #   osd-nvme:
+  #   prepareosd:
+    mgr-sidecar:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+  #   crashcollector:
+  #   logcollector:
+  #   cleanup:
+  #   exporter:
+  #   cmd-reporter:
+  # The option to automatically remove OSDs that are out and are safe to destroy.
+  removeOSDsIfOutAndSafeToRemove: true
+  priorityClassNames:
+    #all: rook-ceph-default-priority-class
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
+    #crashcollector: rook-ceph-crashcollector-priority-class
+  storage: # cluster level storage configuration and selection
+    useAllNodes: false
+    useAllDevices: true
+    config:
+      osdsPerDevice: "4"
+    allowDeviceClassUpdate: true # whether to allow changing the device class of an OSD after it is created
+    allowOsdCrushWeightUpdate: true # whether to allow resizing the OSD crush weight after osd pvc is increased
+    nodes:
+      - name: asuka
+      - name: kaji
+      - name: rei
+      - name: shiro
+        config:
+          osdsPerDevice: "1"
+    # Whether to always schedule OSD pods on nodes declared explicitly in the "nodes" section, even if they are
+    # temporarily not schedulable. If set to true, consider adding placement tolerations for unschedulable nodes.
+    scheduleAlways: false
+    # when onlyApplyOSDPlacement is false, will merge both placement.All() and placement.osd
+    onlyApplyOSDPlacement: false
+    # Time for which an OSD pod will sleep before restarting, if it stopped due to flapping
+    # flappingRestartIntervalHours: 24
+    # The ratio at which Ceph should block IO if the OSDs are too full. The default is 0.95.
+    # fullRatio: 0.95
+    # The ratio at which Ceph should stop backfilling data if the OSDs are too full. The default is 0.90.
+    # backfillFullRatio: 0.90
+    # The ratio at which Ceph should raise a health warning if the OSDs are almost full. The default is 0.85.
+    # nearFullRatio: 0.85
+  # The section for configuring management of daemon disruptions during upgrade or fencing.
+  disruptionManagement:
+    # If true, the operator will create and manage PodDisruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically
+    # via the strategy outlined in the [design](https://github.com/rook/rook/blob/master/design/ceph/ceph-managed-disruptionbudgets.md). The operator will
+    # block eviction of OSDs by default and unblock them safely when drains are detected.
+    managePodBudgets: true
+    # A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
+    # default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.
+    osdMaintenanceTimeout: 1
+    # A duration in minutes that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up.
+    # Operator will continue with the next drain if the timeout exceeds. It only works if `managePodBudgets` is `true`.
+    # Set to 15 minutes to prevent indefinite hangs during Talos node upgrades while still allowing time for PG recovery.
+    pgHealthCheckTimeout: 15
+
+  # csi defines CSI Driver settings applied per cluster.
+  csi:
+    readAffinity:
+      # Enable read affinity to enable clients to optimize reads from an OSD in the same topology.
+      # Enabling the read affinity may cause the OSDs to consume some extra memory.
+      # For more details see this doc:
+      # https://rook.io/docs/rook/latest/Storage-Configuration/Ceph-CSI/ceph-csi-drivers/#enable-read-affinity-for-rbd-volumes
+      enabled: true
+
+    # cephfs driver specific settings.
+    cephfs:
+      # Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options.
+      kernelMountOptions: "ms_mode=prefer-crc"
+      # Set CephFS Fuse mount options to use https://docs.ceph.com/en/latest/man/8/ceph-fuse/#options.
+      # fuseMountOptions: ""
+
+  # healthChecks
+  # Valid values for daemons are 'mon', 'osd', 'status'
+  healthCheck:
+    daemonHealth:
+      mon:
+        disabled: false
+        interval: 45s
+      osd:
+        disabled: false
+        interval: 60s
+      status:
+        disabled: false
+        interval: 60s
+    # Change pod liveness probe timing or threshold values. Works for all mon,mgr,osd daemons.
+    livenessProbe:
+      mon:
+        disabled: false
+      mgr:
+        disabled: false
+      osd:
+        disabled: false
+    # Change pod startup probe timing or threshold values. Works for all mon,mgr,osd daemons.
+    startupProbe:
+      mon:
+        disabled: false
+      mgr:
+        disabled: false
+      osd:
+        disabled: false

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/dashboard-cluster.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/dashboard-cluster.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-cluster
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Ceph
+  url: https://raw.githubusercontent.com/rook/rook/refs/heads/master/deploy/examples/monitoring/grafana/Ceph%20Cluster%20Dashboard.json

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/dashboard-osd.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/dashboard-osd.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-osd
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Ceph
+  url: https://raw.githubusercontent.com/rook/rook/refs/heads/master/deploy/examples/monitoring/grafana/Ceph%20OSD%20Single%20Dashboard.json

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/dashboard-pools.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/dashboard-pools.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-pools
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Ceph
+  url: https://raw.githubusercontent.com/rook/rook/refs/heads/master/deploy/examples/monitoring/grafana/Ceph%20Pools%20Dashboard.json

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/filesystem.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/filesystem.yaml
@@ -1,0 +1,160 @@
+#################################################################################################################
+# Create a filesystem with settings with replication enabled for a production environment.
+# A minimum of 3 OSDs on different nodes are required in this example.
+# If one mds daemon per node is too restrictive, see the podAntiAffinity below.
+#  kubectl create -f filesystem.yaml
+#################################################################################################################
+---
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: filesystem
+  namespace: rook-ceph # namespace:cluster
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  # The metadata pool spec. Must use replication.
+  metadataPool:
+    replicated:
+      size: 3
+      requireSafeReplicaSize: true
+    parameters:
+      # Inline compression mode for the data pool
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
+      compression_mode:
+        none
+        # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+      # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+      #target_size_ratio: ".5"
+  # The list of data pool specs. Can use replication or erasure coding.
+  dataPools:
+    - name: replicated
+      failureDomain: host
+      enableCrushUpdates: true
+      replicated:
+        size: 3
+        # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+        # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+        requireSafeReplicaSize: true
+      parameters:
+        # Inline compression mode for the data pool
+        # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
+        compression_mode:
+          passive
+          # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+        # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+        #target_size_ratio: ".5"
+  # Whether to preserve filesystem after CephFilesystem CRD deletion
+  preserveFilesystemOnDelete: true
+  # The metadata service (mds) configuration
+  metadataServer:
+    # The number of active MDS instances
+    activeCount: 1
+    # Whether each active MDS instance will have an active standby with a warm metadata cache for faster failover.
+    # If false, standbys will be available, but will not have a warm cache.
+    activeStandby: true
+    # The affinity rules to apply to the mds deployment
+    placement:
+      #  nodeAffinity:
+      #    requiredDuringSchedulingIgnoredDuringExecution:
+      #      nodeSelectorTerms:
+      #      - matchExpressions:
+      #        - key: role
+      #          operator: In
+      #          values:
+      #          - mds-node
+      #  topologySpreadConstraints:
+      #  tolerations:
+      #  - key: mds-node
+      #    operator: Exists
+      #  podAffinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - rook-ceph-mds
+            ## Add this if you want to allow mds daemons for different filesystems to run on one
+            ## node. The value in "values" must match .metadata.name.
+            #    - key: rook_file_system
+            #          operator: In
+            #          values:
+            #            - filesystem
+            # topologyKey: kubernetes.io/hostname will place MDS across different hosts
+            topologyKey: kubernetes.io/hostname
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - rook-ceph-mds
+              # topologyKey: */zone can be used to spread MDS across different AZ
+              # Use <topologyKey: failure-domain.beta.kubernetes.io/zone> in k8s cluster if your cluster is v1.16 or lower
+              # Use <topologyKey: topology.kubernetes.io/zone>  in k8s cluster is v1.17 or upper
+              topologyKey: topology.kubernetes.io/zone
+    # A key/value list of annotations
+    # annotations:
+    #  key: value
+    # A key/value list of labels
+    # labels:
+    #  key: value
+    # resources:
+    # The requests and limits set here, allow the filesystem MDS Pod(s) to use half of one CPU core and 1 gigabyte of memory
+    #  limits:
+    #    memory: "1024Mi"
+    #  requests:
+    #    cpu: "500m"
+    #    memory: "1024Mi"
+    priorityClassName: system-cluster-critical
+    livenessProbe:
+      disabled: false
+    startupProbe:
+      disabled: false
+  # Filesystem mirroring settings
+  # mirroring:
+  #   enabled: true
+  #   # list of Kubernetes Secrets containing the peer token
+  #   # for more details see: https://docs.ceph.com/en/latest/dev/cephfs-mirroring/#bootstrap-peers
+  #   # Add the secret name if it already exists else specify the empty list here.
+  #   peers:
+  #     secretNames:
+  #     - secondary-cluster-peer
+  #   # specify the schedule(s) on which snapshots should be taken
+  #   # see the official syntax here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-schedules
+  #   snapshotSchedules:
+  #     - path: /
+  #       interval: 24h # daily snapshots
+  #   # The startTime should be mentioned in the format YYYY-MM-DDTHH:MM:SS
+  #   # If startTime is not specified, then by default the start time is considered as midnight UTC.
+  #   # see usage here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#usage
+  #   # startTime: 2022-07-15T11:55:00
+  #   # manage retention policies
+  #   # see syntax duration here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-retention-policies
+  #   snapshotRetention:
+  #     - path: /
+  #       duration: "h 24"
+---
+# create default csi subvolume group
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystemSubVolumeGroup
+metadata:
+  name: filesystem-csi # lets keep the svg crd name same as `filesystem name + csi` for the default csi svg
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
+  name: csi
+  # filesystemName is the metadata name of the CephFilesystem CR where the subvolume group will be created
+  filesystemName: filesystem
+  # reference https://docs.ceph.com/en/latest/cephfs/fs-volumes/#pinning-subvolumes-and-subvolume-groups
+  # only one out of (export, distributed, random) can be set at a time
+  # by default pinning is set with value: distributed=1
+  # for disabling default values set (distributed=0)
+  pinning:
+    distributed: 1 # distributed=<0, 1> (disabled=0)
+    # export:                 # export=<0-256> (disabled=-1)
+    # random:                 # random=[0.0, 1.0](disabled=0.0)

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/httproute.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/httproute.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rook
+  namespace: rook-ceph
+  annotations:
+    item.homer.rajsingh.info/name: "Rook Ceph"
+    item.homer.rajsingh.info/subtitle: "Storage Dashboard"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/rook.svg"
+    item.homer.rajsingh.info/keywords: "storage, ceph, dashboard"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "rook.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: rook-ceph-mgr-dashboard
+          port: 7000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./httproute.yaml
+  - ./filesystem.yaml
+  - ./toolbox.yaml
+  - ./storageclass.yaml
+  - ./volumesnapshot.yaml
+  - ./blockpool.yaml
+  # Dashboards
+  - ./dashboard-cluster.yaml
+  - ./dashboard-osd.yaml
+  - ./dashboard-pools.yaml
+  # Probes
+  - ./probes.yaml

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/probes.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/probes.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-rook-ceph
+spec:
+  jobName: blackbox
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://rook-ceph-mgr.rook-ceph:9283
+      labels:
+        service: rook-ceph
+        target: mgr-metrics

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/storageclass.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/storageclass.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-cephfs
+provisioner: rook-ceph.cephfs.csi.ceph.com # csi-provisioner-name
+parameters:
+  # clusterID is the namespace where the rook cluster is running
+  # If you change this namespace, also change the namespace below where the secret namespaces are defined
+  clusterID: rook-ceph # namespace:cluster
+
+  # CephFS filesystem name into which the volume shall be created
+  fsName: filesystem
+
+  # Ceph pool into which the volume shall be created
+  # Required for provisionVolume: "true"
+  pool: filesystem-replicated
+
+  # The secrets contain Ceph admin credentials. These are generated automatically by the operator
+  # in the same namespace as the cluster.
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
+
+  # (optional) Set it to true to encrypt each volume with encryption keys
+  # from a key management system (KMS)
+  # encrypted: "true"
+
+  # (optional) Use external key management system (KMS) for encryption key by
+  # specifying a unique ID matching a KMS ConfigMap. The ID is only used for
+  # correlation to configmap entry.
+  # encryptionKMSID: <kms-config-id>
+
+  # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)
+  # If omitted, default volume mounter will be used - this is determined by probing for ceph-fuse
+  # or by setting the default mounter explicitly via --volumemounter command-line argument.
+  # mounter: kernel
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+# mountOptions:
+  # uncomment the following line for debugging
+  #- debug
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-block-replicated
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+parameters:
+  clusterID: rook-ceph
+  pool: ceph-blockpool-replicated  # Use the same existing pool
+  
+  # Compression for space efficiency (especially good for NVMe)
+  compression_mode: aggressive
+  compression_algorithm: zstd
+  
+  # Image format and features
+  imageFormat: "2"
+  imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
+  
+  # CSI secrets
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  
+provisioner: rook-ceph.rbd.csi.ceph.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+# Mount options for TRIM/discard support on NVMe
+mountOptions:
+  - discard

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/toolbox.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/toolbox.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-tools
+  namespace: rook-ceph # namespace:cluster
+  labels:
+    app: rook-ceph-tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-tools
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-tools
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: rook-ceph-default
+      containers:
+        - name: rook-ceph-tools
+          image: quay.io/ceph/ceph:v20.2.1
+          command: ["/bin/bash"]
+          args:
+            - "-c"
+            - |
+              # Replicate the script from toolbox.sh inline so the ceph image
+              # can be run directly, instead of requiring the rook toolbox
+              CEPH_CONFIG="/etc/ceph/ceph.conf"
+              MON_CONFIG="/etc/rook/mon-endpoints"
+              KEYRING_FILE="/etc/ceph/keyring"
+
+              # create a ceph config file in its default location so ceph/rados tools can be used
+              # without specifying any arguments
+              write_endpoints() {
+                endpoints=$$(cat $${MON_CONFIG})
+
+                # filter out the mon names
+                # external cluster can have numbers or hyphens in mon names, handling them in regex
+                # shellcheck disable=SC2001
+                mon_endpoints=$$(echo "$${endpoints}"| sed 's/[a-z0-9_-]\+=//g')
+
+                DATE=$$(date)
+                echo "$$DATE writing mon endpoints to $${CEPH_CONFIG}: $${endpoints}"
+                  cat <<EOF > $${CEPH_CONFIG}
+              [global]
+              mon_host = $${mon_endpoints}
+
+              [client.admin]
+              keyring = $${KEYRING_FILE}
+              EOF
+              }
+
+              # watch the endpoints config file and update if the mon endpoints ever change
+              watch_endpoints() {
+                # get the timestamp for the target of the soft link
+                real_path=$$(realpath $${MON_CONFIG})
+                initial_time=$$(stat -c %Z "$${real_path}")
+                while true; do
+                  real_path=$$(realpath $${MON_CONFIG})
+                  latest_time=$$(stat -c %Z "$${real_path}")
+
+                  if [[ "$${latest_time}" != "$${initial_time}" ]]; then
+                    write_endpoints
+                    initial_time=$${latest_time}
+                  fi
+
+                  sleep 10
+                done
+              }
+
+              # read the secret from an env var (for backward compatibility), or from the secret file
+              ceph_secret=$${ROOK_CEPH_SECRET}
+              if [[ "$$ceph_secret" == "" ]]; then
+                ceph_secret=$$(cat /var/lib/rook-ceph-mon/secret.keyring)
+              fi
+
+              # create the keyring file
+              cat <<EOF > $${KEYRING_FILE}
+              [$${ROOK_CEPH_USERNAME}]
+              key = $${ceph_secret}
+              EOF
+
+              # write the initial config file
+              write_endpoints
+
+              # continuously update the mon endpoints if they fail over
+              watch_endpoints
+          imagePullPolicy: IfNotPresent
+          tty: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2016
+            runAsGroup: 2016
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+              readOnly: true
+      volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: data
+                path: mon-endpoints
+        - name: ceph-config
+          emptyDir: {}
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 5

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/volumesnapshot.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config/volumesnapshot.yaml
@@ -1,0 +1,36 @@
+# 1.17 <= K8s <= v1.19
+# apiVersion: snapshot.storage.k8s.io/v1beta1
+# K8s >= v1.20
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-rbdplugin-snapclass
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+driver: rook-ceph.rbd.csi.ceph.com # driver:namespace:operator
+parameters:
+  # Specify a string that identifies your cluster. Ceph CSI supports any
+  # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
+  # for example "rook-ceph".
+  clusterID: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph # namespace:cluster
+deletionPolicy: Delete
+# 1.17 <= K8s <= v1.19
+# apiVersion: snapshot.storage.k8s.io/v1beta1
+# K8s >= v1.20
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-cephfsplugin-snapclass
+driver: rook-ceph.cephfs.csi.ceph.com # driver:namespace:operator
+parameters:
+  # Specify a string that identifies your cluster. Ceph CSI supports any
+  # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
+  # for example "rook-ceph".
+  clusterID: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph # namespace:cluster
+deletionPolicy: Delete

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/app/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: rook-ceph
+      version: v1.19.5
+      sourceRef:
+        kind: HelmRepository
+        name: rook-ceph-charts
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    monitoring:
+      enabled: true
+      createPrometheusRules: true
+    toolbox:
+      enabled: true
+    csi:
+      # Deploy the csi-addons sidecar into the RBD provisioner + nodeplugin pods.
+      # Required for automatic RBD network fencing on hard node loss: when a node
+      # is tainted node.kubernetes.io/out-of-service, CephCSI uses the sidecar +
+      # NetworkFenceClass (clusters/talos-robbinsdale/apps/csi-addons) to blocklist
+      # the dead node in Ceph, breaking its RBD exclusive-lock so RWO volumes
+      # reattach on a healthy node immediately instead of waiting out the
+      # force-detach timeout. The csi-addons CONTROLLER + CRDs are installed by the
+      # csi-addons app.
+      csiAddons:
+        enabled: true 

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml 

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/blockpool.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/blockpool.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: ceph-blockpool-replicated-nvme
+  namespace: rook-ceph
+spec:
+  failureDomain: host
+  replicated:
+    size: 3
+  deviceClass: nvme

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/cluster.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/cluster.yaml
@@ -1,0 +1,382 @@
+#################################################################################################################
+# Define the settings for the rook-ceph cluster with common settings for a production cluster.
+# All nodes with available raw devices will be used for the Ceph cluster. At least three nodes are required
+# in this example. See the documentation for more details on storage settings available.
+
+# For example, to create the cluster:
+#   kubectl create -f crds.yaml -f common.yaml -f operator.yaml
+#   kubectl create -f cluster.yaml
+#################################################################################################################
+
+---
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph # namespace:cluster
+spec:
+  cephConfig:
+    mds:
+      mds_wipe_ino_prealloc: "true"
+    mon:
+      mon_osd_down_out_interval: "300"
+      mon_osd_auto_mark_in: "true"
+  cephVersion:
+    # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
+    # v18 is Reef, v19 is Squid
+    # RECOMMENDATION: In production, use a specific version tag instead of the general v19 flag, which pulls the latest release and could result in different
+    # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
+    # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v18.2.4-20240724
+    # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
+    image: quay.io/ceph/ceph:v20.2.1
+    # Whether to allow unsupported versions of Ceph. Currently Reef, Squid, and Tentacle are supported.
+    allowUnsupported: false
+  # The path on the host where configuration files will be persisted. Must be specified. If there are multiple clusters, the directory must be unique for each cluster.
+  # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
+  # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
+  dataDirHostPath: /var/lib/rook
+  # Whether or not upgrade should continue even if a check fails
+  # This means Ceph's status could be degraded and we don't recommend upgrading but you might decide otherwise
+  # Use at your OWN risk
+  # To understand Rook's upgrade process of Ceph, read https://rook.io/docs/rook/latest/ceph-upgrade.html#ceph-version-upgrades
+  skipUpgradeChecks: false
+  # Whether or not continue if PGs are not clean during an upgrade
+  continueUpgradeAfterChecksEvenIfNotHealthy: false
+  # WaitTimeoutForHealthyOSDInMinutes defines the time (in minutes) the operator would wait before an OSD can be stopped for upgrade or restart.
+  # If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
+  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would
+  # continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+  # The default wait timeout is 10 minutes.
+  waitTimeoutForHealthyOSDInMinutes: 10
+  # Whether or not requires PGs are clean before an OSD upgrade. If set to `true` OSD upgrade process won't start until PGs are healthy.
+  # This configuration will be ignored if `skipUpgradeChecks` is `true`.
+  # Default is false.
+  upgradeOSDRequiresHealthyPGs: false
+  mon:
+    # Set the number of mons to be started. Generally recommended to be 3.
+    # For highest availability, an odd number of mons should be specified.
+    count: 3
+    # The mons should be on unique nodes. For production, at least 3 nodes are recommended for this reason.
+    # Mons should only be allowed on the same node for test environments where data loss is acceptable.
+    allowMultiplePerNode: true
+  mgr:
+    # When higher availability of the mgr is needed, increase the count to 2.
+    # In that case, one mgr will be active and one in standby. When Ceph updates which
+    # mgr is active, Rook will update the mgr services to match the active mgr.
+    count: 2
+    allowMultiplePerNode: false
+    modules:
+      # List of modules to optionally enable or disable.
+      # Note the "dashboard" and "monitoring" modules are already configured by other settings in the cluster CR.
+      - name: rook
+        enabled: true
+        settings:
+          balancerMode: upmap
+      
+  # enable the ceph dashboard for viewing cluster status
+  dashboard:
+    enabled: true
+    # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
+    # urlPrefix: /ceph-dashboard
+    # serve the dashboard at the given port.
+    # port: 8443
+    # serve the dashboard using SSL
+    ssl: false
+    # The url of the Prometheus instance
+    # prometheusEndpoint: <protocol>://<prometheus-host>:<port>
+    # Whether SSL should be verified if the Prometheus server is using https
+    # prometheusEndpointSSLVerify: false
+  # enable prometheus alerting for cluster
+  monitoring:
+    # requires Prometheus to be pre-installed
+    enabled: true
+    # Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
+    # If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+    metricsDisabled: false
+    # Ceph exporter metrics config.
+    exporter:
+      # Specifies which performance counters are exported.
+      # Corresponds to --prio-limit Ceph exporter flag
+      # 0 - all counters are exported
+      perfCountersPrioLimit: 5
+      # Time to wait before sending requests again to exporter server (seconds)
+      # Corresponds to --stats-period Ceph exporter flag
+      statsPeriodSeconds: 5
+  network:
+    connections:
+      # Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network.
+      # The default is false. When encryption is enabled, all communication between clients and Ceph daemons, or between Ceph daemons will be encrypted.
+      # When encryption is not enabled, clients still establish a strong initial authentication and data integrity is still validated with a crc check.
+      # IMPORTANT: Encryption requires the 5.11 kernel for the latest nbd and cephfs drivers. Alternatively for testing only,
+      # you can set the "mounter: rbd-nbd" in the rbd storage class, or "mounter: fuse" in the cephfs storage class.
+      # The nbd and fuse drivers are *not* recommended in production since restarting the csi driver pod will disconnect the volumes.
+      encryption:
+        enabled: false
+      # Whether to compress the data in transit across the wire. The default is false.
+      # See the kernel requirements above for encryption.
+      compression:
+        enabled: false
+      # Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
+      # and clients will be required to connect to the Ceph cluster with the v2 port (3300).
+      # Requires a kernel that supports msgr v2 (kernel 5.11 or CentOS 8.4 or newer).
+      requireMsgr2: false
+    # enable host networking
+    #provider: host
+    # enable the Multus network provider
+    # provider: multus
+    # selectors:
+    #   public: rook-ceph/rook-public-nw
+      # cluster: rook-ceph/rook-cluster-nw
+    #  The selector keys are required to be `public` and `cluster`.
+    #  Based on the configuration, the operator will do the following:
+    #    1. if only the `public` selector key is specified both public_network and cluster_network Ceph settings will listen on that interface
+    #    2. if both `public` and `cluster` selector keys are specified the first one will point to 'public_network' flag and the second one to 'cluster_network'
+    #
+    #  In order to work, each selector value must match a NetworkAttachmentDefinition object in Multus
+    #
+    #  public: public-conf --> NetworkAttachmentDefinition object name in Multus
+    #  cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
+    # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
+    #ipFamily: "IPv6"
+    # Ceph daemons to listen on both IPv4 and Ipv6 networks
+    #dualStack: false
+    # Enable multiClusterService to export the mon and OSD services to peer cluster.
+    # This is useful to support RBD mirroring between two clusters having overlapping CIDRs.
+    # Ensure that peer clusters are connected using an MCS API compatible application, like Globalnet Submariner.
+    #multiClusterService:
+    #  enabled: false
+
+  # enable the crash collector for ceph daemon crash collection
+  crashCollector:
+    disable: false
+    # Uncomment daysToRetain to prune ceph crash entries older than the
+    # specified number of days.
+    #daysToRetain: 30
+  # enable log collector, daemons will log on files and rotate
+  logCollector:
+    enabled: true
+    periodicity: daily # one of: hourly, daily, weekly, monthly
+    maxLogSize: 500M # SUFFIX may be 'M' or 'G'. Must be at least 1M.
+  # automate [data cleanup process](https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/ceph-teardown.md#delete-the-data-on-hosts) in cluster destruction.
+  # cleanupPolicy:
+  #   # Since cluster cleanup is destructive to data, confirmation is required.
+  #   # To destroy all Rook data on hosts during uninstall, confirmation must be set to "yes-really-destroy-data".
+  #   # This value should only be set when the cluster is about to be deleted. After the confirmation is set,
+  #   # Rook will immediately stop configuring the cluster and only wait for the delete command.
+  #   # If the empty string is set, Rook will not destroy any data on hosts during uninstall.
+  #   confirmation: "yes-really-destroy-data"
+  #   # sanitizeDisks represents settings for sanitizing OSD disks on cluster deletion
+  #   sanitizeDisks:
+  #     # method indicates if the entire disk should be sanitized or simply ceph's metadata
+  #     # in both case, re-install is possible
+  #     # possible choices are 'complete' or 'quick' (default)
+  #     method: quick
+  #     # dataSource indicate where to get random bytes from to write on the disk
+  #     # possible choices are 'zero' (default) or 'random'
+  #     # using random sources will consume entropy from the system and will take much more time then the zero source
+  #     dataSource: zero
+  #     # iteration overwrite N times instead of the default (1)
+  #     # takes an integer value
+  #     iteration: 1
+  #   # allowUninstallWithVolumes defines how the uninstall should be performed
+  #   # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
+  #   allowUninstallWithVolumes: true
+  # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
+  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
+  # tolerate taints with a key of 'storage-node'.
+  # placement:
+  #   all:
+  #     nodeAffinity:
+  #       requiredDuringSchedulingIgnoredDuringExecution:
+  #         nodeSelectorTerms:
+  #         - matchExpressions:
+  #           - key: role
+  #             operator: In
+  #             values:
+  #             - storage-node
+  #     podAffinity:
+  #     podAntiAffinity:
+  #     topologySpreadConstraints:
+  #     tolerations:
+  #     - key: storage-node
+  #       operator: Exists
+  # The above placement information can also be specified for mon, osd, and mgr components
+  #   mon:
+  # Monitor deployments may contain an anti-affinity rule for avoiding monitor
+  # collocation on the same node. This is a required rule when host network is used
+  # or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
+  # preferred rule with weight: 50.
+  #   osd:
+  #    prepareosd:
+  #    mgr:
+  #    cleanup:
+  annotations:
+  #   all:
+  #   mon:
+  #   mgr:
+  #   osd:
+  #   exporter:
+  #   crashcollector:
+  #   cleanup:
+  #   prepareosd:
+  # cmdreporter is for jobs to detect ceph and csi versions, and check network status
+  #   cmdreporter:
+  # clusterMetadata annotations will be applied to only `rook-ceph-mon-endpoints` configmap and the `rook-ceph-mon` and `rook-ceph-admin-keyring` secrets.
+  # And clusterMetadata annotations will not be merged with `all` annotations.
+  #    clusterMetadata:
+  #       kubed.appscode.com/sync: "true"
+  # If no mgr annotations are set, prometheus scrape annotations will be set by default.
+  #   mgr:
+  labels:
+  #   all:
+  #   mon:
+  #   osd:
+  #   cleanup:
+  #   mgr:
+  #   prepareosd:
+  # These labels are applied to ceph-exporter servicemonitor only
+  #   exporter:
+  # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
+  # These labels can be passed as LabelSelector to Prometheus
+  #   monitoring:
+  #   crashcollector:
+  resources:
+  #The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
+  #   mgr:
+  #     limits:
+  #       memory: "1024Mi"
+  #     requests:
+  #       cpu: "500m"
+  #       memory: "1024Mi"
+  # The above example requests/limits can also be added to the other components
+  #   mon:
+  #   osd:
+  # For OSD it also is a possible to specify requests/limits based on device class
+  #   osd-hdd:
+  #   osd-ssd:
+  #   osd-nvme:
+  #   prepareosd:
+  #   mgr-sidecar:
+  #   crashcollector:
+  #   logcollector:
+  #   cleanup:
+  #   exporter:
+  #   cmd-reporter:
+  # The option to automatically remove OSDs that are out and are safe to destroy.
+  removeOSDsIfOutAndSafeToRemove: true
+  priorityClassNames:
+    #all: rook-ceph-default-priority-class
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
+    #crashcollector: rook-ceph-crashcollector-priority-class
+  storage: # cluster level storage configuration and selection
+    useAllNodes: false
+    useAllDevices: false
+    config:
+      # crushRoot: "custom-root" # specify a non-default root label for the CRUSH map
+      # metadataDevice: "md0" # specify a non-rotational storage so ceph-volume will use it as block db device of bluestore.
+      # databaseSizeMB: "1024" # uncomment if the disks are smaller than 100 GB
+      # osdsPerDevice: "1" # this value can be overridden at the node or device level
+      # encryptedDevice: "true" # the default value for this option is "false"
+      # deviceClass: "myclass" # specify a device class for OSDs in the cluster
+    allowDeviceClassUpdate: true # whether to allow changing the device class of an OSD after it is created
+    allowOsdCrushWeightUpdate: true # whether to allow resizing the OSD crush weight after osd pvc is increased
+    # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
+    # nodes below will be used as storage resources.
+    nodes:
+      - name: "stone"
+        devices:
+          - name: "nvme1n1"
+      - name: "titan"
+        devices:
+          - name: "nvme0n1"
+          - name: "nvme1n1"
+          - name: "sda"
+          - name: "sdc"
+          - name: "sdd"
+      - name: "tank"
+        devices:
+          - name: "nvme*"
+    #   - name: "172.17.4.201"
+    #     devices: # specific devices to use for storage can be specified for each node
+    #       - name: "sdb"
+    #       - name: "nvme01" # multiple osds can be created on high performance devices
+    #         config:
+    #           osdsPerDevice: "5"
+    #       - name: "/dev/disk/by-id/ata-ST4000DM004-XXXX" # devices can be specified using full udev paths
+    #     config: # configuration can be specified at the node level which overrides the cluster level config
+    #   - name: "172.17.4.301"
+    #     deviceFilter: "^sd."
+    # Whether to always schedule OSD pods on nodes declared explicitly in the "nodes" section, even if they are
+    # temporarily not schedulable. If set to true, consider adding placement tolerations for unschedulable nodes.
+    scheduleAlways: false
+    # when onlyApplyOSDPlacement is false, will merge both placement.All() and placement.osd
+    onlyApplyOSDPlacement: false
+    # Time for which an OSD pod will sleep before restarting, if it stopped due to flapping
+    # flappingRestartIntervalHours: 24
+    # The ratio at which Ceph should block IO if the OSDs are too full. The default is 0.95.
+    # fullRatio: 0.95
+    # The ratio at which Ceph should stop backfilling data if the OSDs are too full. The default is 0.90.
+    # backfillFullRatio: 0.90
+    # The ratio at which Ceph should raise a health warning if the OSDs are almost full. The default is 0.85.
+    # nearFullRatio: 0.85
+  # The section for configuring management of daemon disruptions during upgrade or fencing.
+  disruptionManagement:
+    # If true, the operator will create and manage PodDisruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically
+    # via the strategy outlined in the [design](https://github.com/rook/rook/blob/master/design/ceph/ceph-managed-disruptionbudgets.md). The operator will
+    # block eviction of OSDs by default and unblock them safely when drains are detected.
+    managePodBudgets: true
+    # A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
+    # default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.
+    osdMaintenanceTimeout: 1
+    # A duration in minutes that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up.
+    # Operator will continue with the next drain if the timeout exceeds. It only works if `managePodBudgets` is `true`.
+    # Set to 15 minutes to prevent indefinite hangs during Talos node upgrades while still allowing time for PG recovery.
+    pgHealthCheckTimeout: 15
+
+  # csi defines CSI Driver settings applied per cluster.
+  csi:
+    readAffinity:
+      # Enable read affinity to enable clients to optimize reads from an OSD in the same topology.
+      # Enabling the read affinity may cause the OSDs to consume some extra memory.
+      # For more details see this doc:
+      # https://rook.io/docs/rook/latest/Storage-Configuration/Ceph-CSI/ceph-csi-drivers/#enable-read-affinity-for-rbd-volumes
+      enabled: false
+
+    # cephfs driver specific settings.
+    cephfs: {} # Ensure this is an empty object
+      # Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options.
+      # kernelMountOptions: ""
+      # Set CephFS Fuse mount options to use https://docs.ceph.com/en/latest/man/8/ceph-fuse/#options.
+      # fuseMountOptions: ""
+
+  # healthChecks
+  # Valid values for daemons are 'mon', 'osd', 'status'
+  healthCheck:
+    daemonHealth:
+      mon:
+        disabled: false
+        interval: 45s
+      osd:
+        disabled: false
+        interval: 60s
+      status:
+        disabled: false
+        interval: 60s
+    # Change pod liveness probe timing or threshold values. Works for all mon,mgr,osd daemons.
+    livenessProbe:
+      mon:
+        disabled: false
+      mgr:
+        disabled: false
+      osd:
+        disabled: false
+    # Change pod startup probe timing or threshold values. Works for all mon,mgr,osd daemons.
+    startupProbe:
+      mon:
+        disabled: false
+      mgr:
+        disabled: false
+      osd:
+        disabled: false

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/dashboard-cluster.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/dashboard-cluster.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-cluster
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Ceph
+  grafanaCom:
+    id: 2842

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/dashboard-osd.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/dashboard-osd.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-osd
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Ceph
+  grafanaCom:
+    id: 5336

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/dashboard-pools.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/dashboard-pools.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-pools
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: Ceph
+  grafanaCom:
+    id: 5342

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/filesystem.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/filesystem.yaml
@@ -1,0 +1,158 @@
+#################################################################################################################
+# Create a filesystem with settings with replication enabled for a production environment.
+# A minimum of 3 OSDs on different nodes are required in this example.
+# If one mds daemon per node is too restrictive, see the podAntiAffinity below.
+#  kubectl create -f filesystem.yaml
+#################################################################################################################
+
+---
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: filesystem
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The metadata pool spec. Must use replication.
+  metadataPool:
+    replicated:
+      size: 3
+      requireSafeReplicaSize: true
+    parameters:
+      # Inline compression mode for the data pool
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
+      compression_mode:
+        none
+        # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+      # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+      #target_size_ratio: ".5"
+  # The list of data pool specs. Can use replication or erasure coding.
+  dataPools:
+    - name: replicated
+      failureDomain: host
+      replicated:
+        size: 3
+        # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+        # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+        requireSafeReplicaSize: true
+      parameters:
+        # Inline compression mode for the data pool
+        # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
+        compression_mode:
+          passive
+          # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+        # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+        #target_size_ratio: ".5"
+  # Whether to preserve filesystem after CephFilesystem CRD deletion
+  preserveFilesystemOnDelete: true
+  # The metadata service (mds) configuration
+  metadataServer:
+    # The number of active MDS instances
+    activeCount: 1
+    # Whether each active MDS instance will have an active standby with a warm metadata cache for faster failover.
+    # If false, standbys will be available, but will not have a warm cache.
+    activeStandby: true
+    # The affinity rules to apply to the mds deployment
+    placement:
+      #  nodeAffinity:
+      #    requiredDuringSchedulingIgnoredDuringExecution:
+      #      nodeSelectorTerms:
+      #      - matchExpressions:
+      #        - key: role
+      #          operator: In
+      #          values:
+      #          - mds-node
+      #  topologySpreadConstraints:
+      #  tolerations:
+      #  - key: mds-node
+      #    operator: Exists
+      #  podAffinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - rook-ceph-mds
+            ## Add this if you want to allow mds daemons for different filesystems to run on one
+            ## node. The value in "values" must match .metadata.name.
+            #    - key: rook_file_system
+            #          operator: In
+            #          values:
+            #            - filesystem
+            # topologyKey: kubernetes.io/hostname will place MDS across different hosts
+            topologyKey: kubernetes.io/hostname
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - rook-ceph-mds
+              # topologyKey: */zone can be used to spread MDS across different AZ
+              # Use <topologyKey: failure-domain.beta.kubernetes.io/zone> in k8s cluster if your cluster is v1.16 or lower
+              # Use <topologyKey: topology.kubernetes.io/zone>  in k8s cluster is v1.17 or upper
+              topologyKey: topology.kubernetes.io/zone
+    # A key/value list of annotations
+    # annotations:
+    #  key: value
+    # A key/value list of labels
+    # labels:
+    #  key: value
+    # resources:
+    # The requests and limits set here, allow the filesystem MDS Pod(s) to use half of one CPU core and 1 gigabyte of memory
+    #  limits:
+    #    memory: "1024Mi"
+    #  requests:
+    #    cpu: "500m"
+    #    memory: "1024Mi"
+    priorityClassName: system-cluster-critical
+    livenessProbe:
+      disabled: false
+    startupProbe:
+      disabled: false
+  # Filesystem mirroring settings
+  # mirroring:
+  #   enabled: true
+  #   # list of Kubernetes Secrets containing the peer token
+  #   # for more details see: https://docs.ceph.com/en/latest/dev/cephfs-mirroring/#bootstrap-peers
+  #   # Add the secret name if it already exists else specify the empty list here.
+  #   peers:
+  #     secretNames:
+  #     - secondary-cluster-peer
+  #   # specify the schedule(s) on which snapshots should be taken
+  #   # see the official syntax here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-schedules
+  #   snapshotSchedules:
+  #     - path: /
+  #       interval: 24h # daily snapshots
+  #   # The startTime should be mentioned in the format YYYY-MM-DDTHH:MM:SS
+  #   # If startTime is not specified, then by default the start time is considered as midnight UTC.
+  #   # see usage here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#usage
+  #   # startTime: 2022-07-15T11:55:00
+  #   # manage retention policies
+  #   # see syntax duration here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-retention-policies
+  #   snapshotRetention:
+  #     - path: /
+  #       duration: "h 24"
+# create default csi subvolume group
+---
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystemSubVolumeGroup
+metadata:
+  name: filesystem-csi # lets keep the svg crd name same as `filesystem name + csi` for the default csi svg
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
+  name: csi
+  # filesystemName is the metadata name of the CephFilesystem CR where the subvolume group will be created
+  filesystemName: filesystem
+  # reference https://docs.ceph.com/en/latest/cephfs/fs-volumes/#pinning-subvolumes-and-subvolume-groups
+  # only one out of (export, distributed, random) can be set at a time
+  # by default pinning is set with value: distributed=1
+  # for disabling default values set (distributed=0)
+  pinning:
+    distributed: 1 # distributed=<0, 1> (disabled=0)
+    # export:                 # export=<0-256> (disabled=-1)
+    # random:                 # random=[0.0, 1.0](disabled=0.0)

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/httproute.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/httproute.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rook
+  namespace: rook-ceph
+  annotations:
+    item.homer.rajsingh.info/name: "Rook Ceph"
+    item.homer.rajsingh.info/subtitle: "Storage Dashboard"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/rook.svg"
+    item.homer.rajsingh.info/keywords: "storage, ceph, dashboard"
+
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-server"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "rook.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: rook-ceph-mgr-dashboard
+          port: 7000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./httproute.yaml
+  - ./filesystem.yaml
+  - ./toolbox.yaml
+  - ./storageclass.yaml
+  - ./volumesnapshot.yaml
+  - ./blockpool.yaml
+  # Dashboards
+  - ./dashboard-cluster.yaml
+  - ./dashboard-osd.yaml
+  - ./dashboard-pools.yaml

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/storageclass.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/storageclass.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-cephfs
+provisioner: rook-ceph.cephfs.csi.ceph.com # csi-provisioner-name
+parameters:
+  # clusterID is the namespace where the rook cluster is running
+  # If you change this namespace, also change the namespace below where the secret namespaces are defined
+  clusterID: rook-ceph # namespace:cluster
+
+  # CephFS filesystem name into which the volume shall be created
+  fsName: filesystem
+
+  # Ceph pool into which the volume shall be created
+  # Required for provisionVolume: "true"
+  pool: filesystem-replicated
+
+  # The secrets contain Ceph admin credentials. These are generated automatically by the operator
+  # in the same namespace as the cluster.
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
+
+  # (optional) Set it to true to encrypt each volume with encryption keys
+  # from a key management system (KMS)
+  # encrypted: "true"
+
+  # (optional) Use external key management system (KMS) for encryption key by
+  # specifying a unique ID matching a KMS ConfigMap. The ID is only used for
+  # correlation to configmap entry.
+  # encryptionKMSID: <kms-config-id>
+
+  # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)
+  # If omitted, default volume mounter will be used - this is determined by probing for ceph-fuse
+  # or by setting the default mounter explicitly via --volumemounter command-line argument.
+  # mounter: kernel
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+# mountOptions:
+  # uncomment the following line for debugging
+  #- debug
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: ceph-block-replicated-nvme
+parameters:
+  clusterID: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  imageFeatures: layering
+  imageFormat: "2"
+  pool: ceph-blockpool-replicated-nvme
+provisioner: rook-ceph.rbd.csi.ceph.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/toolbox.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/toolbox.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-tools
+  namespace: rook-ceph # namespace:cluster
+  labels:
+    app: rook-ceph-tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-tools
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-tools
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: rook-ceph-default
+      containers:
+        - name: rook-ceph-tools
+          image: quay.io/ceph/ceph:v20.2.1
+          command: ["/bin/bash"]
+          args:
+            - "-c"
+            - |
+              # Replicate the script from toolbox.sh inline so the ceph image
+              # can be run directly, instead of requiring the rook toolbox
+              CEPH_CONFIG="/etc/ceph/ceph.conf"
+              MON_CONFIG="/etc/rook/mon-endpoints"
+              KEYRING_FILE="/etc/ceph/keyring"
+
+              # create a ceph config file in its default location so ceph/rados tools can be used
+              # without specifying any arguments
+              write_endpoints() {
+                endpoints=$$(cat $${MON_CONFIG})
+
+                # filter out the mon names
+                # external cluster can have numbers or hyphens in mon names, handling them in regex
+                # shellcheck disable=SC2001
+                mon_endpoints=$$(echo "$${endpoints}"| sed 's/[a-z0-9_-]\+=//g')
+
+                DATE=$$(date)
+                echo "$$DATE writing mon endpoints to $${CEPH_CONFIG}: $${endpoints}"
+                  cat <<EOF > $${CEPH_CONFIG}
+              [global]
+              mon_host = $${mon_endpoints}
+
+              [client.admin]
+              keyring = $${KEYRING_FILE}
+              EOF
+              }
+
+              # watch the endpoints config file and update if the mon endpoints ever change
+              watch_endpoints() {
+                # get the timestamp for the target of the soft link
+                real_path=$$(realpath $${MON_CONFIG})
+                initial_time=$$(stat -c %Z "$${real_path}")
+                while true; do
+                  real_path=$$(realpath $${MON_CONFIG})
+                  latest_time=$$(stat -c %Z "$${real_path}")
+
+                  if [[ "$${latest_time}" != "$${initial_time}" ]]; then
+                    write_endpoints
+                    initial_time=$${latest_time}
+                  fi
+
+                  sleep 10
+                done
+              }
+
+              # read the secret from an env var (for backward compatibility), or from the secret file
+              ceph_secret=$${ROOK_CEPH_SECRET}
+              if [[ "$$ceph_secret" == "" ]]; then
+                ceph_secret=$$(cat /var/lib/rook-ceph-mon/secret.keyring)
+              fi
+
+              # create the keyring file
+              cat <<EOF > $${KEYRING_FILE}
+              [$${ROOK_CEPH_USERNAME}]
+              key = $${ceph_secret}
+              EOF
+
+              # write the initial config file
+              write_endpoints
+
+              # continuously update the mon endpoints if they fail over
+              watch_endpoints
+          imagePullPolicy: IfNotPresent
+          tty: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2016
+            runAsGroup: 2016
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+              readOnly: true
+      volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: data
+                path: mon-endpoints
+        - name: ceph-config
+          emptyDir: {}
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 5

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/volumesnapshot.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config/volumesnapshot.yaml
@@ -1,0 +1,35 @@
+# 1.17 <= K8s <= v1.19
+# apiVersion: snapshot.storage.k8s.io/v1beta1
+# K8s >= v1.20
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-rbdplugin-snapclass
+driver: rook-ceph.rbd.csi.ceph.com # driver:namespace:operator
+parameters:
+  # Specify a string that identifies your cluster. Ceph CSI supports any
+  # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
+  # for example "rook-ceph".
+  clusterID: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph # namespace:cluster
+deletionPolicy: Delete
+# 1.17 <= K8s <= v1.19
+# apiVersion: snapshot.storage.k8s.io/v1beta1
+# K8s >= v1.20
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-cephfsplugin-snapclass
+driver: rook-ceph.cephfs.csi.ceph.com # driver:namespace:operator
+parameters:
+  # Specify a string that identifies your cluster. Ceph CSI supports any
+  # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
+  # for example "rook-ceph".
+  clusterID: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph # namespace:cluster
+deletionPolicy: Delete
+---

--- a/kubernetes/apps/base/spiderpool/spiderpool-stpetersburg/app/helmrelease.yaml
+++ b/kubernetes/apps/base/spiderpool/spiderpool-stpetersburg/app/helmrelease.yaml
@@ -1,0 +1,84 @@
+---
+# Spiderpool — adopted for its CNI-chain "coordinator" plugin only. We keep
+# Cilium (primary CNI), Multus (meta-CNI), and the CNI dhcp IPAM. The
+# coordinator handles route reconciliation between Cilium's overlay and the
+# Multus-attached macvlan, which eliminates the route-fix init container we
+# previously had to bolt onto every multi-homed pod.
+#
+# Architecture:
+#   - Cilium owns eth0 in pods (10.5.0.0/16)
+#   - Multus attaches net1 (macvlan on host eth0, DHCP'd from UDM)
+#   - Spider Coordinator (chained after macvlan in the NAD) keeps Cilium's
+#     default route + cluster service routing intact, adds policy-based rules
+#     so reply traffic uses the correct interface, sets rp_filter=0, etc.
+#
+# We intentionally disable Spiderpool's IPAM and DaemonSet-managed CNI binary
+# install: we already have macvlan/dhcp/ipvlan via siderolabs/install-cni, and
+# our existing CNI DHCP daemon DS handles dynamic IPs from the UDM.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spiderpool
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: spiderpool
+      version: "1.2.x"
+      sourceRef:
+        kind: HelmRepository
+        name: spiderpool
+        namespace: flux-system
+      interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Multus is already installed via clusters/talos-stpetersburg/apps/cilium
+    multus:
+      enableMultusConfig: true   # need SpiderMultusConfig CRD even if not used
+      multusCNI:
+        install: false           # don't reinstall the Multus DS
+    # CNI reference plugins (macvlan, dhcp, ipvlan, bridge, etc.) are already
+    # shipped to /opt/cni/bin by siderolabs/install-cni (in our Multus DS).
+    plugins:
+      installCNI: false
+      installOvsCNI: false
+      installRdmaCNI: false
+    # Coordinator is the whole reason we're installing Spiderpool. It installs
+    # the spider-coordinator CNI binary to /opt/cni/bin on each node.
+    coordinator:
+      enabled: true
+      mode: overlay
+      podCIDRType: cluster
+      tuneMode: overlay
+      tunePodRoutes: true
+    # Default SpiderCoordinator CR (auto-detects overlay/serviceCIDR from
+    # kubeadm-config or kube-controller-manager). Talos: needs `auto` mode to
+    # pull CIDRs from the running cluster.
+    spiderpoolController:
+      replicas: 2
+      podAntiAffinity:
+        nodeAffinity:
+          enabled: true
+    # IPAM stays enabled so spiderpool-init's readiness check (/v1/ipam/healthy)
+    # succeeds. We don't reference Spiderpool's IPAM in our NAD chain — DHCP
+    # IPAM continues to handle LAN IP allocation — but the controller needs
+    # to expose the IPAM HTTP endpoints for its own startup health.
+    ipam:
+      enableIPv4: true
+      enableIPv6: false
+    # Don't create the chart's example default pools; we manage IPs via DHCP.
+    clusterDefaultPool:
+      installIPv4IPPool: false
+      installIPv6IPPool: false
+    spiderpoolAgent:
+      prometheus:
+        enabled: false
+    grafanaDashboard:
+      install: false

--- a/kubernetes/apps/base/spiderpool/spiderpool-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/spiderpool/spiderpool-stpetersburg/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/tuppr/tuppr-app/app/helmrelease.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-app/app/helmrelease.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tuppr
+spec:
+  interval: 30m
+  timeout: 15m
+  chart:
+    spec:
+      chart: tuppr
+      version: 0.2.3
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: tuppr-values
+      valuesKey: values.yaml
+      optional: false

--- a/kubernetes/apps/base/tuppr/tuppr-app/app/kustomization.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-app/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: tuppr-values
+    files:
+      - values.yaml

--- a/kubernetes/apps/base/tuppr/tuppr-app/app/values.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-app/app/values.yaml
@@ -1,0 +1,28 @@
+---
+replicaCount: 1
+
+controller:
+  leaderElection:
+    enabled: true
+  metrics:
+    enabled: true
+    secure: false
+
+webhook:
+  enabled: true
+  certManager:
+    enabled: true
+
+monitoring:
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    labels:
+      prometheus: kube-prometheus
+
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule

--- a/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/kubernetes-upgrade.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.36.1
+  healthChecks:
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+      description: All nodes must be Ready
+      timeout: 10m
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook
+      namespace: rook-ceph
+      expr: status.ceph.health != "HEALTH_ERR" && !(has(status.ceph.details) && "PG_AVAILABILITY" in status.ceph.details)
+      description: Ceph must have no inactive PGs before upgrading next node
+      timeout: 30m
+    - apiVersion: garage.rajsingh.info/v1beta1
+      kind: GarageCluster
+      name: garage
+      namespace: garage
+      expr: status.phase == 'Running' && status.readyReplicas == object.spec.replicas
+      description: Garage cluster must be running with all replicas ready
+      timeout: 10m
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      expr: |
+        status.phase == 'Cluster in healthy state' &&
+          status.readyInstances == object.spec.instances
+      description: All CNPG clusters must be healthy with all instances ready
+      timeout: 15m

--- a/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/kustomization.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - talos-upgrade.yaml
+  - kubernetes-upgrade.yaml

--- a/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/talos-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/talos-upgrade.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: talos
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.13.3
+  policy:
+    debug: true
+    force: true
+    rebootMode: default
+    placement: soft
+    timeout: 30m
+  drain:
+    enabled: true
+    disableEviction: true
+  healthChecks:
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+      description: All nodes must be Ready
+      timeout: 10m
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook
+      namespace: rook-ceph
+      expr: status.ceph.health != "HEALTH_ERR" && !(has(status.ceph.details) && "PG_AVAILABILITY" in status.ceph.details)
+      description: Ceph must have no inactive PGs before upgrading next node
+      timeout: 30m

--- a/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kubernetes-upgrade.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.36.1
+  healthChecks:
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+      description: All nodes must be Ready
+      timeout: 10m
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
+      namespace: rook-ceph
+      expr: status.ceph.health != "HEALTH_ERR" && !(has(status.ceph.details) && "PG_AVAILABILITY" in status.ceph.details)
+      description: Ceph must have no inactive PGs before upgrading next node
+      timeout: 30m
+    - apiVersion: garage.rajsingh.info/v1beta1
+      kind: GarageCluster
+      name: garage
+      namespace: garage
+      expr: status.phase == 'Running' && status.readyReplicas == object.spec.replicas
+      description: Garage cluster must be running with all replicas ready
+      timeout: 10m
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      expr: |
+        status.phase == 'Cluster in healthy state' &&
+          status.readyInstances == object.spec.instances
+      description: All CNPG clusters must be healthy with all instances ready
+      timeout: 15m

--- a/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kustomization.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - talos-upgrade.yaml
+  - kubernetes-upgrade.yaml

--- a/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/talos-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/talos-upgrade.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: talos
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.13.3
+  policy:
+    debug: true
+    force: true
+    rebootMode: default
+    placement: soft
+    timeout: 30m
+  drain:
+    enabled: true
+    disableEviction: true
+  healthChecks:
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+      description: All nodes must be Ready
+      timeout: 10m
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
+      namespace: rook-ceph
+      expr: status.ceph.health != "HEALTH_ERR" && !(has(status.ceph.details) && "PG_AVAILABILITY" in status.ceph.details)
+      description: Ceph must have no inactive PGs before upgrading next node
+      timeout: 30m

--- a/kubernetes/apps/base/tuppr/tuppr-config-stpetersburg/config/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-stpetersburg/config/kubernetes-upgrade.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.36.1
+  healthChecks:
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+      description: All nodes must be Ready
+      timeout: 10m

--- a/kubernetes/apps/base/tuppr/tuppr-config-stpetersburg/config/kustomization.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-stpetersburg/config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - talos-upgrade.yaml
+  - kubernetes-upgrade.yaml

--- a/kubernetes/apps/base/tuppr/tuppr-config-stpetersburg/config/talos-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-stpetersburg/config/talos-upgrade.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: talos
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.13.3
+  policy:
+    debug: true
+    force: true
+    rebootMode: default
+    placement: soft
+    timeout: 30m

--- a/kubernetes/apps/ottawa/csi-addons/csi-addons-config.yaml
+++ b/kubernetes/apps/ottawa/csi-addons/csi-addons-config.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-addons-config
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: csi-addons
+  path: ./kubernetes/apps/base/csi-addons/csi-addons-config-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/csi-addons/csi-addons.yaml
+++ b/kubernetes/apps/ottawa/csi-addons/csi-addons.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-addons
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-operator
+  path: ./deploy/controller
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: csi-addons
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/csi-addons/kustomization.yaml
+++ b/kubernetes/apps/ottawa/csi-addons/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./csi-addons.yaml
+  - ./csi-addons-config.yaml

--- a/kubernetes/apps/ottawa/csi-driver-smb/csi-driver-smb.yaml
+++ b/kubernetes/apps/ottawa/csi-driver-smb/csi-driver-smb.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-driver-smb
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/csi-driver-smb/csi-driver-smb-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/csi-driver-smb/kustomization.yaml
+++ b/kubernetes/apps/ottawa/csi-driver-smb/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./csi-driver-smb.yaml

--- a/kubernetes/apps/ottawa/k8s-gpu-dra-driver/k8s-gpu-dra-driver.yaml
+++ b/kubernetes/apps/ottawa/k8s-gpu-dra-driver/k8s-gpu-dra-driver.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app k8s-gpu-dra-driver
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/k8s-gpu-dra-driver/k8s-gpu-dra-driver-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/k8s-gpu-dra-driver/kustomization.yaml
+++ b/kubernetes/apps/ottawa/k8s-gpu-dra-driver/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./k8s-gpu-dra-driver.yaml

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -58,3 +58,5 @@ resources:
   - ./csi-addons
   - ./csi-driver-smb
   - ./tuppr
+  - ./k8s-gpu-dra-driver
+  - ./rook-ceph

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -57,3 +57,4 @@ resources:
   - ./local-path-storage
   - ./csi-addons
   - ./csi-driver-smb
+  - ./tuppr

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -55,3 +55,5 @@ resources:
   - ./node-feature-discovery
   - ./tailscale
   - ./local-path-storage
+  - ./csi-addons
+  - ./csi-driver-smb

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -54,3 +54,4 @@ resources:
   - ./flux-system
   - ./node-feature-discovery
   - ./tailscale
+  - ./local-path-storage

--- a/kubernetes/apps/ottawa/local-path-storage/kustomization.yaml
+++ b/kubernetes/apps/ottawa/local-path-storage/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./local-path-storage.yaml

--- a/kubernetes/apps/ottawa/local-path-storage/local-path-storage.yaml
+++ b/kubernetes/apps/ottawa/local-path-storage/local-path-storage.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app local-path-storage
+  namespace: flux-system
+spec:
+  targetNamespace: local-path-storage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/local-path-storage/local-path-storage-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/ottawa/rook-ceph/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rook-ceph.yaml

--- a/kubernetes/apps/ottawa/rook-ceph/rook-ceph.yaml
+++ b/kubernetes/apps/ottawa/rook-ceph/rook-ceph.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-operator
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  path: ./kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-cluster-config
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-operator
+    - name: snapshot-controller
+  path: ./kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/kubernetes/apps/ottawa/tuppr/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tuppr/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tuppr.yaml
+  - ./tuppr-config.yaml

--- a/kubernetes/apps/ottawa/tuppr/namespace.yaml
+++ b/kubernetes/apps/ottawa/tuppr/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-upgrade
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/tuppr/tuppr-config.yaml
+++ b/kubernetes/apps/ottawa/tuppr/tuppr-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr-config
+  namespace: flux-system
+spec:
+  targetNamespace: system-upgrade
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: tuppr
+  path: ./kubernetes/apps/base/tuppr/tuppr-config-ottawa/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/tuppr/tuppr.yaml
+++ b/kubernetes/apps/ottawa/tuppr/tuppr.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+  namespace: flux-system
+spec:
+  targetNamespace: system-upgrade
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cert-manager
+  path: ./kubernetes/apps/base/tuppr/tuppr-app/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/cert-manager/cert-manager-issuers.yaml
+++ b/kubernetes/apps/robbinsdale/cert-manager/cert-manager-issuers.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cert-manager-issuers
+  namespace: flux-system
+spec:
+  targetNamespace: cert-manager
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cert-manager
+  path: ./kubernetes/apps/base/cert-manager/cert-manager-issuers-robbinsdale/issuers
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/cloudflare/cloudflared.yaml
+++ b/kubernetes/apps/robbinsdale/cloudflare/cloudflared.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudflared
+  namespace: flux-system
+spec:
+  targetNamespace: cloudflare
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/cloudflare/cloudflared-robbinsdale/cloudflared
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/cloudflare/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/cloudflare/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./cloudflare.yaml
+  - ./cloudflared.yaml

--- a/kubernetes/apps/robbinsdale/csi-addons/csi-addons-config.yaml
+++ b/kubernetes/apps/robbinsdale/csi-addons/csi-addons-config.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-addons-config
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: csi-addons
+  path: ./kubernetes/apps/base/csi-addons/csi-addons-config-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/csi-addons/csi-addons.yaml
+++ b/kubernetes/apps/robbinsdale/csi-addons/csi-addons.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-addons
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-operator
+  path: ./deploy/controller
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: csi-addons
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/csi-addons/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/csi-addons/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./csi-addons.yaml
+  - ./csi-addons-config.yaml

--- a/kubernetes/apps/robbinsdale/csi-driver-smb/csi-driver-smb.yaml
+++ b/kubernetes/apps/robbinsdale/csi-driver-smb/csi-driver-smb.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app csi-driver-smb
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/csi-driver-smb/csi-driver-smb-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/csi-driver-smb/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/csi-driver-smb/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./csi-driver-smb.yaml

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -45,3 +45,4 @@ resources:
   - ./tailscale-examples
   - ./tailscale-system
   - ./tailscale
+  - ./local-path-storage

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -48,3 +48,4 @@ resources:
   - ./local-path-storage
   - ./csi-addons
   - ./csi-driver-smb
+  - ./tuppr

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -46,3 +46,5 @@ resources:
   - ./tailscale-system
   - ./tailscale
   - ./local-path-storage
+  - ./csi-addons
+  - ./csi-driver-smb

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -49,3 +49,4 @@ resources:
   - ./csi-addons
   - ./csi-driver-smb
   - ./tuppr
+  - ./rook-ceph

--- a/kubernetes/apps/robbinsdale/local-path-storage/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/local-path-storage/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./local-path-storage.yaml

--- a/kubernetes/apps/robbinsdale/local-path-storage/local-path-storage.yaml
+++ b/kubernetes/apps/robbinsdale/local-path-storage/local-path-storage.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app local-path-storage
+  namespace: flux-system
+spec:
+  targetNamespace: local-path-storage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/local-path-storage/local-path-storage-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/rook-ceph/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rook-ceph.yaml

--- a/kubernetes/apps/robbinsdale/rook-ceph/rook-ceph.yaml
+++ b/kubernetes/apps/robbinsdale/rook-ceph/rook-ceph.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-operator
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  path: ./kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-cluster-config
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-operator
+    - name: snapshot-controller
+  path: ./kubernetes/apps/base/rook-ceph/rook-ceph-robbinsdale/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/kubernetes/apps/robbinsdale/tuppr/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/tuppr/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tuppr.yaml
+  - ./tuppr-config.yaml

--- a/kubernetes/apps/robbinsdale/tuppr/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/tuppr/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-upgrade
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/tuppr/tuppr-config.yaml
+++ b/kubernetes/apps/robbinsdale/tuppr/tuppr-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr-config
+  namespace: flux-system
+spec:
+  targetNamespace: system-upgrade
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: tuppr
+  path: ./kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/tuppr/tuppr.yaml
+++ b/kubernetes/apps/robbinsdale/tuppr/tuppr.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+  namespace: flux-system
+spec:
+  targetNamespace: system-upgrade
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cert-manager
+  path: ./kubernetes/apps/base/tuppr/tuppr-app/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/cloudflare/cloudflare-cluster-app.yaml
+++ b/kubernetes/apps/stpetersburg/cloudflare/cloudflare-cluster-app.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudflare-cluster-app
+  namespace: flux-system
+spec:
+  targetNamespace: cloudflare
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/cloudflare/cloudflare-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/cloudflare/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/cloudflare/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./cloudflare.yaml
+  - ./cloudflare-cluster-app.yaml

--- a/kubernetes/apps/stpetersburg/flux-system/flux-system-stpetersburg.yaml
+++ b/kubernetes/apps/stpetersburg/flux-system/flux-system-stpetersburg.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-system-stpetersburg
+  namespace: flux-system
+spec:
+  targetNamespace: flux-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: flux-system
+  path: ./kubernetes/apps/base/flux-system/flux-system-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/flux-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/flux-system/kustomization.yaml
@@ -2,4 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./namespace.yaml
   - ./flux-system.yaml
+  - ./flux-system-stpetersburg.yaml

--- a/kubernetes/apps/stpetersburg/flux-system/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/flux-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/garage/garage-nodes-stpetersburg.yaml
+++ b/kubernetes/apps/stpetersburg/garage/garage-nodes-stpetersburg.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-nodes-stpetersburg
+  namespace: flux-system
+spec:
+  targetNamespace: garage
+  path: ./kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: garage

--- a/kubernetes/apps/stpetersburg/garage/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/garage/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./garage.yaml
+  - ./garage-nodes-stpetersburg.yaml

--- a/kubernetes/apps/stpetersburg/gpu-operator/gpu-operator.yaml
+++ b/kubernetes/apps/stpetersburg/gpu-operator/gpu-operator.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gpu-operator
+  namespace: flux-system
+spec:
+  targetNamespace: gpu-operator
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/gpu-operator/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/gpu-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gpu-operator.yaml

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -45,3 +45,4 @@ resources:
   - ./tailscale-system
   - ./tailscale
   - ./local-path-storage
+  - ./tuppr

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -44,3 +44,4 @@ resources:
   - ./tailscale-examples
   - ./tailscale-system
   - ./tailscale
+  - ./local-path-storage

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -46,3 +46,6 @@ resources:
   - ./tailscale
   - ./local-path-storage
   - ./tuppr
+  - ./rdma-shared-dp
+  - ./spiderpool
+  - ./gpu-operator

--- a/kubernetes/apps/stpetersburg/local-path-storage/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/local-path-storage/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./local-path-storage.yaml

--- a/kubernetes/apps/stpetersburg/local-path-storage/local-path-storage.yaml
+++ b/kubernetes/apps/stpetersburg/local-path-storage/local-path-storage.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app local-path-storage
+  namespace: flux-system
+spec:
+  targetNamespace: local-path-storage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/local-path-storage/local-path-storage-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/rdma-shared-dp/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/rdma-shared-dp/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rdma-shared-dp.yaml

--- a/kubernetes/apps/stpetersburg/rdma-shared-dp/rdma-shared-dp.yaml
+++ b/kubernetes/apps/stpetersburg/rdma-shared-dp/rdma-shared-dp.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rdma-shared-dp
+  namespace: flux-system
+spec:
+  targetNamespace: rdma-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/rdma-shared-dp/rdma-shared-dp-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/spiderpool/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/spiderpool/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./spiderpool.yaml

--- a/kubernetes/apps/stpetersburg/spiderpool/spiderpool.yaml
+++ b/kubernetes/apps/stpetersburg/spiderpool/spiderpool.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app spiderpool
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/spiderpool/spiderpool-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/tuppr/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/tuppr/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tuppr.yaml
+  - ./tuppr-config.yaml

--- a/kubernetes/apps/stpetersburg/tuppr/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/tuppr/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-upgrade
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/tuppr/tuppr-config.yaml
+++ b/kubernetes/apps/stpetersburg/tuppr/tuppr-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr-config
+  namespace: flux-system
+spec:
+  targetNamespace: system-upgrade
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: tuppr
+  path: ./kubernetes/apps/base/tuppr/tuppr-config-stpetersburg/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/tuppr/tuppr.yaml
+++ b/kubernetes/apps/stpetersburg/tuppr/tuppr.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+  namespace: flux-system
+spec:
+  targetNamespace: system-upgrade
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cert-manager
+  path: ./kubernetes/apps/base/tuppr/tuppr-app/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

Wave D PR-A — all 7 steps. Adopts storage and node-plumbing apps from \`clusters/*/apps/\` into \`kubernetes/apps/base/\` + per-location pointers. No content changes; adoption key is unchanged CR \`metadata.name\` so Flux takes ownership without pod restarts.

Apps migrated (strictly sequential):

- **step-1**: cert-manager-issuers (robbinsdale), cloudflared (robbinsdale), cloudflare-cluster-app (stpetersburg), flux-system-stpetersburg
- **step-2**: local-path-storage (ottawa, robbinsdale, stpetersburg) — verbatim with vendored local-path-provisioner.yaml
- **step-3**: csi-addons + csi-addons-config (ottawa, robbinsdale), csi-driver-smb (ottawa, robbinsdale)
- **step-4**: tuppr + tuppr-config (ottawa, robbinsdale, stpetersburg)
- **step-5**: k8s-gpu-dra-driver (ottawa), rdma-shared-dp/spiderpool/gpu-operator (stpetersburg)
- **step-6**: garage-nodes-stpetersburg — raw GarageNode CRs normalized with new Flux Kustomization CR \`garage-nodes-stpetersburg\` (grafana-redirect precedent)
- **step-7**: rook-ceph-operator + rook-ceph-cluster-config (ottawa, robbinsdale) — LAST; pre-existing ceph health captured: ottawa=HEALTH_WARN (BlueStore slow ops), robbinsdale=HEALTH_OK

## Verification

All base copies are byte-identical:
- \`kustomize build <old-path>\` vs \`kustomize build <new-path>\` — empty diff for all apps/configs

Note: \`make test\` shows flate failures for \`tuppr-config\` (and other in-flight wave paths) due to PR-A window non-determinism — flate clones remote main which doesn't yet have these paths. CI renders-diff is the authoritative gate.

## After merge

PR-B (release) will \`git rm -r clusters/talos-*/apps/{cert-manager,cloudflare,flux-system,local-path-storage,csi-addons,csi-driver-smb,tuppr,k8s-gpu-dra-driver,rdma-shared-dp,spiderpool,gpu-operator,garage,rook-ceph}\` after live adoption is verified:
- \`flux get ks -A | grep <app>\` shows label \`kustomize.toolkit.fluxcd.io/name: kubernetes-apps\`
- For rook-ceph: \`ceph health\` must match pre-existing state (ottawa=HEALTH_WARN bluestore slow ops, robbinsdale=HEALTH_OK)
- For garage nodes: \`kubectl get garagenodes -n garage\` unchanged
- For GPU pods: \`gpu-operator\` and \`ai\` namespaces keep startTimes