### PR TITLE
feat(cilium): adopt cilium/cilium-config for stpetersburg to kubernetes/ tree (PR-A)

### DIFF
--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/cni-dhcp-daemon.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/cni-dhcp-daemon.yaml
@@ -1,0 +1,65 @@
+---
+# CNI DHCP daemon — provides IPAM type "dhcp" for Multus secondary networks.
+# Each node already has /opt/cni/bin/dhcp installed by siderolabs/install-cni
+# (the same DaemonSet that installs the Multus shim). This DS just runs the
+# binary in daemon mode, listening on /run/cni/dhcp.sock, so that NADs with
+# `"ipam":{"type":"dhcp"}` can lease IPs from the LAN DHCP server (UDM at
+# 192.168.73.1).
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-dhcp-daemon
+  namespace: kube-system
+  labels:
+    app: cni-dhcp-daemon
+spec:
+  selector:
+    matchLabels:
+      app: cni-dhcp-daemon
+  template:
+    metadata:
+      labels:
+        app: cni-dhcp-daemon
+    spec:
+      hostNetwork: true
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-node-critical
+      containers:
+        - name: dhcp
+          image: busybox:1.38
+          command: ["/opt/cni/bin/dhcp"]
+          args: ["daemon"]
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /opt/cni/bin
+              readOnly: true
+            - name: cni-socket
+              mountPath: /run/cni
+            # /var/run/netns is where Multus puts pod network namespaces;
+            # the daemon needs to setns() into each one to do DHCPDISCOVER.
+            - name: host-netns
+              mountPath: /var/run/netns
+              mountPropagation: HostToContainer
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin
+            type: Directory
+        - name: cni-socket
+          hostPath:
+            path: /run/cni
+            type: DirectoryOrCreate
+        - name: host-netns
+          hostPath:
+            path: /var/run/netns
+            type: Directory

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/descheduler-cronjob.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/descheduler-cronjob.yaml
@@ -1,0 +1,194 @@
+# Vendored from github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=release-1.32
+# upstream commit: 1de26e82a190823d3a56495e5c595e2d5ed7f499 — re-render with: kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=release-1.32'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: descheduler-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: descheduler-cluster-role
+rules:
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - descheduler
+  resources:
+  - leases
+  verbs:
+  - get
+  - patch
+  - delete
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: descheduler-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: descheduler-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: descheduler-sa
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  policy.yaml: |
+    apiVersion: "descheduler/v1alpha2"
+    kind: "DeschedulerPolicy"
+    profiles:
+      - name: ProfileName
+        pluginConfig:
+        - name: "DefaultEvictor"
+        - name: "RemovePodsViolatingInterPodAntiAffinity"
+        - name: "RemoveDuplicates"
+        - name: "LowNodeUtilization"
+          args:
+            thresholds:
+              "cpu" : 20
+              "memory": 20
+              "pods": 20
+            targetThresholds:
+              "cpu" : 50
+              "memory": 50
+              "pods": 50
+        plugins:
+          balance:
+            enabled:
+              - "LowNodeUtilization"
+              - "RemoveDuplicates"
+          deschedule:
+            enabled:
+              - "RemovePodsViolatingInterPodAntiAffinity"
+kind: ConfigMap
+metadata:
+  name: descheduler-policy-configmap
+  namespace: kube-system
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: descheduler-cronjob
+  namespace: kube-system
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: descheduler-pod
+        spec:
+          containers:
+          - args:
+            - --policy-config-file
+            - /policy-dir/policy.yaml
+            - --v
+            - "3"
+            command:
+            - /bin/descheduler
+            image: registry.k8s.io/descheduler/descheduler:v0.36.0
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: 10258
+                scheme: HTTPS
+              initialDelaySeconds: 3
+              periodSeconds: 10
+            name: descheduler
+            resources:
+              requests:
+                cpu: 500m
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+            volumeMounts:
+            - mountPath: /policy-dir
+              name: policy-volume
+          priorityClassName: system-cluster-critical
+          restartPolicy: Never
+          serviceAccountName: descheduler-sa
+          volumes:
+          - configMap:
+              name: descheduler-policy-configmap
+            name: policy-volume
+  schedule: '*/2 * * * *'

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/generic-device-plugin.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/generic-device-plugin.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: generic-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: generic-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: generic-device-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: generic-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - image: ghcr.io/squat/generic-device-plugin
+        args:
+        - --device
+        - |
+          name: tun
+          groups:
+            - count: 1000
+              paths:
+                - path: /dev/net/tun          
+        name: generic-device-plugin
+        ports:
+        - containerPort: 8080
+          name: http
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities: { drop: ["ALL"] }
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/device-plugins
+        - name: dev
+          mountPath: /dev
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+      - name: dev
+        hostPath:
+          path: /dev
+  updateStrategy:
+    type: RollingUpdate

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/helmrelease.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: cilium
+      version: 1.19.4
+      sourceRef:
+        kind: HelmRepository
+        name: cilium
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: cilium-values
+      valuesKey: values.yaml
+      optional: false

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/irqbalance-daemonset.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/irqbalance-daemonset.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: irqbalance
+  namespace: kube-system
+  labels:
+    app: irqbalance
+spec:
+  selector:
+    matchLabels:
+      app: irqbalance
+  template:
+    metadata:
+      labels:
+        app: irqbalance
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      containers:
+      - name: irqbalance
+        image: ghcr.io/home-operations/irqbalance:1.9.4@sha256:6cc768c3f074c221412d56b341a19c8432f9a6d76eda0b346285f9c5e2d3b2cc
+        command: ["/usr/sbin/irqbalance"]
+        args: ["--foreground", "--journal"]
+        env:
+        - name: IRQBALANCE_BANNED_CPULIST
+          value: "12-19"
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: run
+          mountPath: /run/irqbalance
+      volumes:
+      - name: run
+        emptyDir: {}
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - generic-device-plugin.yaml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset-thick.yml
+  # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/daemonset-install.yaml
+  # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
+  # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+  - descheduler-cronjob.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/62ede9a032dcfbc41b3418d7360678cb83092498/config/crd/multicluster.x-k8s.io_serviceexports.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/62ede9a032dcfbc41b3418d7360678cb83092498/config/crd/multicluster.x-k8s.io_serviceimports.yaml
+  - helmrelease.yaml
+  - irqbalance-daemonset.yaml
+  - cni-dhcp-daemon.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: cilium-values
+    files:
+      - values.yaml
+patches:
+  - path: patch-multus.yaml
+  - path: patch-descheduler-cronjob.yaml

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-descheduler-cronjob.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-descheduler-cronjob.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: descheduler-cronjob
+  namespace: kube-system
+spec:
+  schedule: "*/5 * * * *"

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: host-run-netns
+          hostPath:
+            path: /var/run/netns/
+      initContainers:
+        - name: install-multus-binary
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+          command:
+            - "cp"
+            - "-f"
+            - "/usr/src/multus-cni/bin/multus-shim"
+            - "/host/opt/cni/bin/multus-shim"
+        - command:
+            - /install-cni.sh
+          image: ghcr.io/siderolabs/install-cni:v1.9.0
+          name: install-cni
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              mountPropagation: Bidirectional
+              name: cnibin
+      containers:
+        - name: kube-multus
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "200Mi"
+            limits:
+              cpu: "1000m"
+              memory: "3000Mi"

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/values.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/values.yaml
@@ -1,0 +1,108 @@
+cluster:
+  name: ${LOCATION}
+cni:
+  exclusive: false
+kubeProxyReplacement: true
+socketLB:
+  enabled: true
+  hostNamespaceOnly: true
+autoDirectNodeRoutes: true
+directRoutingSkipUnreachable: true
+enableIPv4BIGTCP: true
+enableIPv4Masquerade: true
+routingMode: native
+bpf:
+  masquerade: true
+  lbExternalClusterIP: true # https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#external-access-to-clusterip-services
+# Exclude the ConnectX-7 RDMA rail (spark-0 ↔ spark-1) from SNAT so any TCP
+# fallback for NCCL retains real source IPs. RDMA verbs traffic bypasses the
+# kernel entirely, so this is preemptive insurance.
+ipMasqAgent:
+  enabled: true
+  config:
+    nonMasqueradeCIDRs:
+      - 10.0.0.0/8
+      - 192.168.74.0/30
+ipv4:
+  enabled: true
+ipv4NativeRoutingCIDR: 10.0.0.0/8
+bandwidthManager:
+  enabled: true
+  bbr: true
+envoy:
+  enabled: true
+ipam:
+  mode: "cluster-pool"
+  operator:
+    clusterPoolIPv4PodCIDRList:
+      - "10.5.0.0/16"
+    clusterPoolIPv4MaskSize: 24
+prometheus:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    trustCRDsExist: true
+    metricRelabelings:
+      - targetLabel: cluster
+        replacement: ${CLUSTER_NAME}
+operator:
+  rollOutPods: true
+  # 2 replicas with pod anti-affinity so a single node reboot doesn't leave the
+  # cluster without an operator (which is what blocked auto-untaint after spark-1
+  # rebooted under memory pressure — pods on the rebooted node couldn't schedule
+  # because the agent-not-ready taint never got removed).
+  replicas: 2
+  # Make cilium-operator actively strip the `node.cilium.io/agent-not-ready` taint
+  # from any node whose cilium-agent reports Ready. Default in Cilium ≥1.14 but
+  # explicitly required by our chart version (1.18.x). Without this, manual
+  # `kubectl taint nodes ... -` is needed after every node reboot.
+  removeNodeTaints: true
+  setNodeNetworkStatus: true
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      trustCRDsExist: true
+      metricRelabelings:
+        - targetLabel: cluster
+          replacement: ${CLUSTER_NAME}
+rollOutCiliumPods: true
+localRedirectPolicy: true
+bgpControlPlane:
+  enabled: true
+hubble:
+  relay:
+    enabled: true
+  tls:
+    auto:
+      method: certmanager
+      certManagerIssuerRef:
+        group: cert-manager.io
+        kind: ClusterIssuer
+        name: internal
+
+# Talos specific settings
+cgroup:
+  autoMount:
+    enabled: false
+  hostRoot: /sys/fs/cgroup
+k8sServiceHost: localhost
+k8sServicePort: 7445
+securityContext:
+  capabilities:
+    ciliumAgent:
+    - CHOWN
+    - KILL
+    - NET_ADMIN
+    - NET_RAW
+    - IPC_LOCK
+    - SYS_ADMIN
+    - SYS_RESOURCE
+    - DAC_OVERRIDE
+    - FOWNER
+    - SETGID
+    - SETUID
+    cleanCiliumState:
+    - NET_ADMIN
+    - SYS_ADMIN
+    - SYS_RESOURCE

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/bgp.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/bgp.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumBGPClusterConfig
+metadata:
+  name: unifi
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+  bgpInstances:
+    - name: unifi
+      localASN: 64514
+      peers:
+        - name: "udm-1"
+          peerASN: 64515
+          peerAddress: ${LAN_GATEWAY_IP}
+          peerConfigRef:
+            name: cilium-peer
+---
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: cilium-peer
+spec:
+  timers:
+    holdTimeSeconds: 9
+    keepAliveTimeSeconds: 3
+  ebgpMultihop: 4
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 15
+  families:
+    - afi: ipv4
+      safi: unicast
+      advertisements:
+        matchLabels:
+          advertise: bgp
+---
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  name: bgp-advertisements
+  labels:
+    advertise: bgp
+spec:
+  advertisements:
+    - advertisementType: "Service"
+      service:
+        addresses:
+          - ClusterIP
+          - ExternalIP
+          - LoadBalancerIP
+      selector:
+        matchExpressions:
+          - { key: somekey, operator: NotIn, values: ["never-used-value"] }
+    - advertisementType: "PodCIDR"

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/coredns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/coredns.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |-
+    .:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        log . {
+            class error
+        }
+        prometheus :9153
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
+        }
+        forward . /etc/resolv.conf {
+           max_concurrent 1000
+        }
+        cache 30 {
+           disable success cluster.local
+           disable denial cluster.local
+        }
+        loop
+        reload
+        loadbalance
+        header {
+            response set ra
+        }
+    }
+    ts.net {
+      errors
+      cache 30
+      forward . 10.73.69.50
+    }

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - lbippool.yaml
+  - localredirects.yaml
+  - nodelocaldns.yaml
+  - coredns.yaml
+  - bgp.yaml

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/lbippool.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/lbippool.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: "k8s-pool"
+spec:
+  blocks:
+    - cidr: "${CLUSTER_LOAD_BALANCER_CIDR}"
+  serviceSelector:
+    matchExpressions:
+      - { key: somekey, operator: NotIn, values: ["never-used-value"] }

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/localredirects.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/localredirects.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "nodelocaldns"
+  namespace: kube-system
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: kube-dns
+      namespace: kube-system
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        k8s-app: node-local-dns
+    toPorts:
+      - port: "53"
+        name: dns
+        protocol: UDP
+      - port: "53"
+        name: dns-tcp
+        protocol: TCP

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/nodelocaldns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/nodelocaldns.yaml
@@ -1,0 +1,167 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-upstream
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: "KubeDNSUpstream"
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        health
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__UPSTREAM__SERVERS__
+        prometheus :9253
+        }
+    ts.net:53 {
+      errors
+      cache 30
+      reload
+      loop
+      bind 0.0.0.0
+      forward . 10.73.69.50
+      prometheus :9253
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: node-local-dns
+      annotations:
+        policy.cilium.io/no-track-port: "53"
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.26.8
+        resources:
+          requests:
+            cpu: 25m
+            memory: 32Mi
+          limits:
+            memory: 256Mi
+        args: [ "-localip", "169.254.20.10,10.4.0.10", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream", "-skipteardown=true", "-setupinterface=false", "-setupiptables=false" ]
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        - name: kube-dns-config
+          mountPath: /etc/kube-dns
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true
+      - name: config-volume
+        configMap:
+          name: node-local-dns
+          items:
+            - key: Corefile
+              path: Corefile.base

--- a/kubernetes/apps/stpetersburg/kube-system/cilium.yaml
+++ b/kubernetes/apps/stpetersburg/kube-system/cilium.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/cilium-stpetersburg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium-config
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/cilium-stpetersburg/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  dependsOn:
+    - name: cilium
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/kube-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kube-system/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./core-dns.yaml
   - ./csi-secrets-store.yaml
   - ./headlamp.yaml
+  - ./cilium.yaml


### PR DESCRIPTION
Adopt `clusters/talos-stpetersburg/apps/cilium` (app + config) into the `kubernetes/` tree under `cilium-stpetersburg` per-cluster base. Verbatim copy, byte-identical.

Part of #1553.