### PR TITLE
cdn-site: fix cloudflare-proxied annotation (YAML bool -> string)

### DIFF
--- a/kubernetes/apps/ottawa/k8gb/k8gb.yaml
+++ b/kubernetes/apps/ottawa/k8gb/k8gb.yaml
@@ -68,4 +68,3 @@ spec:
       BUCKET: raj-assistant-web
       PUBLIC_HOST: trades.rajsingh.info
       CDN_HOST: trades.cdn.keiretsu.top
-      PROXIED: "true"

--- a/kubernetes/apps/robbinsdale/k8gb/k8gb.yaml
+++ b/kubernetes/apps/robbinsdale/k8gb/k8gb.yaml
@@ -68,4 +68,3 @@ spec:
       BUCKET: raj-assistant-web
       PUBLIC_HOST: trades.rajsingh.info
       CDN_HOST: trades.cdn.keiretsu.top
-      PROXIED: "true"

--- a/kubernetes/apps/stpetersburg/k8gb/k8gb.yaml
+++ b/kubernetes/apps/stpetersburg/k8gb/k8gb.yaml
@@ -68,4 +68,3 @@ spec:
       BUCKET: raj-assistant-web
       PUBLIC_HOST: trades.rajsingh.info
       CDN_HOST: trades.cdn.keiretsu.top
-      PROXIED: "true"

--- a/kubernetes/components/cdn-site/httproute.yaml
+++ b/kubernetes/components/cdn-site/httproute.yaml
@@ -6,9 +6,13 @@ metadata:
   annotations:
     # Publish PUBLIC_HOST -> CDN_HOST via the zone's gateway-watching external-dns.
     # CDN_HOST is the k8gb-delegated GSLB name, so this inherits health-checked,
-    # multi-cluster resolution. PROXIED toggles the Cloudflare edge in front.
+    # multi-cluster resolution. DNS-only (grey) — the GSLB is the health-check /
+    # failover layer; a Cloudflare-proxied edge would be a per-site override.
+    # NB: "false" is a literal (kustomize keeps it quoted as a string). Do not
+    # turn this into a ${VAR}: kustomize strips the quotes and Flux substitution
+    # then yields a YAML boolean, which annotation values reject.
     external-dns.alpha.kubernetes.io/target: "${CDN_HOST}"
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "${PROXIED}"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/components/cdn-site/kustomization.yaml
+++ b/kubernetes/components/cdn-site/kustomization.yaml
@@ -10,7 +10,6 @@
 #     BUCKET:      <garage bucket, e.g. raj-assistant-web>
 #     PUBLIC_HOST: <user-facing host, e.g. trades.rajsingh.info>
 #     CDN_HOST:    <GSLB name under cdn.${COMMON_DOMAIN}, e.g. trades.cdn.keiretsu.top>
-#     PROXIED:     "true" | "false"               # Cloudflare edge in front of GSLB?
 #
 # Generates:
 #   - HTTPRoute on the `public` gateway: matches both CDN_HOST and PUBLIC_HOST,


### PR DESCRIPTION
`cdn-site-trades` failed its dry-run — `cloudflare-proxied: expected string, got true`. kustomize strips the quotes around `"${PROXIED}"`, so Flux substitution yielded a bare `true` (YAML boolean), which annotation values reject. The route never applied and the old route was already removed → **trades.rajsingh.info 404**.

Fix: hardcode `cloudflare-proxied: "false"` (literal, kustomize keeps it quoted) and drop the `PROXIED` var. trades is now grey / GSLB-only (the proven `home.keiretsu.top` path); a Cloudflare-proxied edge can be a clean per-site override later.

Verified: kustomize build keeps the value quoted; rendered+substituted YAML parses `cloudflare-proxied` as a string.