### PR TITLE
flux: enable StrictPostBuildSubstitutions; fix every silent-empty substitution

### DIFF
--- a/clusters/talos-ottawa/flux/config/cluster.yaml
+++ b/clusters/talos-ottawa/flux/config/cluster.yaml
@@ -86,6 +86,9 @@ spec:
       - kind: Secret
         name: cluster-user-secrets
         optional: true
+      - kind: Secret
+        name: garage-keiretsu-bucket
+        optional: true
   patches:
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -113,6 +116,9 @@ spec:
                 optional: true
               - kind: Secret
                 name: cluster-user-secrets
+                optional: true
+              - kind: Secret
+                name: garage-keiretsu-bucket
                 optional: true
       target:
         group: kustomize.toolkit.fluxcd.io

--- a/clusters/talos-robbinsdale/flux/config/cluster.yaml
+++ b/clusters/talos-robbinsdale/flux/config/cluster.yaml
@@ -89,6 +89,9 @@ spec:
       - kind: Secret
         name: cluster-user-secrets
         optional: true
+      - kind: Secret
+        name: garage-keiretsu-bucket
+        optional: true
   patches:
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -116,6 +119,9 @@ spec:
                 optional: true
               - kind: Secret
                 name: cluster-user-secrets
+                optional: true
+              - kind: Secret
+                name: garage-keiretsu-bucket
                 optional: true
       target:
         group: kustomize.toolkit.fluxcd.io

--- a/clusters/talos-stpetersburg/flux/config/cluster.yaml
+++ b/clusters/talos-stpetersburg/flux/config/cluster.yaml
@@ -89,6 +89,9 @@ spec:
       - kind: Secret
         name: cluster-user-secrets
         optional: true
+      - kind: Secret
+        name: garage-keiretsu-bucket
+        optional: true
   patches:
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -116,6 +119,9 @@ spec:
                 optional: true
               - kind: Secret
                 name: cluster-user-secrets
+                optional: true
+              - kind: Secret
+                name: garage-keiretsu-bucket
                 optional: true
       target:
         group: kustomize.toolkit.fluxcd.io

--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -46,22 +46,22 @@ data:
     echo "[download] Starting model download with hf CLI…"
     hf download "$HF_REPO" --local-dir "$MODEL_DIR" 2>&1
 
-    echo "[validate] Checking for ${EXPECTED} shards…"
+    echo "[validate] Checking for $${EXPECTED} shards…"
     COUNT="$(find . -name '*.safetensors' | wc -l)"
-    echo "[validate] Found ${COUNT} shard(s)"
+    echo "[validate] Found $${COUNT} shard(s)"
 
     if [ "$COUNT" -lt "$EXPECTED" ]; then
-      echo "[ERROR] Expected ${EXPECTED} shards, got ${COUNT}. Redownloading…"
+      echo "[ERROR] Expected $${EXPECTED} shards, got $${COUNT}. Redownloading…"
       rm -rf "$MODEL_DIR"/*
       hf download "$HF_REPO" --local-dir "$MODEL_DIR" 2>&1
       COUNT="$(find . -name '*.safetensors' | wc -l)"
       if [ "$COUNT" -lt "$EXPECTED" ]; then
-        echo "[FATAL] Still only ${COUNT} shards after retry. Aborting."
+        echo "[FATAL] Still only $${COUNT} shards after retry. Aborting."
         exit 1
       fi
     fi
 
-    echo "[validate] Shard validation OK (${COUNT}/${EXPECTED})"
+    echo "[validate] Shard validation OK ($${COUNT}/$${EXPECTED})"
     echo "[download] Done."
 ---
 apiVersion: v1

--- a/kubernetes/apps/base/flux-system/flux-system-common/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/flux-system-common/flux-instance/app/helmrelease.yaml
@@ -29,6 +29,15 @@ spec:
         size: medium
       kustomize:
         patches:
+          # undefined ${VAR} in postBuild-substituted manifests is an error
+          # instead of a silent empty string (phase 5; repo audited first)
+          - patch: |-
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --feature-gates=StrictPostBuildSubstitutions=true
+            target:
+              kind: Deployment
+              name: kustomize-controller
           # size: medium sets memory=1Gi; bump to 2Gi to match current config
           - patch: |-
               apiVersion: apps/v1

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
       external-endpoints:
         - name: Heartbeat
           group: Alertmanager
-          url: "${GATUS_HEARTBEAT_URL}"
+          url: "${GATUS_HEARTBEAT_URL:-}"
           token: "${GATUS_HEARTBEAT_TOKEN}"
           heartbeat:
             interval: 5m

--- a/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/gpu-metrics.yaml
+++ b/kubernetes/apps/base/gpu-operator/gpu-operator-stpetersburg/app/gpu-metrics.yaml
@@ -87,7 +87,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The official product name of the GPU. This is an alphanumeric string. For all products.",
           "fieldConfig": {
@@ -140,7 +140,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_gpu_info{uuid=\"$gpu\"}",
@@ -156,7 +156,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The current performance state for the GPU. States range from P0 (maximum performance) to P12 (minimum performance).",
           "fieldConfig": {
@@ -218,7 +218,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_pstate{uuid=\"$gpu\"}",
@@ -233,7 +233,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Percent of time over the past sample period during which one or more kernels was executing on the GPU.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
           "fieldConfig": {
@@ -293,7 +293,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_utilization_gpu_ratio{uuid=\"$gpu\"}",
@@ -308,7 +308,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The last measured power draw for the entire board, in watts. Only available if power management is supported. This reading is accurate to within +/- 5 watts / The software power limit in watts.",
           "fieldConfig": {
@@ -368,7 +368,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_power_draw_watts{uuid=\"$gpu\"} / nvidia_smi_power_default_limit_watts{uuid=\"$gpu\"}",
@@ -383,7 +383,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The fan speed value is the percent of the product's maximum noise tolerance fan speed that the device's fan is currently intended to run at. This value may exceed 100% in certain cases. Note: The reported speed is the intended fan speed. If the fan is physically blocked and unable to spin, this output will not match the actual fan speed. Many parts do not report fan speeds because they rely on cooling via fans in the surrounding enclosure.\n",
           "fieldConfig": {
@@ -443,7 +443,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_fan_speed_ratio{uuid=\"$gpu\"}",
@@ -458,7 +458,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Core GPU temperature. in degrees C.",
           "fieldConfig": {
@@ -518,7 +518,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_temperature_gpu{uuid=\"$gpu\"}",
@@ -533,7 +533,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Percent of time over the past sample period during which global (device) memory was being read or written.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
           "fieldConfig": {
@@ -621,7 +621,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_utilization_memory_ratio{uuid=\"$gpu\"}",
@@ -636,7 +636,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The version of the installed NVIDIA display driver. This is an alphanumeric string.",
           "fieldConfig": {
@@ -689,7 +689,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_gpu_info{uuid=\"$gpu\"}",
@@ -705,7 +705,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The BIOS of the GPU board.",
           "fieldConfig": {
@@ -758,7 +758,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_gpu_info{uuid=\"$gpu\"}",
@@ -774,7 +774,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Information about factors that are reducing the frequency of clocks. If all throttle reasons are returned as \"Not Active\" it means that clocks are running as high as possible.",
           "fieldConfig": {
@@ -840,7 +840,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_throttle_reasons_gpu_idle{uuid=\"$gpu\"}",
@@ -852,7 +852,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown{uuid=\"$gpu\"}",
@@ -864,7 +864,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_throttle_reasons_sw_power_cap{uuid=\"$gpu\"}",
@@ -876,7 +876,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_throttle_reasons_applications_clocks_setting{uuid=\"$gpu\"}",
@@ -888,7 +888,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown{uuid=\"$gpu\"}",
@@ -900,7 +900,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown{uuid=\"$gpu\"}",
@@ -912,7 +912,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_throttle_reasons_sync_boost{uuid=\"$gpu\"}",
@@ -928,7 +928,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Current frequency of graphics (shader) clock\n/\nMaximum frequency of graphics (shader) clock.\n",
           "fieldConfig": {
@@ -988,7 +988,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_current_graphics_clock_hz{uuid=\"$gpu\"} / nvidia_smi_clocks_max_graphics_clock_hz{uuid=\"$gpu\"}",
@@ -1003,7 +1003,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Current frequency of memory clock / Maximum frequency of memory clock",
           "fieldConfig": {
@@ -1063,7 +1063,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_current_memory_clock_hz{uuid=\"$gpu\"} / nvidia_smi_clocks_max_memory_clock_hz{uuid=\"$gpu\"}",
@@ -1078,7 +1078,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Total memory allocated by active contexts / Total installed GPU memory.",
           "fieldConfig": {
@@ -1138,7 +1138,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_memory_used_bytes{uuid=\"$gpu\"} / nvidia_smi_memory_total_bytes{uuid=\"$gpu\"}",
@@ -1153,7 +1153,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Percent of time over the past sample period during which global (device) memory was being read or written.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
           "fieldConfig": {
@@ -1213,7 +1213,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_utilization_memory_ratio{uuid=\"$gpu\"}",
@@ -1228,7 +1228,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Percent of time over the past sample period during which one or more kernels was executing on the GPU.\nThe sample period may be between 1 second and 1/6 second depending on the product.",
           "fieldConfig": {
@@ -1316,7 +1316,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_utilization_gpu_ratio{uuid=\"$gpu\"}",
@@ -1331,7 +1331,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Total memory allocated by active contexts.",
           "fieldConfig": {
@@ -1414,7 +1414,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_memory_used_bytes{uuid=\"$gpu\"}",
@@ -1429,7 +1429,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Core GPU temperature. in degrees C.",
           "fieldConfig": {
@@ -1517,7 +1517,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_temperature_gpu{uuid=\"$gpu\"}",
@@ -1532,7 +1532,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The last measured power draw for the entire board, in watts. Only available if power management is supported. This reading is accurate to within +/- 5 watts",
           "fieldConfig": {
@@ -1615,7 +1615,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_power_draw_watts{uuid=\"$gpu\"}",
@@ -1630,7 +1630,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "The fan speed value is the percent of the product's maximum noise tolerance fan speed that the device's fan is currently intended to run at. This value may exceed 100% in certain cases. Note: The reported speed is the intended fan speed. If the fan is physically blocked and unable to spin, this output will not match the actual fan speed. Many parts do not report fan speeds because they rely on cooling via fans in the surrounding enclosure.\n",
           "fieldConfig": {
@@ -1718,7 +1718,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_fan_speed_ratio{uuid=\"$gpu\"}",
@@ -1733,7 +1733,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Current frequency of graphics (shader) clock.",
           "fieldConfig": {
@@ -1816,7 +1816,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_current_graphics_clock_hz{uuid=\"$gpu\"}",
@@ -1832,7 +1832,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Current frequency of video encoder/decoder clock.",
           "fieldConfig": {
@@ -1915,7 +1915,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_current_video_clock_hz{uuid=\"$gpu\"}",
@@ -1931,7 +1931,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Current frequency of SM (Streaming Multiprocessor) clock.",
           "fieldConfig": {
@@ -2014,7 +2014,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_current_sm_clock_hz{uuid=\"$gpu\"}",
@@ -2030,7 +2030,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "description": "Current frequency of memory clock.",
           "fieldConfig": {
@@ -2113,7 +2113,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "nvidia_smi_clocks_current_memory_clock_hz{uuid=\"$gpu\"}",
@@ -2141,7 +2141,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "$${DS_PROMETHEUS}"
             },
             "definition": "label_values(nvidia_smi_index, uuid)",
             "hide": 0,

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/k6/tailscale-paths.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/k6/tailscale-paths.yaml
@@ -32,7 +32,7 @@ spec:
           {
             "name": "cluster_src",
             "type": "query",
-            "datasource": { "type": "prometheus", "uid": "${datasource}" },
+            "datasource": { "type": "prometheus", "uid": "$${datasource}" },
             "query": "label_values(k6_http_reqs_total, cluster_src)",
             "refresh": 2,
             "includeAll": true,
@@ -41,7 +41,7 @@ spec:
           {
             "name": "cluster_dst",
             "type": "query",
-            "datasource": { "type": "prometheus", "uid": "${datasource}" },
+            "datasource": { "type": "prometheus", "uid": "$${datasource}" },
             "query": "label_values(k6_http_reqs_total, cluster_dst)",
             "refresh": 2,
             "includeAll": true,
@@ -54,7 +54,7 @@ spec:
           "id": 1,
           "title": "P95 latency by transport",
           "type": "timeseries",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
           "targets": [
             {
@@ -69,7 +69,7 @@ spec:
           "id": 2,
           "title": "P99 latency by transport",
           "type": "timeseries",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "gridPos": { "x": 0, "y": 8, "w": 24, "h": 8 },
           "targets": [
             {
@@ -84,7 +84,7 @@ spec:
           "id": 3,
           "title": "Throughput (received bytes/sec)",
           "type": "timeseries",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
           "targets": [
             {
@@ -99,7 +99,7 @@ spec:
           "id": 4,
           "title": "Connection establishment time (P95)",
           "type": "timeseries",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
           "targets": [
             {
@@ -119,7 +119,7 @@ spec:
           "id": 5,
           "title": "Error rate by transport",
           "type": "timeseries",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "gridPos": { "x": 0, "y": 24, "w": 24, "h": 6 },
           "targets": [
             {

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/statefulset.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/derper/statefulset.yaml
@@ -58,7 +58,7 @@ spec:
           protocol: UDP
         volumeMounts:
         - name: certs
-          mountPath: /root/derper/${TS_DERP_HOSTNAME}
+          mountPath: /root/derper/${TS_DERP_HOSTNAME:-}
         - name: tailscale-state
           mountPath: /var/lib/tailscale
       volumes:

--- a/kubernetes/apps/base/tailscale/resources/tailnet.yaml
+++ b/kubernetes/apps/base/tailscale/resources/tailnet.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: tailscale
 type: Opaque
 stringData:
-  client_id: ${TSJUSTWORKS_TS_OAUTH_CLIENT_ID}
-  client_secret: ${TSJUSTWORKS_TS_OAUTH_CLIENT_SECRET}
+  client_id: ${TSJUSTWORKS_TS_OAUTH_CLIENT_ID:-}
+  client_secret: ${TSJUSTWORKS_TS_OAUTH_CLIENT_SECRET:-}
 ---
 apiVersion: tailscale.com/v1alpha1
 kind: Tailnet


### PR DESCRIPTION
audit found 15 undefined-var names: restored grafana dashboard templating
and dsv4 script vars that envsubst was silently eating (escape to $$),
gave explicit empty defaults to the live-only sandbox vars (tsjustworks
tailnet, derper hostname, gatus heartbeat), and re-added the
garage-keiretsu-bucket secret to kubernetes-apps substituteFrom on all
clusters — the migration had dropped it, rendering empty s3 backup creds
