### PR TITLE
trades: stabilize DNS (ottawa-only + restore force-default-targets)

### DIFF
--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-rajsingh-info.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-rajsingh-info.yaml
@@ -33,18 +33,17 @@ spec:
             key: RAJSINGH_INFO_CLOUDFLARE_API_TOKEN
     extraArgs:
       - --gateway-label-filter=gateway==public
-      # The public gateway's default target is ${LOCATION}.keiretsu.top — a
-      # different Cloudflare account, so an un-annotated rajsingh.info route would
-      # CNAME cross-account and hit Error 1014. --default-targets is the
-      # same-account fallback, but NOTE it only applies when neither the route nor
-      # the gateway provides a target; the gateway annotation outranks it. So every
-      # public rajsingh.info HTTPRoute MUST carry its own
-      # external-dns.alpha.kubernetes.io/target:
-      #   - single-site site → ${LOCATION}.rajsingh.info
-      #   - cdn-site (GSLB)  → <name>.cdn.keiretsu.top   (see components/cdn-site)
-      # We do NOT use --force-default-targets: it would clobber those per-route
-      # targets and break GSLB fronting.
+      # The public gateway's target annotation is ${LOCATION}.${CLUSTER_DOMAIN}
+      # (a non-rajsingh.info zone), and external-dns's gateway-httproute source
+      # honors the GATEWAY target over any per-route target annotation. Force the
+      # same-account default so every rajsingh.info public route resolves to
+      # ${LOCATION}.rajsingh.info instead of a cross-zone CNAME.
+      # NOTE: this means per-route external-dns targets (incl. cdn-site's GSLB
+      # CNAME) do NOT take effect for rajsingh.info — GSLB-fronting a
+      # rajsingh.info host needs a DNSEndpoint published by a CRD-source
+      # external-dns (the keiretsu.top pattern), not a gateway route.
       - --default-targets=${LOCATION}.rajsingh.info
+      - --force-default-targets
     policy: sync
     sources:
       - gateway-httproute

--- a/kubernetes/apps/robbinsdale/k8gb/k8gb.yaml
+++ b/kubernetes/apps/robbinsdale/k8gb/k8gb.yaml
@@ -40,31 +40,3 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app cdn-site-trades
-  namespace: flux-system
-spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  dependsOn:
-    - name: garage
-    - name: k8gb-app
-  path: ./kubernetes/apps/base/k8gb/k8gb-common/trades
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: kubernetes-manifests
-  wait: false
-  interval: 30m
-  retryInterval: 1m
-  timeout: 5m
-  postBuild:
-    substitute:
-      SITE: trades
-      BUCKET: raj-assistant-web
-      PUBLIC_HOST: trades.rajsingh.info
-      CDN_HOST: trades.cdn.keiretsu.top

--- a/kubernetes/apps/stpetersburg/k8gb/k8gb.yaml
+++ b/kubernetes/apps/stpetersburg/k8gb/k8gb.yaml
@@ -40,31 +40,3 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app cdn-site-trades
-  namespace: flux-system
-spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  dependsOn:
-    - name: garage
-    - name: k8gb-app
-  path: ./kubernetes/apps/base/k8gb/k8gb-common/trades
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: kubernetes-manifests
-  wait: false
-  interval: 30m
-  retryInterval: 1m
-  timeout: 5m
-  postBuild:
-    substitute:
-      SITE: trades
-      BUCKET: raj-assistant-web
-      PUBLIC_HOST: trades.rajsingh.info
-      CDN_HOST: trades.cdn.keiretsu.top


### PR DESCRIPTION
The cdn-site **route-annotation GSLB target doesn't work for rajsingh.info**: external-dns's gateway-httproute source honors the public gateway's per-cluster `target` annotation (`${LOCATION}.${CLUSTER_DOMAIN}`) over the per-route target. Running the trades route on all 3 clusters flapped `trades.rajsingh.info` across each cluster's target (ottawa.killinit.cc / robbinsdale.lukehouge.com / …) → intermittently NXDOMAIN.

Stabilize: restore `--force-default-targets` (clean `${LOCATION}.rajsingh.info`) and scope `cdn-site-trades` to **ottawa only** (single stable writer). trades serves again.

True GSLB-fronting of a rajsingh.info host needs a `DNSEndpoint` published by a CRD-source external-dns (the keiretsu.top `cnames.yaml` pattern), since no gateway-source external-dns can be made to emit the GSLB CNAME for a zone it owns. That's a follow-up.