### PR TITLE
gatus: drop dead Heartbeat external-endpoint

### DIFF
--- a/kubernetes/apps/base/gatus/gatus-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-ottawa/app/helmrelease.yaml
@@ -41,16 +41,6 @@ spec:
             link: "https://github.com/keiretsu-labs/kubernetes-manifests"
           # - name: "Portfolio"
           #   link: "https://www.${CLUSTER_DOMAIN}"
-      external-endpoints:
-        - name: Heartbeat
-          group: Alertmanager
-          token: "${GATUS_HEARTBEAT_TOKEN}"
-          heartbeat:
-            interval: 5m
-          alerts:
-            - type: discord
-              send-on-resolved: true
-
       endpoints:
         # === Network ===
         - name: Internet

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
@@ -46,17 +46,6 @@ spec:
             link: "https://github.com/keiretsu-labs/kubernetes-manifests"
           - name: "Portfolio"
             link: "https://www.rajsingh.info"
-      external-endpoints:
-        - name: Heartbeat
-          group: Alertmanager
-          url: "${GATUS_HEARTBEAT_URL:-}"
-          token: "${GATUS_HEARTBEAT_TOKEN}"
-          heartbeat:
-            interval: 5m
-          alerts:
-            - type: discord
-              send-on-resolved: true
-
       endpoints:
         - name: Kubernetes API
           group: kubernetes

--- a/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
@@ -44,15 +44,6 @@ spec:
         title: "K8s St. Petersburg Status"
         description: "GitOps-managed Kubernetes cluster monitoring"
         header: "K8s-StPetersburg Infrastructure Dashboard"
-      external-endpoints:
-        - name: Heartbeat
-          group: Alertmanager
-          token: "${GATUS_HEARTBEAT_TOKEN}"
-          heartbeat:
-            interval: 5m
-          alerts:
-            - type: discord
-              send-on-resolved: true
       endpoints:
         - name: Kubernetes API
           group: kubernetes


### PR DESCRIPTION
Removes the non-functional `Heartbeat` external-endpoint from all three gatus instances (gatus, gatus-ottawa, gatus-robbinsdale).

It never worked: `GATUS_HEARTBEAT_URL` is only an alertmanager sops secret key, not a Flux postBuild substitution var, so `url: "${GATUS_HEARTBEAT_URL:-}"` rendered empty (gatus + gatus-ottawa didn't even have a `url` line). The external-endpoint had no real target.

Scope kept tight per request:
- **Not touched:** alertmanager's `gatus-heartbeat` receiver/route and the `GATUS_HEARTBEAT_URL`/`GATUS_HEARTBEAT_TOKEN` secret keys. `GATUS_HEARTBEAT_TOKEN` is now an orphaned (harmless) secret.
- **Left as-is:** `garage-keiretsu-bucket` in the cluster postBuild `substituteFrom` — it is **live**, feeding `KEIRETSU_S3_ACCESS_KEY`/`KEIRETSU_S3_SECRET_KEY` to the immich + media/jellystat CNPG/Barman S3 backups (the regression #1648 fixed). Removing it would re-break those backups.