### PR TITLE
egress: ssa merge on all tailscale egress services (self-heal silent freeze)

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/egress.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: stpetersburg-vllm
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-vllm.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/agents/agents/app/egress.yaml
+++ b/kubernetes/apps/base/agents/agents/app/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: ai
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ai.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: aperture
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: aperture.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/clickhouse/clickhouse/egress.yaml
+++ b/kubernetes/apps/base/clickhouse/clickhouse/egress.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: clickhouse.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: clickhouse-global
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-clickhouse.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: ottawa-clickhouse
@@ -43,7 +43,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-clickhouse.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: robbinsdale-clickhouse
@@ -65,7 +65,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-clickhouse.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: stpetersburg-clickhouse

--- a/kubernetes/apps/base/default/default-common/goldpinger/tailsclale-egress.yaml
+++ b/kubernetes/apps/base/default/default-common/goldpinger/tailsclale-egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: goldpinger-ottawa
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: goldpinger-ottawa.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: goldpinger-robbinsdale
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: goldpinger-robbinsdale.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/garage/garage/egress.yaml
+++ b/kubernetes/apps/base/garage/garage/egress.yaml
@@ -1,9 +1,16 @@
+# ssa: merge (not IfNotPresent) on every egress entry. The tailscale operator
+# owns spec.externalName via a separate field manager, so Flux's merge SSA does
+# not reset it (verified: kustomize-controller never owns externalName). merge
+# keeps the rest of the spec self-healing — under IfNotPresent the per-pod
+# gateway egress (*-gw-N) silently froze and a common-egress restart that raced
+# ahead of common-ingress left the gateway egress routes dead for ~2.4 days
+# (cross-region gateway RPC mesh down) with no gitops self-correction.
 ---
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: garage-gw.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: garage-global
@@ -19,7 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-garage.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: ottawa-garage
@@ -44,7 +51,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-garage.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: robbinsdale-garage
@@ -69,7 +76,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-garage.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: stpetersburg-garage
@@ -96,7 +103,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-garage-gw.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: ottawa-garage-gw
@@ -112,7 +119,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-garage-gw.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: robbinsdale-garage-gw
@@ -128,7 +135,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-garage-gw.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: stpetersburg-garage-gw
@@ -150,7 +157,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-gw-0.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: ottawa-gw-0
@@ -166,7 +173,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-gw-1.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: ottawa-gw-1
@@ -182,7 +189,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-gw-0.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: robbinsdale-gw-0
@@ -198,7 +205,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-gw-1.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: robbinsdale-gw-1
@@ -214,7 +221,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-gw-0.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: stpetersburg-gw-0
@@ -230,7 +237,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-gw-1.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: stpetersburg-gw-1

--- a/kubernetes/apps/base/hermes/hermes/app/egress.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: stpetersburg-vllm
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-vllm.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: aperture
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: aperture.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -36,7 +36,7 @@ kind: Service
 metadata:
   name: searxng
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-searxng.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/home/home/tailscale-gateway/egress.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: robbinsdale-envoy-gateway 
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-home-envoy-gateway.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -26,7 +26,7 @@ kind: Service
 metadata:
   name: ottawa-envoy-gateway
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-home-envoy-gateway.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/egress.yaml
+++ b/kubernetes/apps/base/jellyswarrm/jellyswarrm/app/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: robbinsdale-jellyfin
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-jellyfin.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: ottawa-jellyfin
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-jellyfin.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/kube-system/cilium-ottawa/app/clustermesh-egress.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/app/clustermesh-egress.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: robbinsdale

--- a/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/clustermesh-egress.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/clustermesh-egress.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: ottawa

--- a/kubernetes/apps/base/loki/loki/app/egress.yaml
+++ b/kubernetes/apps/base/loki/loki/app/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: loki-gateway
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: loki.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/egress.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: mimir-gateway
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: mimir.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/mimir/mimir/app/egress.yaml
+++ b/kubernetes/apps/base/mimir/mimir/app/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: mimir-gateway
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: mimir.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -23,7 +23,7 @@ metadata:
   annotations:
     tailscale.com/tailnet-fqdn: mimir-qf.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
 spec:
   type: ExternalName
   externalName: placeholder

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/egress.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/hello/egress.yaml
@@ -7,7 +7,7 @@ metadata:
     # IfNotPresent: Flux creates the Service once with placeholder externalName,
     # then never re-applies. The Tailscale operator owns spec.externalName
     # exclusively. See SSA-field-conflict notes.
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-tailscale-examples-hello-world-service.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -23,7 +23,7 @@ kind: Service
 metadata:
   name: hello-world-ottawa
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-tailscale-examples-hello-world-service.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -39,7 +39,7 @@ kind: Service
 metadata:
   name: hello-world-stpetersburg
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-tailscale-examples-hello-world-service.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/egress.yaml
+++ b/kubernetes/apps/base/tailscale-examples/tailscale-examples-sandbox/tsidp/egress.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-idp.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: ottawa-idp-egress
@@ -19,7 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-idp.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
   name: robbinsdale-idp-egress

--- a/kubernetes/apps/base/tailscale/resources/egress.yaml
+++ b/kubernetes/apps/base/tailscale/resources/egress.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: robbinsdale-k8s-operator
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-k8s-operator.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: ottawa-k8s-operator
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-k8s-operator.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -36,7 +36,7 @@ kind: Service
 metadata:
   name: stpetersburg-k8s-operator
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-k8s-operator.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -52,7 +52,7 @@ kind: Service
 metadata:
   name: kubernetes-ottawa
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: kubernetes-ottawa.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -70,7 +70,7 @@ kind: Service
 metadata:
   name: ocm-grpc-hub
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ocm-grpc-hub.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -86,7 +86,7 @@ kind: Service
 metadata:
   name: robbinsdale-smb
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-ip: "192.168.50.115"
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/zot/zot-cache-egress/app/egress.yaml
+++ b/kubernetes/apps/base/zot/zot-cache-egress/app/egress.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: zot-cache
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: zot-cache.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:

--- a/kubernetes/apps/base/zot/zot/egress.yaml
+++ b/kubernetes/apps/base/zot/zot/egress.yaml
@@ -10,7 +10,7 @@ kind: Service
 metadata:
   name: robbinsdale-zot
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: robbinsdale-zot.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -26,7 +26,7 @@ kind: Service
 metadata:
   name: ottawa-zot
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: ottawa-zot.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:
@@ -42,7 +42,7 @@ kind: Service
 metadata:
   name: stpetersburg-zot
   annotations:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    kustomize.toolkit.fluxcd.io/ssa: merge
     tailscale.com/tailnet-fqdn: stpetersburg-zot.keiretsu.ts.net
     tailscale.com/proxy-group: common-egress
 spec:


### PR DESCRIPTION
## What

Switch every Tailscale egress entry in `garage/egress.yaml` from
`kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` to `ssa: merge`.

## Why

The per-pod gateway egress services (`*-gw-N`) and per-region gateway egress
(`*-garage-gw`) were `IfNotPresent`, which makes Flux create them once and never
reconcile again. When the `common-egress` ProxyGroup restarted ~2h ahead of
`common-ingress` (so the `*-gw-N` ingress devices didn't exist yet), the egress
proxies cached empty routes for the gateway FQDNs and never recovered. Result:
the cross-region gateway↔gateway RPC mesh was down for ~2.4 days — ottawa and
stpetersburg saw 14/18 nodes connected, with `addr=None` on the 4 remote
gateway nodes. Storage federation was unaffected (storage egress was already
effectively `merge`), so quorum and the key/bucket tables stayed consistent and
there was no S3 outage — but gateway redundancy was silently degraded with no
gitops self-correction.

Recovered by rolling-restarting `common-egress` in ottawa + stpetersburg (all
three regions are back to 18/18). This PR makes the config self-healing so it
can't silently freeze again.

## Safety

`merge` does not let Flux clobber the operator-set `spec.externalName`:
`kubectl get svc ... --show-managed-fields` confirms `kustomize-controller`
never owns `externalName` (the tailscale `operator` field manager does), on both
the already-`merge` storage entries and the `IfNotPresent` gateway entries.
Flux merge SSA yields on that field. The storage `*-garage` entries already run
`merge` live and have been stable, so this aligns the gateway entries to a
proven pattern.

Does not address the underlying restart-ordering fragility (egress proxy not
re-resolving when its target ingress device appears later) — tracked separately.
