### PR TITLE
agents: expose teaspoon dashboard at raj.hermes.keiretsu.top behind Tinyauth auth

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/abtar/httproute-hermes-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/httproute-hermes-web.yaml
@@ -1,11 +1,10 @@
 ---
-# Hermes dashboard at raj.hermes.keiretsu.top — Tinyauth-gated via
-# SecurityPolicy extAuth. Routes to the teaspoon dashboard (port 9119)
-# through the public + private gateways.
+# Hermes dashboard at abtar.hermes.keiretsu.top — Tinyauth-gated
+# via the shared hermes-auth securitypolicy.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: teaspoon-hermes-web
+  name: abtar-hermes-web
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
@@ -17,12 +16,12 @@ spec:
       name: private
       namespace: home
   hostnames:
-    - "teaspoon.hermes.${COMMON_DOMAIN}"
+    - "abtar.hermes.${COMMON_DOMAIN}"
   rules:
     - backendRefs:
         - group: ""
           kind: Service
-          name: teaspoon
+          name: abtar
           port: 9119
           weight: 1
       matches:

--- a/kubernetes/apps/base/agents/agents/app/abtar/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/abtar/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - garagekey.yaml
   - configmap.yaml
   - secret.yaml
+  - httproute-hermes-web.yaml

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-hermes-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-hermes-web.yaml
@@ -1,11 +1,10 @@
 ---
-# Hermes dashboard at raj.hermes.keiretsu.top — Tinyauth-gated via
-# SecurityPolicy extAuth. Routes to the teaspoon dashboard (port 9119)
-# through the public + private gateways.
+# Hermes dashboard at assistant-raj.hermes.keiretsu.top — Tinyauth-gated
+# via the shared hermes-auth securitypolicy.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: teaspoon-hermes-web
+  name: assistant-raj-hermes-web
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
@@ -17,12 +16,12 @@ spec:
       name: private
       namespace: home
   hostnames:
-    - "teaspoon.hermes.${COMMON_DOMAIN}"
+    - "assistant-raj.hermes.${COMMON_DOMAIN}"
   rules:
     - backendRefs:
         - group: ""
           kind: Service
-          name: teaspoon
+          name: assistant-raj
           port: 9119
           weight: 1
       matches:

--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - garagekey-web.yaml
   - bucket.yaml
   - httproute-web.yaml
+  - httproute-hermes-web.yaml
   - securitypolicy-web.yaml
   - oidc-secret.yaml
   - egress.yaml

--- a/kubernetes/apps/base/agents/agents/app/hermes-auth-securitypolicy.yaml
+++ b/kubernetes/apps/base/agents/agents/app/hermes-auth-securitypolicy.yaml
@@ -1,19 +1,24 @@
 ---
-# extAuth via Tinyauth for raj.hermes.keiretsu.top — Google OAuth gated
-# to rajsinghcpre@gmail.com (the global whitelist on the tinyauth ConfigMap).
-# Tinyauth's envoy mode reads the original host from the check request's own
-# authority, the original path from ?path=, and requires cookie +
-# x-forwarded-proto to be forwarded. On deny, envoy passes tinyauth's
-# 302/Set-Cookie through to the browser.
+# Shared Tinyauth extAuth for all *.hermes.keiretsu.top agent dashboards.
+# Uses the global tinyauth config (Google OAuth, whitelist: rajsinghcpre@gmail.com).
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: teaspoon-hermes-web-auth
+  name: hermes-auth
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: teaspoon-hermes-web
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: assistant-raj-hermes-web
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kartik-hermes-web
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: abtar-hermes-web
   extAuth:
     headersToExtAuth:
       - cookie

--- a/kubernetes/apps/base/agents/agents/app/kartik/httproute-hermes-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/httproute-hermes-web.yaml
@@ -1,11 +1,10 @@
 ---
-# Hermes dashboard at raj.hermes.keiretsu.top — Tinyauth-gated via
-# SecurityPolicy extAuth. Routes to the teaspoon dashboard (port 9119)
-# through the public + private gateways.
+# Hermes dashboard at kartik.hermes.keiretsu.top — Tinyauth-gated
+# via the shared hermes-auth securitypolicy.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: teaspoon-hermes-web
+  name: kartik-hermes-web
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
@@ -17,12 +16,12 @@ spec:
       name: private
       namespace: home
   hostnames:
-    - "teaspoon.hermes.${COMMON_DOMAIN}"
+    - "kartik.hermes.${COMMON_DOMAIN}"
   rules:
     - backendRefs:
         - group: ""
           kind: Service
-          name: teaspoon
+          name: kartik
           port: 9119
           weight: 1
       matches:

--- a/kubernetes/apps/base/agents/agents/app/kartik/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kartik/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - garagekey.yaml
   - configmap.yaml
   - secret.yaml
+  - httproute-hermes-web.yaml

--- a/kubernetes/apps/base/agents/agents/app/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - kartik
   - teaspoon
   - camofox
+  - hermes-auth-securitypolicy.yaml
 # NOTE: hermes groups (groups/<name>) are NOT listed here. Each is reconciled by
 # its own Flux Kustomization (ks-<name>.yaml) so tenants build independently —
 # no shared kustomize accumulation (group-meta would collide) and one group's

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/httproute-hermes-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/httproute-hermes-web.yaml
@@ -1,0 +1,31 @@
+---
+# Hermes dashboard at raj.hermes.keiretsu.top — Tinyauth-gated via
+# SecurityPolicy extAuth. Routes to the teaspoon dashboard (port 9119)
+# through the public + private gateways.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: teaspoon-hermes-web
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "raj.hermes.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: teaspoon
+          port: 9119
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
   - httproute-web.yaml
   - httproute-hermes-web.yaml
   - securitypolicy.yaml
-  - securitypolicy-hermes-web.yaml
   - oidc-secret.yaml
   - storagestack.yaml
   - garagekey.yaml

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/kustomization.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/kustomization.yaml
@@ -5,11 +5,12 @@ namespace: agents
 resources:
   - deployment.yaml
   - service.yaml
-  - service-tailscale.yaml
   # egress.yaml removed — aperture consolidated to agents/app/egress.yaml
   - httproute.yaml
   - httproute-web.yaml
+  - httproute-hermes-web.yaml
   - securitypolicy.yaml
+  - securitypolicy-hermes-web.yaml
   - oidc-secret.yaml
   - storagestack.yaml
   - garagekey.yaml

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/securitypolicy-hermes-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/securitypolicy-hermes-web.yaml
@@ -1,0 +1,33 @@
+---
+# extAuth via Tinyauth for raj.hermes.keiretsu.top — Google OAuth gated
+# to rajsinghcpre@gmail.com (the global whitelist on the tinyauth ConfigMap).
+# Tinyauth's envoy mode reads the original host from the check request's own
+# authority, the original path from ?path=, and requires cookie +
+# x-forwarded-proto to be forwarded. On deny, envoy passes tinyauth's
+# 302/Set-Cookie through to the browser.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: teaspoon-hermes-web-auth
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: teaspoon-hermes-web
+  extAuth:
+    headersToExtAuth:
+      - cookie
+      - x-forwarded-proto
+      - x-forwarded-for
+      - user-agent
+    http:
+      backendRefs:
+        - name: tinyauth
+          namespace: tinyauth
+          port: 3000
+      path: "/api/auth/envoy?path="
+      headersToBackend:
+        - remote-user
+        - remote-email
+        - remote-name
+        - remote-groups

--- a/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
@@ -9,6 +9,9 @@ spec:
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: authtest
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: agents
   to:
     - group: ""
       kind: Service

--- a/kubernetes/apps/base/home/home/local-gateway/gateway-private.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/gateway-private.yaml
@@ -80,6 +80,19 @@ spec:
         - group: ''
           kind: Secret
           name: wildcard-keiretsu-top
+    - name: wildcard-hermes-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.hermes.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-${COMMON_DOMAIN//./-}
     - name: forgejo-ssh
       protocol: TCP
       port: 22

--- a/kubernetes/apps/base/home/home/local-gateway/gateway-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/gateway-public.yaml
@@ -94,6 +94,19 @@ spec:
         - group: ''
           kind: Secret
           name: wildcard-agents-${COMMON_DOMAIN//./-}
+    - name: wildcard-hermes-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.hermes.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-${COMMON_DOMAIN//./-}
     - name: wildcard-cdn-keiretsu-top-https
       protocol: HTTPS
       port: 443


### PR DESCRIPTION
## Summary

Changes how **teaspoon** (the Hermes Agent running as my Discord persona) is exposed:

### What changed

1. **Disabled Tailscale LB exposure** — removed `service-tailscale.yaml` from the teaspoon kustomization. The `teaspoon-ts` LoadBalancer (Tailscale DNS `teaspoon.keiretsu.ts.net`) is no longer deployed, eliminating direct tailnet access to the dashboard.

2. **New public route at `raj.hermes.keiretsu.top`** — HTTPRoute `teaspoon-hermes-web` routes `raj.hermes.keiretsu.top` → `teaspoon:9119` (dashboard) via the `public` + `private` gateways.

3. **Tinyauth extAuth gating** — SecurityPolicy `teaspoon-hermes-web-auth` uses Tinyauth's envoy extAuth at `auth.keiretsu.top`. Google OAuth with whitelist `rajsinghcpre@gmail.com` (the global tinyauth config).

4. **ReferenceGrant updated** — allowed `agents` namespace SecurityPolicies to reference the `tinyauth` service (was `authtest` only).

5. **Gateway listeners** — added `*.hermes.keiretsu.top` HTTPS listener to the `public` and `private` gateways (the existing `*.keiretsu.top` wildcard only matches single-level subdomains). Reuses the existing `wildcard-keiretsu-top` TLS cert.

### Changeset

| File | Action |
|------|--------|
| `.../teaspoon/kustomization.yaml` | Removed `service-tailscale.yaml`; added new route + security policy |
| `.../teaspoon/httproute-hermes-web.yaml` | **New** — HTTPRoute for `raj.hermes.keiretsu.top` → dashboard:9119 |
| `.../teaspoon/securitypolicy-hermes-web.yaml` | **New** — SecurityPolicy with Tinyauth extAuth |
| `.../tinyauth/referencegrant.yaml` | Added `agents` namespace to allowed SecurityPolicy sources |
| `.../gateway-public.yaml` | Added `*.hermes.keiretsu.top` HTTPS listener |
| `.../gateway-private.yaml` | Added `*.hermes.keiretsu.top` HTTPS listener |

### Verification

- `kustomize build` passes for both the teaspoon overlay and the tinyauth base
- The existing `teaspoon-web` route (Garage S3 static site at `teaspoon.agents.keiretsu.top` with Pocket ID OIDC) is unchanged