### PR TITLE
fix: prevent homepage probes from polluting the app discovery cache

### DIFF
--- a/kubernetes/apps/base/home/home/homepage/server.py
+++ b/kubernetes/apps/base/home/home/homepage/server.py
@@ -300,7 +300,13 @@ class HomepageHandler(BaseHTTPRequestHandler):
         email = self.headers.get("Remote-Email", "").strip().lower()
         name = self.headers.get("Remote-Name", "").strip()
 
-        groups_data = discover_user_apps(email)
+        # Skip discovery for probes or unauthenticated requests
+        # (liveness/readiness probes don't send Remote-Email).
+        # This prevents them from polluting the cache with empty results.
+        if not email:
+            groups_data = {"groups": []}
+        else:
+            groups_data = discover_user_apps(email)
         html = render_page(email, name, groups_data, self.style)
 
         self.send_response(200)


### PR DESCRIPTION
The readiness/liveness probes hit / without a Remote-Email header, causing `discover_user_apps('')` to cache empty groups. All subsequent real user requests then returned an empty homepage for up to 5 minutes.

**Fix:** skip the discovery cache entirely when email is empty, so probe requests never cache anything.

- [x] No ConfigMap change — no hot reload needed
- [x] Server restart clears cache naturally