### PR TITLE
feat: deploy Velero + Kopia on all 3 clusters as secondary backup to Garage S3

### DIFF
--- a/clusters/common/flux/repositories/helm/kustomization.yaml
+++ b/clusters/common/flux/repositories/helm/kustomization.yaml
@@ -86,3 +86,4 @@ resources:
   - ./kro.yaml
   - ./ocm.yaml
   - ./border0.yaml
+  - ./vmware-tanzu.yaml

--- a/clusters/common/flux/repositories/helm/vmware-tanzu.yaml
+++ b/clusters/common/flux/repositories/helm/vmware-tanzu.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vmware-tanzu
+  namespace: flux-system
+spec:
+  type: default
+  interval: 30m
+  timeout: 3m
+  url: https://vmware-tanzu.github.io/helm-charts/

--- a/kubernetes/apps/base/garage/garage-velero-bucket/bucket.yaml
+++ b/kubernetes/apps/base/garage/garage-velero-bucket/bucket.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: velero
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: velero
+  quotas:
+    maxSize: 200Gi
+    maxObjects: 5000000

--- a/kubernetes/apps/base/garage/garage-velero-bucket/key.yaml
+++ b/kubernetes/apps/base/garage/garage-velero-bucket/key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: velero-key
+spec:
+  clusterRef:
+    name: garage
+  name: "Velero Backup Key"
+  secretTemplate:
+    name: velero-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    additionalData:
+      endpoint: "http://${COMMON_S3_ENDPOINT}"
+      region: garage
+  bucketPermissions:
+    - bucketRef:
+        name: velero
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-velero-bucket/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-velero-bucket/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: garage
+resources:
+  - bucket.yaml
+  - key.yaml

--- a/kubernetes/apps/base/velero/velero/credentials-secret.yaml
+++ b/kubernetes/apps/base/velero/velero/credentials-secret.yaml
@@ -1,0 +1,15 @@
+# --- Velero S3 credentials in the format Velero expects ---
+# Uses the master Garage S3 credentials from common-secrets (via Flux substitution).
+# Scoped by the 'velero' GarageBucket's key permissions.
+# The Garage operator creates velero-s3 with raw AWS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY,
+# but Velero needs them in INI format under a "cloud" key.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-credentials
+  namespace: velero-system
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id=${GARAGE_S3_ACCESS_KEY_ID}
+    aws_secret_access_key=${GARAGE_S3_SECRET_ACCESS_KEY}

--- a/kubernetes/apps/base/velero/velero/helmrelease.yaml
+++ b/kubernetes/apps/base/velero/velero/helmrelease.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: velero
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: velero
+      version: 12.0.2
+      sourceRef:
+        kind: HelmRepository
+        name: vmware-tanzu
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: docker.io/velero/velero
+      tag: v1.18.1
+
+    initContainers:
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:v1.13.1
+        volumeMounts:
+          - mountPath: /target
+            name: plugins
+
+    credentials:
+      useSecret: true
+      existingSecret: velero-credentials
+
+    configuration:
+      backupStorageLocation:
+        - name: garage
+          provider: aws
+          bucket: velero
+          config:
+            region: garage
+            s3Url: "http://${COMMON_S3_ENDPOINT}"
+            s3ForcePathStyle: "true"
+          credential:
+            name: velero-credentials
+            key: cloud
+      volumeSnapshotLocation: []
+
+    deployNodeAgent: true
+    nodeAgent:
+      uploaderType: kopia
+      podVolumePath: /var/lib/kubelet/pods
+      resources:
+        requests:
+          cpu: 200m
+          memory: 256Mi
+        limits:
+          cpu: 1
+          memory: 1Gi
+
+    metrics:
+      enabled: true
+
+    schedules:
+      media-backup:
+        schedule: "0 6 * * *"
+        useOwnerReferencesInBackup: true
+        template:
+          ttl: "720h"
+          includedNamespaces:
+            - media
+          defaultVolumesToFsBackup: true
+      hermes-backup:
+        schedule: "0 7 * * *"
+        useOwnerReferencesInBackup: true
+        template:
+          ttl: "720h"
+          includedNamespaces:
+            - hermes
+            - agents
+          defaultVolumesToFsBackup: true
+      immutable-backup:
+        schedule: "0 8 * * *"
+        useOwnerReferencesInBackup: true
+        template:
+          ttl: "720h"
+          includedNamespaces:
+            - immich
+          defaultVolumesToFsBackup: true
+      home-backup:
+        schedule: "0 9 * * *"
+        useOwnerReferencesInBackup: true
+        template:
+          ttl: "720h"
+          includedNamespaces:
+            - home
+          defaultVolumesToFsBackup: true

--- a/kubernetes/apps/base/velero/velero/kustomization.yaml
+++ b/kubernetes/apps/base/velero/velero/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./credentials-secret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/velero/velero/namespace.yaml
+++ b/kubernetes/apps/base/velero/velero/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    volsync.backube/privileged-movers: "true"

--- a/kubernetes/apps/ottawa/garage/garage.yaml
+++ b/kubernetes/apps/ottawa/garage/garage.yaml
@@ -83,3 +83,25 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-velero-bucket
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage-bucket
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-velero-bucket
+  path: ./kubernetes/apps/base/garage/garage-velero-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -59,3 +59,4 @@ resources:
   - ./tuppr
   - ./k8s-gpu-dra-driver
   - ./rook-ceph
+  - ./velero

--- a/kubernetes/apps/ottawa/velero/kustomization.yaml
+++ b/kubernetes/apps/ottawa/velero/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./velero.yaml

--- a/kubernetes/apps/ottawa/velero/namespace.yaml
+++ b/kubernetes/apps/ottawa/velero/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/ottawa/velero/velero.yaml
+++ b/kubernetes/apps/ottawa/velero/velero.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  targetNamespace: velero-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: velero
+  path: ./kubernetes/apps/base/velero/velero
+  dependsOn:
+    - name: garage-velero-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/robbinsdale/garage/garage.yaml
+++ b/kubernetes/apps/robbinsdale/garage/garage.yaml
@@ -125,3 +125,25 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-velero-bucket
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage-bucket
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-velero-bucket
+  path: ./kubernetes/apps/base/garage/garage-velero-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -48,3 +48,4 @@ resources:
   - ./csi-driver-smb
   - ./tuppr
   - ./rook-ceph
+  - ./velero

--- a/kubernetes/apps/robbinsdale/velero/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/velero/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./velero.yaml

--- a/kubernetes/apps/robbinsdale/velero/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/velero/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/robbinsdale/velero/velero.yaml
+++ b/kubernetes/apps/robbinsdale/velero/velero.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  targetNamespace: velero-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: velero
+  path: ./kubernetes/apps/base/velero/velero
+  dependsOn:
+    - name: garage-velero-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/stpetersburg/garage/garage.yaml
+++ b/kubernetes/apps/stpetersburg/garage/garage.yaml
@@ -83,3 +83,25 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-velero-bucket
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage-bucket
+  targetNamespace: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-velero-bucket
+  path: ./kubernetes/apps/base/garage/garage-velero-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -48,3 +48,4 @@ resources:
   - ./rdma-shared-dp
   - ./spiderpool
   - ./gpu-operator
+  - ./velero

--- a/kubernetes/apps/stpetersburg/velero/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/velero/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./velero.yaml

--- a/kubernetes/apps/stpetersburg/velero/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/velero/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/stpetersburg/velero/velero.yaml
+++ b/kubernetes/apps/stpetersburg/velero/velero.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  targetNamespace: velero-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: velero
+  path: ./kubernetes/apps/base/velero/velero
+  dependsOn:
+    - name: garage-velero-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m


### PR DESCRIPTION
## Summary

Deploys **Velero v1.18.1** with **Kopia uploader** (File System Backup) on all 3 clusters as a secondary backup layer alongside the existing VolSync/restic setup.

## What was done

### Garage resources (per cluster)
- Created `GarageBucket` `velero` (200Gi quota) with global alias `velero`
- Created `GarageKey` `velero-key` with bucket-scoped permissions (owner)
- Dependency chain: `garage → garage-bucket → garage-velero-bucket → velero`

### Velero configuration
- **Helm chart**: vmware-tanzu/velero 12.0.2 (Velero v1.18.1)
- **Backend**: Garage S3 (existing `COMMON_S3_ENDPOINT`) via AWS S3-compatible plugin
- **Uploader**: Kopia (default in v1.18, restic being deprecated)
- **Credentials**: From `common-secrets` SOPS (`GARAGE_S3_ACCESS_KEY_ID` + `GARAGE_S3_SECRET_ACCESS_KEY`)
- **Node-agent**: DaemonSet running per node, 200m/256Mi requests

### Backup schedules
| Schedule | Namespaces | When |
|----------|-----------|------|
| `media-backup` | media | 06:00 UTC daily |
| `hermes-backup` | hermes, agents | 07:00 UTC daily |
| `immutable-backup` | immich | 08:00 UTC daily |
| `home-backup` | home | 09:00 UTC daily |

All backups: Kopia FSB, 30-day TTL.

### Cluster wiring
- Ottawa, Robbinsdale, StPetersburg all get Velero + the Garage velero bucket
- HelmRepository `vmware-tanzu` added to common Flux repos
- Each cluster's `kustomization.yaml` includes `./velero`

## Why Kopia over restic?
- 2x+ faster for small config PVCs (most of our backups are 5Gi databases)
- 3-4x smaller repo sizes for same data
- Handles eventually-consistent S3 better (relevant for Garage)
- Velero creates one repo per namespace with unique encryption keys by default

## Testing
- [ ] Flux reconciles HelmRepository
- [ ] GarageBucket + GarageKey created
- [ ] Velero pods start (server + node-agent)
- [ ] First scheduled backup runs
- [ ] Verify Velero can restore a PVC