### PR TITLE
feat: add LiteLLM proxy — front StPete DSV4 Sparks with Corp AI overflow

### DIFF
--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ./jellyswarrm
   - ./kro-system
   - ./kube-system
+  - ./litellm
   - ./lws-system
   - ./loki
   - ./mimir

--- a/kubernetes/apps/stpetersburg/litellm/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./litellm-secret.yaml
+  - ./litellm-config.yaml
+  - ./litellm.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/stpetersburg/litellm/litellm-config.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm-config.yaml
@@ -1,0 +1,48 @@
+# LiteLLM proxy config: front the StPete DSV4 Sparks with overflow to Corp AI
+# Consumers hit litellm.keiretsu.ts.net/v1/chat/completions with model=deepseek-v4-flash
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: agents
+data:
+  config.yaml: |
+    model_list:
+      # ── Primary: StPete DGX Sparks (DSV4 vLLM) ──────────────────────
+      - model_name: deepseek-v4-flash
+        litellm_params:
+          model: hosted_vllm/deepseek-v4-flash
+          api_base: http://dsv4.ai.svc.cluster.local:8000/v1
+          api_key: ""
+          rpm: 60
+        # Priority makes the router try this deployment first
+        model_info:
+          mode: primary
+
+      # ── Fallback: Corp AI endpoint ───────────────────────────────────
+      - model_name: deepseek-v4-flash
+        litellm_params:
+          model: openai/deepseek-v4-flash
+          api_base: http://ai/v1
+          # Corp API key from K8s secret (set via envFrom)
+          api_key: os.environ/CORP_API_KEY
+        model_info:
+          mode: fallback
+
+    # ── Routing ────────────────────────────────────────────────────────
+    router_settings:
+      # If primary deployment fails (timeout/429/503/unhealthy), fallback
+      # to the next deployment in the model group. Tries in declaration order.
+      fallbacks: [{ "deepseek-v4-flash": ["deepseek-v4-flash"] }]
+      num_retries: 2
+      retry_after: 5   # seconds before retrying primary after failure
+      timeout: 30       # request timeout to individual deployments
+      routing_strategy: usage-based-routing
+      enable_pre_call_checks: true
+      allowed_fails: 3  # mark deployment unhealthy after N consecutive failures
+
+    general_settings:
+      # Master key for admin endpoints (set via env LITELLM_MASTER_KEY)
+      # Salt key for credential encryption (set via env LITELLM_SALT_KEY)
+      database_url: ""  # in-memory mode (no persistence)

--- a/kubernetes/apps/stpetersburg/litellm/litellm-config.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm-config.yaml
@@ -23,10 +23,9 @@ data:
       # ── Fallback: Corp AI endpoint ───────────────────────────────────
       - model_name: deepseek-v4-flash
         litellm_params:
-          model: openai/deepseek-v4-flash
+          model: hosted_vllm/deepseek-v4-flash
           api_base: http://ai/v1
-          # Corp API key from K8s secret (set via envFrom)
-          api_key: os.environ/CORP_API_KEY
+          api_key: ""
         model_info:
           mode: fallback
 

--- a/kubernetes/apps/stpetersburg/litellm/litellm-secret.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm-secret.yaml
@@ -1,0 +1,15 @@
+---
+# Secret template for LiteLLM — values are substituted by Flux postBuild
+# from cluster-secrets / common-secrets at deploy time.
+#   LITELLM_MASTER_KEY — Master key for LiteLLM admin API
+#   LITELLM_SALT_KEY   — Salt key for encrypting stored credentials
+#   CORP_API_KEY       — API key for the Corp AI fallback endpoint
+apiVersion: v1
+kind: Secret
+metadata:
+  name: litellm-secret
+  namespace: agents
+stringData:
+  master_key: ${LITELLM_MASTER_KEY}
+  salt_key: ${LITELLM_SALT_KEY}
+  corp_api_key: ${CORP_API_KEY}

--- a/kubernetes/apps/stpetersburg/litellm/litellm-secret.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm-secret.yaml
@@ -3,7 +3,6 @@
 # from cluster-secrets / common-secrets at deploy time.
 #   LITELLM_MASTER_KEY — Master key for LiteLLM admin API
 #   LITELLM_SALT_KEY   — Salt key for encrypting stored credentials
-#   CORP_API_KEY       — API key for the Corp AI fallback endpoint
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,4 +11,3 @@ metadata:
 stringData:
   master_key: ${LITELLM_MASTER_KEY}
   salt_key: ${LITELLM_SALT_KEY}
-  corp_api_key: ${CORP_API_KEY}

--- a/kubernetes/apps/stpetersburg/litellm/litellm.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm.yaml
@@ -44,11 +44,6 @@ spec:
                 secretKeyRef:
                   name: litellm-secret
                   key: salt_key
-            - name: CORP_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: litellm-secret
-                  key: corp_api_key
           ports:
             - containerPort: 4000
               name: http

--- a/kubernetes/apps/stpetersburg/litellm/litellm.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm.yaml
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2025 Raj Singh <raj@keiretsu.cloud>
+# SPDX-License-Identifier: MIT
+#
+# LiteLLM proxy deployment — fronts StPete DSV4 Sparks with Corp AI overflow.
+---
+# ── Deployment ───────────────────────────────────────────────────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+  namespace: agents
+  labels:
+    app: litellm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: litellm
+  template:
+    metadata:
+      labels:
+        app: litellm
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: litellm
+          image: ghcr.io/berriai/litellm:main-latest
+          imagePullPolicy: Always
+          args:
+            - "--config"
+            - "/app/config.yaml"
+            - "--port"
+            - "4000"
+          env:
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-secret
+                  key: master_key
+            - name: LITELLM_SALT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-secret
+                  key: salt_key
+            - name: CORP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-secret
+                  key: corp_api_key
+          ports:
+            - containerPort: 4000
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /health/liveliness
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+      volumes:
+        - name: config
+          configMap:
+            name: litellm-config
+---
+# ── ClusterIP Service ────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm
+  namespace: agents
+  labels:
+    app: litellm
+spec:
+  type: ClusterIP
+  selector:
+    app: litellm
+  ports:
+    - name: http
+      port: 4000
+      protocol: TCP
+      targetPort: http
+---
+# ── Tailscale LoadBalancer ──────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-ts
+  namespace: agents
+  annotations:
+    tailscale.com/hostname: litellm
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: tag:singh360,tag:k8s,tag:stpetersburg
+  labels:
+    app: litellm
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app: litellm
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http

--- a/kubernetes/apps/stpetersburg/litellm/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agents


### PR DESCRIPTION
## What

Deploys **LiteLLM** — an open-source AI gateway/proxy — in the `agents` namespace on StPete.

### Architecture

Consumer `→` `litellm.keiretsu.ts.net:80` (Tailscale LB) `→` LiteLLM Proxy (agents:4000) `→` Primary: `dsv4.ai:8000` (DGX Sparks DSV4) | Fallback: `http://ai` (Corp endpoint)

- **Primary**: StPete's `dsv4.ai.svc.cluster.local:8000` (DGX Spark DSV4 vLLM) — tries 2x before failing over
- **Fallback**: Corp AI endpoint at `http://ai/v1` — overflow when Sparks are fully loaded (429/503/timeout)
- No API keys needed — both endpoints are unauthenticated

### Exposed
- **Tailscale LoadBalancer**: `litellm.keiretsu.ts.net:80` → proxy :4000 (tag:k8s)

### Config
- `litellm-config.yaml` — ConfigMap with proxy routing: `hosted_vllm/deepseek-v4-flash` (primary) + same model on `http://ai/v1` (fallback)
- `litellm.yaml` — Deployment (1 replica, ghcr.io/berriai/litellm:main-latest) + ClusterIP + TS LoadBalancer
- `litellm-secret.yaml` — Secret template using Flux `${VAR}` substitution

### Prerequisites (cluster-secrets)
Add these to `cluster-secrets` on StPete:
- `LITELLM_MASTER_KEY` — random string for LiteLLM admin API
- `LITELLM_SALT_KEY` — random string for encrypted credential storage