### PR TITLE
feat: add litellm egress to Ottawa agents namespace

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/egress.yaml
+++ b/kubernetes/apps/base/agents/agents/app/egress.yaml
@@ -30,3 +30,19 @@ spec:
     - name: http
       port: 80
       protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: litellm.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP


### PR DESCRIPTION
## What

Adds an ExternalName egress service so Ottawa's agents namespace can reach the new StPete LiteLLM proxy at `litellm.keiretsu.ts.net`.

### Why

Ottawa-based Hermes agents (teaspoon, assistant-raj, kartik, etc.) need to reach the LiteLLM proxy that fronts the StPete DSV4 Sparks. The Tailscale operator handles resolving `externalName: placeholder` to the actual `ts-litellm-*` ClusterIP service.

### Pattern

Follows the existing `ai` and `aperture` egress entries in the same file — `tailscale.com/proxy-group: common-egress` + `tailscale.com/tailnet-fqdn: litellm.keiretsu.ts.net`.