### PR TITLE
feat: enable LiteLLM Prometheus metrics + ServiceMonitor

### DIFF
--- a/kubernetes/apps/stpetersburg/litellm/litellm-config.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm-config.yaml
@@ -45,3 +45,12 @@ data:
       # Master key for admin endpoints (set via env LITELLM_MASTER_KEY)
       # Salt key for credential encryption (set via env LITELLM_SALT_KEY)
       database_url: ""  # in-memory mode (no persistence)
+
+    # ── Observability ──────────────────────────────────────────────────
+    litellm_settings:
+      callbacks: ["prometheus"]
+    # Exposes /metrics with per-deployment token/request counters.
+    # Labels: model_id, api_base, api_provider differentiate primary vs fallback.
+    #   litellm_total_tokens_metric{model_id="hosted_vllm/deepseek-v4-flash"} — primary (StPete)
+    #   litellm_total_tokens_metric{model_id="openai/deepseek-v4-flash"}      — fallback (Corp)
+    #   litellm_proxy_total_requests_metric{model_id="..."}                   — request counts

--- a/kubernetes/apps/stpetersburg/litellm/litellm.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm.yaml
@@ -116,3 +116,29 @@ spec:
       port: 80
       protocol: TCP
       targetPort: http
+---
+# ── ServiceMonitor ──────────────────────────────────────────────────────
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: litellm
+  namespace: agents
+  labels:
+    app: litellm
+    release: kube-prometheus-stack
+spec:
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: replace
+          replacement: talos-stpetersburg
+          targetLabel: cluster
+  selector:
+    matchLabels:
+      app: litellm
+  namespaceSelector:
+    matchNames:
+      - agents


### PR DESCRIPTION
## What

Enables LiteLLM's built-in Prometheus metrics and adds a ServiceMonitor so kube-prometheus-stack auto-discovers them.

### Why

Raj wants to see token split between StPete (DGX Sparks) vs Corp (fallback) — which deployments are getting traffic and how much.

### Metrics available

| Metric | What it tracks | Differentiation |
|--------|---------------|-----------------|
| `litellm_total_tokens_metric` | Input + output tokens | `model_id` label: `hosted_vllm/*` = primary, `openai/*` = fallback |
| `litellm_input_tokens_metric` | Input tokens only | Same label split |
| `litellm_output_tokens_metric` | Output tokens only | Same label split |
| `litellm_proxy_total_requests_metric` | Request count | `model_id` + `status_code` |
| `litellm_proxy_failed_requests_metric` | Failed requests | `model_id` + `exception_status` |

### Example Grafana queries

```promql
# Tokens through StPete Sparks (primary)
rate(litellm_total_tokens_metric_total{model_id=~"hosted_vllm.*"}[5m])

# Tokens through Corp (fallback)
rate(litellm_total_tokens_metric_total{model_id=~"openai.*"}[5m])

# Ratio of overflow traffic
sum(rate(litellm_total_tokens_metric_total{model_id=~"openai.*"}[5m]))
/
sum(rate(litellm_total_tokens_metric_total{model_id=~"hosted_vllm.*|openai.*"}[5m]))
```

### Config changes
- `litellm_settings.callbacks: ["prometheus"]` added to LiteLLM config
- ServiceMonitor added to `litellm.yaml` (scrapes :4000/metrics)