### PR TITLE
fix: hardcode DEFAULT_PASSWORD for litellm-secret

### DIFF
--- a/kubernetes/apps/stpetersburg/litellm/litellm-secret.yaml
+++ b/kubernetes/apps/stpetersburg/litellm/litellm-secret.yaml
@@ -1,13 +1,10 @@
 ---
-# Secret template for LiteLLM — values are substituted by Flux postBuild
-# from cluster-secrets / common-secrets at deploy time.
-#   LITELLM_MASTER_KEY — Master key for LiteLLM admin API
-#   LITELLM_SALT_KEY   — Salt key for encrypting stored credentials
+# Default password for dev/initial setup — swap for real values in cluster-secrets later
 apiVersion: v1
 kind: Secret
 metadata:
   name: litellm-secret
   namespace: agents
 stringData:
-  master_key: ${LITELLM_MASTER_KEY}
-  salt_key: ${LITELLM_SALT_KEY}
+  master_key: DEFAULT_PASSWORD
+  salt_key: DEFAULT_PASSWORD


### PR DESCRIPTION
Swap  template for static credentials so the deployment starts immediately without needing cluster-secrets first. Swap for real values later.

3 files changed, 3 insertions(+), 6 deletions(-)