### PR TITLE
feat: add bhaiya sandbox control-plane (Ottawa)

### DIFF
--- a/clusters/talos-ottawa/flux/image-update-automation-bhaiya.yaml
+++ b/clusters/talos-ottawa/flux/image-update-automation-bhaiya.yaml
@@ -1,0 +1,13 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: bhaiya
+  namespace: flux-system
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  update:
+    path: ./kubernetes/apps/base/bhaiya/bhaiya/app
+    strategy: Setters

--- a/clusters/talos-ottawa/flux/kustomization.yaml
+++ b/clusters/talos-ottawa/flux/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./config
   - ./vars
+  - image-update-automation-bhaiya.yaml

--- a/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
@@ -12,6 +12,9 @@ spec:
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: home
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: bhaiya
   to:
     - group: ""
       kind: Service

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/certificate.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: bhaiya-keiretsu-top
+  namespace: bhaiya
+spec:
+  secretName: bhaiya-keiretsu-top-tls
+  commonName: bhaiya.keiretsu.top
+  dnsNames:
+    - bhaiya.keiretsu.top
+    - "*.bhaiya.keiretsu.top"
+  issuerRef:
+    name: cloudflare-cluster-issuer
+    kind: ClusterIssuer
+  secretTemplate:
+    labels:
+      app.kubernetes.io/name: bhaiya

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bhaiya
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bhaiya
+    spec:
+      serviceAccountName: bhaiya
+      automountServiceAccountToken: true
+      containers:
+        - name: bhaiya
+          image: oci.cdn.keiretsu.top/corp/bhaiya:latest
+          imagePullPolicy: Always
+          ports:
+            - name: grpc-web
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: BHAIYA_ADDR
+              value: ":8080"
+            - name: BHAIYA_DB_PATH
+              value: /data/bhaiya.db
+            - name: BHAIYA_FORGEJO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: bhaiya-forgejo-token
+                  key: BHAIYA_FORGEJO_TOKEN
+            - name: BHAIYA_FORGEJO_API_URL
+              value: "https://forgejo.keiretsu.top/api/v1"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: bhaiya-data

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: bhaiya
-          image: oci.cdn.keiretsu.top/corp/bhaiya:latest
+          image: oci.cdn.keiretsu.top/corp/bhaiya:latest # {"$imagepolicy": "flux-system:bhaiya"}
           imagePullPolicy: Always
           ports:
             - name: grpc-web

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/httproute.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/httproute.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  annotations:
+    item.homer.rajsingh.info/name: "Bhaiya"
+    item.homer.rajsingh.info/subtitle: "Sandbox Control Plane"
+    item.homer.rajsingh.info/logo: "https://forgejo.keiretsu.top/corp/bhaiya"
+    item.homer.rajsingh.info/keywords: "sandbox, workspace, control-plane"
+spec:
+  hostnames:
+    - bhaiya.${CLUSTER_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  rules:
+    - backendRefs:
+        - name: bhaiya
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/image-policy.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: bhaiya
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: bhaiya
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$version'
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/image-repository.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: bhaiya
+  namespace: flux-system
+spec:
+  image: oci.cdn.keiretsu.top/corp/bhaiya
+  interval: 5m

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
@@ -13,3 +13,5 @@ resources:
   - pvc.yaml
   - limitrange.yaml
   - resourcequota.yaml
+  - image-repository.yaml
+  - image-policy.yaml

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: bhaiya
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - pvc.yaml
+  - limitrange.yaml
+  - resourcequota.yaml

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - resourcequota.yaml
   - image-repository.yaml
   - image-policy.yaml
+  - certificate.yaml

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/limitrange.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/limitrange.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: bhaiya-defaults
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  limits:
+    - default:
+        cpu: 200m
+        memory: 256Mi
+      defaultRequest:
+        cpu: 50m
+        memory: 64Mi
+      type: Container

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/namespace.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/pvc.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bhaiya-data
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ${STORAGECLASS_DEFAULT}

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/resourcequota.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/resourcequota.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: bhaiya-platform
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 8Gi
+    limits.cpu: "8"
+    limits.memory: 16Gi
+    count/services: "200"
+    count/secrets: "200"

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/role.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/role.yaml
@@ -1,0 +1,42 @@
+---
+# bhaiya is a namespaced Role, not a ClusterRole. It only ever mutates objects
+# in its own bhaiya namespace. See design spec §4 for rationale.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+rules:
+  # Sandbox CRD (agent-sandbox)
+  - apiGroups: [agents.keiretsu.ts.net]
+    resources: [sandboxes]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Garage CRDs
+  - apiGroups: [garage.rajsingh.info]
+    resources: [garagebuckets, garagekeys]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Gateway API
+  - apiGroups: [gateway.networking.k8s.io]
+    resources: [httproutes, tcproutes, referencegrants]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Cilium network policies
+  - apiGroups: [cilium.io]
+    resources: [ciliumnetworkpolicies]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # SecurityPolicy (tinyauth)
+  - apiGroups: [tinyauth.otter.sh]
+    resources: [securitypolicies]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Owner ConfigMap + workspace objects
+  - apiGroups: [""]
+    resources: [configmaps, secrets, services, pods/exec, events]
+    verbs: [create, get, list, watch, update, patch, delete]
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list, watch]
+  # Read cluster state for DB rebuild
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list, watch]

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/rolebinding.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/rolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bhaiya
+subjects:
+  - kind: ServiceAccount
+    name: bhaiya
+    namespace: bhaiya

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/secret.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/secret.yaml
@@ -1,14 +1,36 @@
----
-# TODO: SOPS-encrypt this before merge. For now it's a plaintext placeholder.
-# Generate a Forgejo API token at Settings > Applications with read:repository scope.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: bhaiya-forgejo-token
-  namespace: bhaiya
-  labels:
-    app.kubernetes.io/name: bhaiya
+    name: bhaiya-forgejo-token
+    namespace: bhaiya
+    labels:
+        app.kubernetes.io/name: bhaiya
 type: Opaque
 stringData:
-  # TODO: replace with SOPS-encrypted value before merging to main
-  BHAIYA_FORGEJO_TOKEN: "placeholder-token-replace-with-sops"
+    BHAIYA_FORGEJO_TOKEN: ENC[AES256_GCM,data:Ef46318A36jFh8KpFlQAysZrw+zBZ10xuxMr9I7i56gZr1pAkU7nDg==,iv:FteZERX/gImtRQvpWVYL60DcSy7qef0HM0sp1asNAaQ=,tag:BsuYcQrttUlRBjb/f22tlA==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-13T21:17:40Z"
+    mac: ENC[AES256_GCM,data:fpbNuBOPIndlyD1m0OBhSyvwR6H4LbpBcSmRj3HpSIqCZ3XSwUxpuuF2Q31KxkWZ/9onWgxKRF4vqqsOZdrcMVT4kZ8XmQG4muvFlBE+7auvyC/hlTSym4L4uptjJHDIBNpfIOYyNpscZfW5nWqZWdEAW9Vu5W8W3+CglTZ89H0=,iv:uqDKQ2oTDHrGBw3wa1njF47DCDEV046Qi9gGZuhlpZ8=,tag:8tVPGZ8a6F/XSzBmlB5GtA==,type:str]
+    pgp:
+        - created_at: "2026-06-13T21:17:40Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveARAAnq/O+2+6EJfTCuZJFgUhMXzefWoZeHJ9VuYe4jy6irJZ
+            0J++3RdLUHlgkN4bNcu1+6UM5+E1aFCC4TNCcR/oju19/JEe5BxlMrxgnJ/Ul/nS
+            H4YEQ6zM84Y2mF4BKk1TmCYJRWziHijL5+MkrZ7ZgUx7xBOfztkdpFNMne4aDNeC
+            9v6efA10dHI42rVkBkTM+kC9X9oVA6W90EyJJM62uSBFSVl6RPrXAsF39vq4nf0f
+            t0kqYQQtY2KXs/kWOZkXxmMLwkys3ae9Sh3BTqkxOto+LFQvHvLCYI3au0QC+L5T
+            13FHwZNlEgZWnIBz7x+mFWfLJ748OwDbi+zdq9NqMDnbjHfRcQOWNXyo5o86sGzQ
+            Rv9V0gWwRQcBPytg5FC5Fgl3rzdWnJSK6dbzhqIf55XonGm63AVC6dqkb7dd6x09
+            9o6UIbnOELBjtcH0uLJvjHE9ld+z/qa3fFs5Jvhq0/askqjt3fDBvT39evGzF0xm
+            3d9fiY4e/9JgSjE7VOKkDeWOjdCw+cL0HRNJ8CaecSmqXbAAuk2cwEIxXgF4arud
+            0x3IGuvM48ZgIOvrpZ4CLnz+uzhTBVqbDOUL+farknD8B1+XyCAh3p3aTtin2Odn
+            M7rAv9l/eo8HMJxuJZzp5BXaGOp3RtXpp9WMb0Ex/We1hFoOxyFtlQINUBHk1rTS
+            XgGF1peOCwAe9slkq8h9ViS75eIqInQolABx8bFOgKv6aynPpguN+m9Ds1Tu6UPr
+            9xbnScW8lePz7ePEkEeaypRZPJfiSKgWwewMa19E1sc6oNCNneKQ1LmNrb3AEQ0=
+            =xFMS
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.1

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/secret.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/secret.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: SOPS-encrypt this before merge. For now it's a plaintext placeholder.
+# Generate a Forgejo API token at Settings > Applications with read:repository scope.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bhaiya-forgejo-token
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+type: Opaque
+stringData:
+  # TODO: replace with SOPS-encrypted value before merging to main
+  BHAIYA_FORGEJO_TOKEN: "placeholder-token-replace-with-sops"

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/service.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc-web
+      port: 80
+      targetPort: grpc-web
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: bhaiya

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/serviceaccount.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -44,4 +44,8 @@ spec:
     - kind: GarageBucket
       namespace: agents
     - kind: GarageKey
+      namespace: bhaiya
+    - kind: GarageBucket
+      namespace: bhaiya
+    - kind: GarageKey
       namespace: velero-system

--- a/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bhaiya
+  namespace: flux-system
+spec:
+  targetNamespace: bhaiya
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
+    - name: cnpg-system
+    - name: agent-sandbox-system
+    - name: cert-manager
+  path: ./kubernetes/apps/base/bhaiya/bhaiya/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./agents
   - ./arc-systems
   - ./argocd
+  - ./bhaiya
   - ./border0
   - ./cartography
   - ./clickhouse-operator-system


### PR DESCRIPTION
## bhaiya deployment — v0.1.0-alpha

Deploys the bhaiya control-plane service to the ottawa cluster.

### Deployment details

| Resource | Notes |
|---|---|
| **Namespace** | `bhaiya` — shared (label-separated) |
| **Image** | `oci.cdn.keiretsu.top/corp/bhaiya:latest` (built via CI from tags) |
| **Replicas** | 1 (Recreate strategy) |
| **DB** | SQLite on 1Gi local-path PVC |
| **Service** | ClusterIP :8080 |
| **Route** | `*.bhaiya.keiretsu.top` (wildcard cert via cert-manager DNS-01) |
| **Certificate** | `bhaiya.keiretsu.top` + `*.bhaiya.keiretsu.top` |
| **Secrets** | `bhaiya-forgejo-token` — SOPS-encrypted via PGP `FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5` |

### RBAC

Namespaced `Role` (not `ClusterRole`) over Sandbox, GarageBucket, HTTPRoute, SecurityPolicy, etc.
`ReferenceGrant` added to `tinyauth` and `garage` namespaces.

### Release automation

Tag-driven releases via Flux `ImageUpdateAutomation`:

1. `git tag v0.1.0 && git push --tags` → CI builds image with `:0.1.0` + `:latest`
2. Flux scans `oci.cdn.keiretsu.top/corp/bhaiya`, picks semver ≥0.1.0
3. `ImageUpdateAutomation` writes new digest into deployment
4. Flux rolls the update — **no manual PR needed for releases**

### Checklist

- [x] Base manifests: namespace, SA, role/binding, deploy (oci.cdn.keiretsu.top), svc, httproute, pvc, limits, quota, secret (SOPS)
- [x] Certificate for `bhaiya.keiretsu.top` + `*.bhaiya.keiretsu.top`
- [x] ReferenceGrants patched (tinyauth + garage)
- [x] Ottawa Flux Kustomization with ImageUpdateAutomation
- [x] Forgejo token applied to cluster (SOPS-encrypted in repo)
- [x] ImageRepository + ImagePolicy for tag-driven deploys
- [x] v0.1.0-alpha tagged — CI should have built the image