### PR TITLE
fix: align forgejo runner registration labels with config.yaml

### DIFF
--- a/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
@@ -12,6 +12,9 @@ spec:
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: home
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: bhaiya
   to:
     - group: ""
       kind: Service

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bhaiya
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bhaiya
+    spec:
+      serviceAccountName: bhaiya
+      automountServiceAccountToken: true
+      containers:
+        - name: bhaiya
+          image: oci.cdn.keiretsu.top/corp/bhaiya:latest
+          imagePullPolicy: Always
+          ports:
+            - name: grpc-web
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: BHAIYA_ADDR
+              value: ":8080"
+            - name: BHAIYA_DB_PATH
+              value: /data/bhaiya.db
+            - name: BHAIYA_FORGEJO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: bhaiya-forgejo-token
+                  key: BHAIYA_FORGEJO_TOKEN
+            - name: BHAIYA_FORGEJO_API_URL
+              value: "https://forgejo.keiretsu.top/api/v1"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: bhaiya-data

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/httproute.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/httproute.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  annotations:
+    item.homer.rajsingh.info/name: "Bhaiya"
+    item.homer.rajsingh.info/subtitle: "Sandbox Control Plane"
+    item.homer.rajsingh.info/logo: "https://forgejo.keiretsu.top/corp/bhaiya"
+    item.homer.rajsingh.info/keywords: "sandbox, workspace, control-plane"
+spec:
+  hostnames:
+    - bhaiya.${CLUSTER_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  rules:
+    - backendRefs:
+        - name: bhaiya
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: bhaiya
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - pvc.yaml
+  - limitrange.yaml
+  - resourcequota.yaml

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/limitrange.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/limitrange.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: bhaiya-defaults
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  limits:
+    - default:
+        cpu: 200m
+        memory: 256Mi
+      defaultRequest:
+        cpu: 50m
+        memory: 64Mi
+      type: Container

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/namespace.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/pvc.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bhaiya-data
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ${STORAGECLASS_DEFAULT}

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/resourcequota.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/resourcequota.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: bhaiya-platform
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 8Gi
+    limits.cpu: "8"
+    limits.memory: 16Gi
+    count/services: "200"
+    count/secrets: "200"

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/role.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/role.yaml
@@ -1,0 +1,42 @@
+---
+# bhaiya is a namespaced Role, not a ClusterRole. It only ever mutates objects
+# in its own bhaiya namespace. See design spec §4 for rationale.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+rules:
+  # Sandbox CRD (agent-sandbox)
+  - apiGroups: [agents.keiretsu.ts.net]
+    resources: [sandboxes]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Garage CRDs
+  - apiGroups: [garage.rajsingh.info]
+    resources: [garagebuckets, garagekeys]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Gateway API
+  - apiGroups: [gateway.networking.k8s.io]
+    resources: [httproutes, tcproutes, referencegrants]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Cilium network policies
+  - apiGroups: [cilium.io]
+    resources: [ciliumnetworkpolicies]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # SecurityPolicy (tinyauth)
+  - apiGroups: [tinyauth.otter.sh]
+    resources: [securitypolicies]
+    verbs: [create, get, list, watch, update, patch, delete]
+  # Owner ConfigMap + workspace objects
+  - apiGroups: [""]
+    resources: [configmaps, secrets, services, pods/exec, events]
+    verbs: [create, get, list, watch, update, patch, delete]
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list, watch]
+  # Read cluster state for DB rebuild
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list, watch]

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/rolebinding.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/rolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bhaiya
+subjects:
+  - kind: ServiceAccount
+    name: bhaiya
+    namespace: bhaiya

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/secret.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/secret.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: SOPS-encrypt this before merge. For now it's a plaintext placeholder.
+# Generate a Forgejo API token at Settings > Applications with read:repository scope.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bhaiya-forgejo-token
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+type: Opaque
+stringData:
+  # TODO: replace with SOPS-encrypted value before merging to main
+  BHAIYA_FORGEJO_TOKEN: "placeholder-token-replace-with-sops"

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/service.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc-web
+      port: 80
+      targetPort: grpc-web
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: bhaiya

--- a/kubernetes/apps/base/bhaiya/bhaiya/app/serviceaccount.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bhaiya
+  namespace: bhaiya
+  labels:
+    app.kubernetes.io/name: bhaiya

--- a/kubernetes/apps/base/forgejo/forgejo/app/runner.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/runner.yaml
@@ -33,7 +33,7 @@ spec:
                   --instance http://forgejo-http:3000 \
                   --token "$(cat /secrets/token)" \
                   --name "$(hostname)" \
-                  --labels ubuntu-latest:docker://node:20-bookworm,ubuntu-22.04:docker://node:20-bookworm \
+                  --labels ubuntu-latest:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest,ubuntu-22.04:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest,ubuntu-20.04:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest \
                   --no-interactive
               fi
           volumeMounts:

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -44,4 +44,8 @@ spec:
     - kind: GarageBucket
       namespace: agents
     - kind: GarageKey
+      namespace: bhaiya
+    - kind: GarageBucket
+      namespace: bhaiya
+    - kind: GarageKey
       namespace: velero-system

--- a/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bhaiya
+  namespace: flux-system
+spec:
+  targetNamespace: bhaiya
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
+    - name: cnpg-system
+    - name: agent-sandbox-system
+    - name: cert-manager
+  path: ./kubernetes/apps/base/bhaiya/bhaiya/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./agents
   - ./arc-systems
   - ./argocd
+  - ./bhaiya
   - ./border0
   - ./cartography
   - ./clickhouse-operator-system


### PR DESCRIPTION
## Summary

The forgejo-runner init container's `--labels` flag was set to `docker://node:20-bookworm` but the runner's `config.yaml` defines `docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest`.

These must match so the runner's advertised labels match what it actually uses at runtime.

## Changes

- Changed `--labels` in the init container registration to use the ci-runner image, matching config.yaml
- Added the missing `ubuntu-20.04` label for consistency

## Related

The bhaiya CI pipeline (`forgejo.keiretsu.top/corp/bhaiya`) will use these runners once deployed. A runner registration token has been generated and needs to be set in `common-secrets` as `FORGEJO_RUNNER_TOKEN`.