### PR TITLE
fix: align forgejo runner registration labels with config.yaml

### DIFF
--- a/kubernetes/apps/base/forgejo/forgejo/app/runner.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/runner.yaml
@@ -33,7 +33,7 @@ spec:
                   --instance http://forgejo-http:3000 \
                   --token "$(cat /secrets/token)" \
                   --name "$(hostname)" \
-                  --labels ubuntu-latest:docker://node:20-bookworm,ubuntu-22.04:docker://node:20-bookworm \
+                  --labels ubuntu-latest:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest,ubuntu-22.04:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest,ubuntu-20.04:docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest \
                   --no-interactive
               fi
           volumeMounts:


### PR DESCRIPTION
## Summary

The forgejo-runner init container's `--labels` flag used `docker://node:20-bookworm` but the runner's `config.yaml` defines `docker://oci.cdn.keiretsu.top/keiretsu/ci-runner:latest`.

These must match so the runner's advertised labels match what it actually uses at runtime, or CI jobs will fail trying to use the wrong image.

## Changes

- Changed `--labels` in init container: `node:20-bookworm` → `oci.cdn.keiretsu.top/keiretsu/ci-runner:latest`
- Added missing `ubuntu-20.04` label for consistency with config.yaml