### PR TITLE
fix(gatus): add gateway-tier health checks for Garage

### DIFF
--- a/kubernetes/apps/base/gatus/gatus-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-ottawa/app/helmrelease.yaml
@@ -520,6 +520,16 @@ spec:
           alerts:
             - type: discord
               send-on-resolved: true
+        - name: Garage Gateway
+          group: Storage
+          url: tcp://garage-gateway.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
         - name: Garage WebUI
           group: Storage
           url: http://garage-webui.garage:80

--- a/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-robbinsdale/app/helmrelease.yaml
@@ -223,6 +223,16 @@ spec:
           alerts:
             - type: discord
               send-on-resolved: true
+        - name: Garage Gateway (Robbinsdale)
+          group: storage
+          url: tcp://garage-gateway.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
         - name: Garage Ottawa
           group: storage
           url: tcp://ottawa-garage.garage:3900

--- a/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
@@ -73,6 +73,16 @@ spec:
           alerts:
             - type: discord
               send-on-resolved: true
+        - name: Garage Gateway (StPetersburg)
+          group: storage
+          url: tcp://garage-gateway.garage:3900
+          interval: 60s
+          conditions:
+            - "[CONNECTED] == true"
+            - "[RESPONSE_TIME] < 1000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
         - name: Garage Ottawa
           group: storage
           url: tcp://ottawa-garage.garage:3900


### PR DESCRIPTION
# Gatus: Add Gateway-Tier Garage Checks

Gatus was only monitoring the **storage** tier (`garage.garage:3900`) for Garage health. The S3 client path goes through the **gateway** tier (`garage-gateway.garage:3900`), so a gateway-only outage stayed green in the dashboard while all S3 clients failed.

Added `tcp://garage-gateway.garage:3900` checks to all 3 Gatus instances:

| Cluster | Check Name |
|---------|-----------|
| Ottawa | Garage Gateway |
| Robbinsdale | Garage Gateway (Robbinsdale) |
| StPetersburg | Garage Gateway (StPetersburg) |

Keeps the existing storage checks — they're useful for distinguishing storage-down vs gateway-down.