### PR TITLE
feat: add Cache-Control headers to Garage web HTTPRoutes via Envoy Gateway

### DIFF
--- a/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/assistant-raj/httproute-web.yaml
@@ -30,6 +30,11 @@ spec:
         - type: URLRewrite
           urlRewrite:
             hostname: "raj-assistant-web.${COMMON_DOMAIN}"
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Cache-Control
+                value: "public, max-age=3600"
       backendRefs:
         - group: ""
           kind: Service

--- a/kubernetes/apps/base/agents/agents/app/teaspoon/httproute-web.yaml
+++ b/kubernetes/apps/base/agents/agents/app/teaspoon/httproute-web.yaml
@@ -50,6 +50,11 @@ spec:
         - type: URLRewrite
           urlRewrite:
             hostname: "teaspoon-web.${COMMON_DOMAIN}"
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Cache-Control
+                value: "public, max-age=3600"
       backendRefs:
         - group: ""
           kind: Service

--- a/kubernetes/apps/base/garage/garage/httproute-web.yaml
+++ b/kubernetes/apps/base/garage/garage/httproute-web.yaml
@@ -37,6 +37,11 @@ spec:
         - type: URLRewrite
           urlRewrite:
             hostname: "keiretsu.${COMMON_DOMAIN}"
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Cache-Control
+                value: "public, max-age=3600"
       backendRefs:
         - group: ""
           kind: Service

--- a/kubernetes/components/cdn-site/httproute.yaml
+++ b/kubernetes/components/cdn-site/httproute.yaml
@@ -30,6 +30,11 @@ spec:
         - type: URLRewrite
           urlRewrite:
             hostname: "${BUCKET}.${COMMON_DOMAIN}"
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Cache-Control
+                value: "public, max-age=3600"
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
## Why

Garage's web API handler on port 3902 is slow: ~40ms base overhead per request + ~300ms to serve a 182KB index.html (from inside the cluster — external adds more). No `Cache-Control` headers were set, so browsers re-fetched everything on every load. This is why `trades.rajsingh.info` feels like "a second to load."

## What

Added `ResponseHeaderModifier` filter to 4 HTTPRoutes that serve Garage web content via Envoy Gateway:

| Route | Site(s) |
|-------|---------|
| cdn-site component template | trades.rajsingh.info + future CDN sites |
| garage-web | keiretsu.top |
| teaspoon-web | teaspoon.agents.keiretsu.top |
| raj-assistant-web | raj.agents.keiretsu.top |

Each now adds `Cache-Control: public, max-age=3600` to the response from Garage. First load still takes ~300ms, but repeat visits within 1 hour are instant from browser cache.

## Baseline

```
Before — trades.rajsingh.info/index.html (182KB):
  Run 1: 0.291s, Run 2: 0.226s, Run 3: 0.227s
  Headers: no Cache-Control — every load fresh

After — browser caches for 1 hour, repeat loads = 0ms
```

## Next

If you want Envoy-level caching (first visitor to Envoy also gets cached response instead of proxying to Garage), I can follow up with an `EnvoyPatchPolicy` to inject Envoy's HTTP cache filter.