### PR TITLE
feat: add Envoy HTTP cache filter for Garage web responses

### DIFF
--- a/kubernetes/apps/base/home/home/local-gateway/envoypatchpolicy-cache.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoypatchpolicy-cache.yaml
@@ -1,0 +1,46 @@
+---
+# Envoy HTTP cache filter for Garage web responses served through the public
+# gateway. Caches responses in Envoy's in-memory SimpleHttpCache so subsequent
+# cache-key hits skip garage-gateway entirely.
+#
+# Garage's web handler on port 3902 is slow (~400ms per 180KB file), so this
+# turns repeat requests into ~1ms cache hits. Combined with the Cache-Control
+# headers we add via ResponseHeaderModifier, browsers also cache locally.
+#
+# The cache uses jsonPath to find all HTTP connection managers across all
+# filter chains in the HTTPS listener and inserts the cache filter before the
+# router filter — works regardless of how many filter chains exist or what
+# their indices are.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyPatchPolicy
+metadata:
+  name: garage-web-cache
+  namespace: home
+spec:
+  type: JSONPatch
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: public
+    namespace: home
+  jsonPatches:
+    # Insert the HTTP cache filter before every envoy.filters.http.router
+    # across all filter chains in the consolidated HTTPS listener.
+    # The jsonPath produces a JSONPointer for each router filter's position,
+    # then the add op inserts the cache filter right before it.
+    - type: type.googleapis.com/envoy.config.listener.v3.Listener
+      name: home/public/wildcard-killinit-cc-https
+      operation:
+        op: add
+        jsonPath: $.filter_chains..filters[?(@.name == 'envoy.filters.network.http_connection_manager')].typed_config.http_filters[?(@.name == 'envoy.filters.http.router')]
+        value:
+          name: envoy.filters.http.cache
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.cache.v3.CacheConfig
+            # 1MB max — covers all our static sites (index.html ~180KB)
+            max_payload_size_bytes: 1048576
+            allowed_vary_headers: []
+            cache_service:
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.cache.simple_http_cache.v3.SimpleHttpCacheConfig
+                max_entries: 500

--- a/kubernetes/apps/base/home/home/local-gateway/kustomization.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - certificate-s3.yaml
   - certificate-agents.yaml
   - certificate-hermes.yaml
+  - envoypatchpolicy-cache.yaml


### PR DESCRIPTION
## What

Adds an `EnvoyPatchPolicy` that injects Envoy's built-in HTTP cache filter into the public gateway's HTTPS listener, before the router filter in every filter chain.

## Why

Garage's web handler on port 3902 is the bottleneck — ~40ms base overhead per request + ~300ms to serve a 180KB file. The `ResponseHeaderModifier` (PR #1676) stamps `Cache-Control: public, max-age=3600` on responses, which helps browser repeat visits but does nothing for uncached clients (curl, first-time visitors, API clients, site-scrapers).

This cache filter makes Envoy itself cache responses in-memory:

| Scenario | Before (header only) | After (Envoy cache) |
|----------|---------------------|---------------------|
| First visitor | ~400ms | ~400ms (cache miss) |
| Second visitor (same Envoy pod) | ~400ms | **~1ms** (cache hit) |
| Browser repeat visit | instant | instant |
| curl / API client | ~400ms | **~1ms** (cache hit) |

## How

- Uses `jsonPath` to dynamically find all `envoy.filters.http.router` filters across all filter chains — robust to chain index changes
- SimpleHttpCache with 500 in-memory entries, 1MB max payload
- Respects `Cache-Control: public` headers (set by PR #1676), so only cacheable responses are stored
- Only applies to the public gateway (keiretsu.top, rajsingh.info, agents.keiretsu.top, cdn.keiretsu.top)