### PR TITLE
fix: remove namespace from EnvoyPatchPolicy targetRef

### DIFF
--- a/kubernetes/apps/base/home/home/local-gateway/envoypatchpolicy-cache.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoypatchpolicy-cache.yaml
@@ -22,7 +22,6 @@ spec:
     group: gateway.networking.k8s.io
     kind: Gateway
     name: public
-    namespace: home
   jsonPatches:
     # Insert the HTTP cache filter before every envoy.filters.http.router
     # across all filter chains in the consolidated HTTPS listener.


### PR DESCRIPTION
Flux dry-run failed on the Envoy cache filter policy (PR #1679) with: `field not declared in schema` for `.spec.targetRef.namespace`.

The CRD doesn't allow `namespace` in `targetRef` — it's implied from the policy's `metadata.namespace`. Removed it.