### PR TITLE
fix: enable EnvoyPatchPolicy in EnvoyGateway config

### DIFF
--- a/kubernetes/apps/base/envoy-gateway-system/envoy-gw-common/install/helmrelease.yaml
+++ b/kubernetes/apps/base/envoy-gateway-system/envoy-gw-common/install/helmrelease.yaml
@@ -25,3 +25,4 @@ spec:
       envoyGateway:
         extensionApis:
           enableBackend: true
+          enableEnvoyPatchPolicy: true


### PR DESCRIPTION
EnvoyPatchPolicy is disabled by default. The garage web cache filter (PR #1679) was rejected with:

    EnvoyPatchPolicy is disabled in the EnvoyGateway configuration

Added `extensionApis.enableEnvoyPatchPolicy: true` to the HelmRelease values.