### PR TITLE
fix: remove zot cluster proxy config causing proxy loop

### DIFF
--- a/kubernetes/apps/base/zot/zot/helmrelease.yaml
+++ b/kubernetes/apps/base/zot/zot/helmrelease.yaml
@@ -86,13 +86,6 @@ spec:
               "multipartcopymaxconcurrency": 8
             }
           },
-          "cluster": {
-            "members": [
-              "robbinsdale-zot:5000",
-              "ottawa-zot:5000"
-            ],
-            "hashKey": "${ZOT_CLUSTER_HASHKEY}"
-          },
           "http": {
             "address": "0.0.0.0",
             "port": "5000",
@@ -135,21 +128,3 @@ spec:
         }
     secretFiles:
       htpasswd: "${COMMON_OCI}"
-  postRenderers:
-    # Inject a hostAlias so the local zot pod's lookup of its own peer name
-    # (e.g. ottawa-zot in the Ottawa cluster) returns 127.0.0.1, satisfying
-    # zot's GetLocalMemberClusterSocket self-identification check at startup.
-    # Without this, zot panics because the ExternalName Service for its own
-    # location resolves to the common-egress proxy IP, not the pod IP.
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: zot
-            patch: |
-              - op: add
-                path: /spec/template/spec/hostAliases
-                value:
-                  - ip: 127.0.0.1
-                    hostnames:
-                      - ${LOCATION}-zot


### PR DESCRIPTION
## Problem

All Forgejo CI runs for corp/bhaiya fail within 3 seconds. The runner's dinD container cannot pull the `ci-runner:latest` step image from `oci.cdn.keiretsu.top`.

## Root Cause

The zot config has `cluster.members` configured with `[robbinsdale-zot:5000, ottawa-zot:5000]`, enabling the legacy cluster proxy. When a request for `keiretsu/ci-runner` blobs hits Ottawa's zot, the consistent hash routes it to Robbinsdale's zot via ExternalName → Tailscale. Robbinsdale's zot then tries to proxy back (same hashKey), but the hop count is already 1 → `"cannot proxy an already proxied request"` → HTTP 500.

Since both zot instances share Garage S3 storage + Redis cache, the cluster proxy is unnecessary. Each instance serves all repositories independently.

## Fix

1. Remove the `cluster` block (members + hashKey) from zot config — switches from legacy cluster proxy to stateless scale-out mode
2. Remove the `postRenderers` hostAliases hack (was only needed for `GetLocalMemberClusterSocket` self-identification check)