### PR TITLE
fix: use configuration.general.veleroNamespace in velero-ui HelmRelease

### DIFF
--- a/kubernetes/apps/base/velero/velero-ui/helmrelease.yaml
+++ b/kubernetes/apps/base/velero/velero-ui/helmrelease.yaml
@@ -28,11 +28,11 @@ spec:
       tag: ""
 
     # Point at the velero namespace (same cluster, in-cluster auth via service account)
-    veleroNamespace: velero-system
-
-    # Use default password from cluster-secrets
-    secretPassPhrase:
-      value: "${DEFAULT_PASSWORD}"
+    configuration:
+      general:
+        veleroNamespace: velero-system
+        secretPassPhrase:
+          value: "${DEFAULT_PASSWORD}"
 
     # Override basic auth password (admin/${DEFAULT_PASSWORD}) from cluster-secrets
     env:


### PR DESCRIPTION
The velero-ui chart reads the velero namespace from `configuration.general.veleroNamespace`, not the top-level `veleroNamespace` key. This caused the pod to look for the Velero server in namespace `velero` instead of `velero-system`, crashing with `Error: Cannot find Velero server!`.

## Changes
- `kubernetes/apps/base/velero/velero-ui/helmrelease.yaml`: Fixed values structure to use `configuration.general.veleroNamespace`