### PR TITLE
fix: create velero namespace and use configuration.general.veleroNamespace

### DIFF
--- a/kubernetes/apps/base/velero/velero-ui/helmrelease.yaml
+++ b/kubernetes/apps/base/velero/velero-ui/helmrelease.yaml
@@ -28,11 +28,11 @@ spec:
       tag: ""
 
     # Point at the velero namespace (same cluster, in-cluster auth via service account)
-    veleroNamespace: velero-system
-
-    # Use default password from cluster-secrets
-    secretPassPhrase:
-      value: "${DEFAULT_PASSWORD}"
+    configuration:
+      general:
+        veleroNamespace: velero-system
+        secretPassPhrase:
+          value: "${DEFAULT_PASSWORD}"
 
     # Override basic auth password (admin/${DEFAULT_PASSWORD}) from cluster-secrets
     env:

--- a/kubernetes/apps/base/velero/velero-ui/kustomization.yaml
+++ b/kubernetes/apps/base/velero/velero-ui/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./namespace.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./securitypolicy.yaml

--- a/kubernetes/apps/base/velero/velero-ui/namespace.yaml
+++ b/kubernetes/apps/base/velero/velero-ui/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+  labels:
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
Two fixes for the velero-ui deployment:\n\n1. **HelmRelease values path**: The chart reads  from , not the top-level  key.\n2. **Missing  namespace**: The chart hardcodes a Role and RoleBinding in namespace  (not ). Without this namespace, the Helm install fails on every retry.\n\nAdding the namespace and fixing the config path gets the pod running.