### PR TITLE
fix: remove home-assistant from Velero home-backup schedule

### DIFF
--- a/kubernetes/apps/base/velero/velero/helmrelease.yaml
+++ b/kubernetes/apps/base/velero/velero/helmrelease.yaml
@@ -91,5 +91,4 @@ spec:
           ttl: "720h"
           includedNamespaces:
             - home
-            - home-assistant
           defaultVolumesToFsBackup: true


### PR DESCRIPTION
The `home-assistant` namespace was consolidated into `home` during the VolSync removal (#1666), but the Velero home-backup schedule still listed `home-assistant` in `includedNamespaces`. This caused every daily backup to be **PartiallyFailed** with:\n\n> `fail to get the namespace home-assistant specified in backup.Spec.IncludedNamespaces`\n\n**Also contributing to the failure:** The 10m resource timeout (`velero.io/resource-timeout=10m0s`) fired while waiting for node-agent pods to list during Kopia PVB preparation — but that's a separate issue. The namespace error was the primary cause of the backup being marked PartiallyFailed.\n\n**Fix:** Remove `home-assistant` from the schedule's `includedNamespaces`. All resources are already covered by the `home` namespace entry.\n\nCloses the PartiallyFailed backup on `velero.killinit.cc`.