### PR TITLE
velero: granular per-cluster backup schedules + exclude data volumes

### DIFF
--- a/kubernetes/apps/base/media/media-ottawa/autobrr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/autobrr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: autobrr
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-1080p/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-1080p
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-4k/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-4k
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-4kremux/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-4kremux/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-4kremux
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-anime/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-anime
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/jellyfin/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/jellyfin/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: jellyfin
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/jellyseerr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/jellyseerr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: jellyseerr
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/lidarr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/lidarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: lidarr
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/overseerr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/overseerr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: overseerr
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/plex/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/plex/app.yaml
@@ -15,6 +15,8 @@ spec:
       app: plex
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media-volume
       labels:
         app: plex
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/prowlarr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/prowlarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: prowlarr
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/qb-pvt/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/qb-pvt/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: qbittorrent-pvt
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/qb/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/qb/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: qbittorrent
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/radarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-1080p/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-1080p
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/radarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-4k/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-4k
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/radarr-4kremux/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-4kremux/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-4kremux
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/radarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-anime/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-anime
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/sabnzbd/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sabnzbd/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sabnzbd
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/sonarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sonarr-1080p/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-1080p
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/sonarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sonarr-4k/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-4k
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/sonarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sonarr-anime/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-anime
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/tautulli/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/tautulli/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: tautulli
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/wizarr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/wizarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: wizarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/audioarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/audioarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: audioarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/autobrr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/autobrr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: autobrr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/bazarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/bazarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/jellyfin/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/jellyfin/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: jellyfin
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/jellyseerr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/jellyseerr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: jellyseerr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/lidarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/lidarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: lidarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/overseerr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/overseerr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: overseerr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/plex/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/plex/app.yaml
@@ -16,6 +16,8 @@ spec:
       app: plex
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media-volume
       labels:
         app: plex
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/prowlarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/prowlarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: prowlarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/radarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/radarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/readarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/readarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: readarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/sabnzbd/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/sabnzbd/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sabnzbd
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/sonarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/sonarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/tautulli/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/tautulli/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: tautulli
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/transmission-books/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/transmission-books/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: transmission-books
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/transmission-movies/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/transmission-movies/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: transmission-movies
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/transmission-music/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/transmission-music/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: transmission-music
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/transmission-tv/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/transmission-tv/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: transmission-tv
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/wizarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/wizarr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes-excludes: media
       labels:
         app: wizarr
     spec:

--- a/kubernetes/apps/base/velero/velero/helmrelease.yaml
+++ b/kubernetes/apps/base/velero/velero/helmrelease.yaml
@@ -65,30 +65,3 @@ spec:
 
     metrics:
       enabled: true
-
-    schedules:
-      media-backup:
-        schedule: "0 6 * * *"
-        useOwnerReferencesInBackup: true
-        template:
-          ttl: "720h"
-          includedNamespaces:
-            - media
-          defaultVolumesToFsBackup: true
-      hermes-backup:
-        schedule: "0 7 * * *"
-        useOwnerReferencesInBackup: true
-        template:
-          ttl: "720h"
-          includedNamespaces:
-            - hermes
-            - agents
-          defaultVolumesToFsBackup: true
-      home-backup:
-        schedule: "0 9 * * *"
-        useOwnerReferencesInBackup: true
-        template:
-          ttl: "720h"
-          includedNamespaces:
-            - home
-          defaultVolumesToFsBackup: true

--- a/kubernetes/apps/ottawa/velero/schedules/hermes-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/hermes-backup.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: hermes-backup
+  namespace: velero-system
+spec:
+  schedule: "0 7 * * *"
+  template:
+    ttl: 720h
+    includedNamespaces:
+      - hermes
+      - agents
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: home-backup
+  namespace: velero-system
+spec:
+  schedule: "0 9 * * *"
+  template:
+    ttl: 720h
+    includedNamespaces:
+      - home
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./media-config-backup.yaml
+  - ./hermes-backup.yaml
+  - ./home-backup.yaml

--- a/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: media-config-backup
+  namespace: velero-system
+spec:
+  schedule: "0 6 * * *"
+  template:
+    ttl: 720h
+    includedNamespaces:
+      - media
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/robbinsdale/velero/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/velero/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./velero.yaml
+  - ./schedules

--- a/kubernetes/apps/robbinsdale/velero/schedules/home-backup.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/home-backup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: home-backup
+  namespace: velero-system
+spec:
+  schedule: "0 9 * * *"
+  template:
+    ttl: 720h
+    includedNamespaces:
+      - home
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/robbinsdale/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/kustomization.yaml
@@ -1,7 +1,6 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./velero.yaml
-  - ./velero-ui.yaml
-  - ./schedules
+  - ./media-config-backup.yaml
+  - ./home-backup.yaml

--- a/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: media-config-backup
+  namespace: velero-system
+spec:
+  schedule: "0 6 * * *"
+  template:
+    ttl: 720h
+    includedNamespaces:
+      - media
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/stpetersburg/velero/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/velero/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - ./namespace.yaml
   - ./velero.yaml
   - ./garage-ottawa-bsl.yaml
+  - ./schedules

--- a/kubernetes/apps/stpetersburg/velero/schedules/hermes-backup.yaml
+++ b/kubernetes/apps/stpetersburg/velero/schedules/hermes-backup.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: hermes-backup
+  namespace: velero-system
+spec:
+  schedule: "0 7 * * *"
+  template:
+    ttl: 720h
+    includedNamespaces:
+      - hermes
+      - agents
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/stpetersburg/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/velero/schedules/kustomization.yaml
@@ -1,7 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./velero.yaml
-  - ./velero-ui.yaml
-  - ./schedules
+  - ./hermes-backup.yaml


### PR DESCRIPTION
## Summary

Moves Velero backup schedules out of the shared HelmRelease into per-cluster standalone Schedule CRDs. Adds `backup.velero.io/backup-volumes-excludes` annotations to media deployments to prevent Kopia from backing up multi-Ti data volumes.

## Problem

The base HelmRelease defined all schedules with `defaultVolumesToFsBackup: true`, shared across all 3 clusters. This caused Velero to try backing up **every PVC** in the media namespace — including 20Ti SMB media shares and 20Ti torrent download volumes that are completely replaceable.

Key offenders:
- `media-share` (20Ti) — mounted in every *arr app
- `qbittorrent-downloads` (20Ti) — permanent downloads
- `media-share-robbinsdale` (20Ti)

## Changes

### 1. Schedules moved out of HelmRelease → per-cluster Schedule CRDs

Old: all schedules in `base/velero/velero/helmrelease.yaml`
New: standalone `Schedule` CRDs per cluster

| Cluster | Schedules |
|---------|-----------|
| Ottawa  | `media-config-backup` (06:00), `hermes-backup` (07:00), `home-backup` (09:00) |
| Robbinsdale | `media-config-backup` (06:00), `home-backup` (09:00) |
| StPetersburg | `hermes-backup` (07:00) |

### 2. Exclude annotations on media deployments

Added `backup.velero.io/backup-volumes-excludes` to every media deployment that mounts media-share (20Ti) or download volumes:

- **Ottawa (23 apps):** most *arr → exclude `media`, qbittorrent → exclude `downloads-volume`, plex → exclude `media-volume`
- **Robbinsdale (19 apps):** same patterns for transmission instead of qbittorrent

Apps without media-share mounts (`maintainerr`, `tracearr`) left untouched.

### 3. Per-cluster kustomization updates

Each clusters `velero/kustomization.yaml` now includes a `./schedules` subdirectory.

## Files Changed

- `kubernetes/apps/base/velero/velero/helmrelease.yaml` — removed schedules section
- `kubernetes/apps/{ottawa,robbinsdale,stpetersburg}/velero/schedules/*.yaml` — 3 new directories with Schedule CRDs
- `kubernetes/apps/{ottawa,robbinsdale,stpetersburg}/velero/kustomization.yaml` — added schedules/ resource
- `kubernetes/apps/base/media/media-ottawa/*/app.yaml` — 23 app annotations
- `kubernetes/apps/base/media/media-robbinsdale/*/app.yaml` — 19 app annotations