### PR TITLE
fix(bhaiya): remove stale Forgejo env vars from deployment

### DIFF
--- a/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
+++ b/kubernetes/apps/base/bhaiya/bhaiya/app/deployment.yaml
@@ -41,13 +41,6 @@ spec:
               value: ":8080"
             - name: BHAIYA_DB_PATH
               value: /data/bhaiya.db
-            - name: BHAIYA_FORGEJO_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: bhaiya-forgejo-token
-                  key: BHAIYA_FORGEJO_TOKEN
-            - name: BHAIYA_FORGEJO_API_URL
-              value: "https://forgejo.keiretsu.top/api/v1"
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary

bhaiya v0.2.1 removes  and  from its config — templates are now embedded via `go:embed` and no longer fetched from Forgejo at runtime. The corresponding env vars in the Deployment manifest reference config keys that no longer exist.

Also removes the `BHAIYA_FORGEJO_TOKEN` Secret reference — the secret can be cleaned up separately if desired.

### Changes
- Remove `BHAIYA_FORGEJO_TOKEN` and `BHAIYA_FORGEJO_API_URL` env vars from the bhaiya container spec

### Automation
No new Flux-managed resources are needed:
- Workspace HTTPRoutes + SecurityPolicies are created **dynamically** by bhaiya's new ExposeRoute implementation
- All such objects carry an ownerRef to the `ws-<slug>` ConfigMap and are cascade-deleted with the workspace
- The existing Role already covers `httproutes` and `securitypolicies` CRUD