### PR TITLE
velero: fix StPetersburg schedule - replace hermes with home-assistant

### DIFF
--- a/kubernetes/apps/stpetersburg/velero/schedules/home-assistant-backup.yaml
+++ b/kubernetes/apps/stpetersburg/velero/schedules/home-assistant-backup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: home-assistant-backup
+  namespace: velero-system
+spec:
+  schedule: "0 9 * * *"
+  template:
+    ttl: 720h
+    includedNamespaces:
+      - home-assistant
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/stpetersburg/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/velero/schedules/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./hermes-backup.yaml
+  - ./home-assistant-backup.yaml


### PR DESCRIPTION
StPetersburg does not have `hermes` or `agents` namespaces (those are Ottawa-only), so the `hermes-backup` schedule was running for ~6 seconds, finding nothing, and reporting 2 errors per run.

Replaced with `home-assistant-backup` which backs up the `home-assistant` namespace (contains ~10Gi `homeassistant-config` PVC).

This was a gap I found during the post-merge audit of #1706.