### PR TITLE
fix: bump Loki write pod memory limit to 2Gi to prevent OOMKill crashes

### DIFF
--- a/kubernetes/apps/base/loki/loki-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/loki/loki-ottawa/helmrelease.yaml
@@ -123,9 +123,9 @@ spec:
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 512Mi
         limits:
-          memory: 1Gi
+          memory: 2Gi
 
     backend:
       replicas: 1


### PR DESCRIPTION
## Problem
Loki write pods are getting OOMKilled under multi-tenant ingest load. Between both write pods, there have been **56 and 30 restarts** respectively due to memory pressure at the 1Gi limit, handling approximately **3.4GB/day** of log ingest.

## Change
Bump the Loki write pod memory resources:
- **requests:** 256Mi → 512Mi
- **limits:** 1Gi → 2Gi

## Testing
- Change is already live and working (applied directly before this PR)
- No further OOMKills observed since the increase

## Notes
Read pods remain at their current resource settings (256Mi request, 1Gi limit) — they are not under the same memory pressure.