### PR TITLE
fix: add Talos machine-logging patch for Robbinsdale to forward kernel/system logs to fluent-bit

### DIFF
--- a/clusters/talos-robbinsdale/bootstrap/talos/patches/global/machine-logging.yaml
+++ b/clusters/talos-robbinsdale/bootstrap/talos/patches/global/machine-logging.yaml
@@ -1,0 +1,7 @@
+machine:
+  logging:
+    destinations:
+      - endpoint: "tcp://10.50.69.51:5170/"
+        format: "json_lines"
+        extraTags:
+          cluster: robbinsdale

--- a/clusters/talos-robbinsdale/bootstrap/talos/talconfig.yaml
+++ b/clusters/talos-robbinsdale/bootstrap/talos/talconfig.yaml
@@ -89,6 +89,7 @@ patches:
   - "@./patches/global/metrics-server.yaml"
   - "@./patches/global/sysctls.yaml"
   - "@./patches/global/node-labels.yaml"
+  - "@./patches/global/machine-logging.yaml"
 
 # Control plane nodes config
 controlPlane:


### PR DESCRIPTION
## Problem
Robbinsdale Talos nodes were not shipping kernel/system logs to Loki. Ottawa and StPetersburg both have the `machine-logging.yaml` patch configured, but Robbinsdale was missing it entirely.

## Change
Added `clusters/talos-robbinsdale/bootstrap/talos/patches/global/machine-logging.yaml` and referenced it in `talconfig.yaml` global patches list.

This configures Talos to forward journald logs to fluent-bit's TCP input on port `10.50.69.51:5170` with JSON lines format and a `cluster: robbinsdale` tag.