### PR TITLE
feat(victoria-logs): centralize log storage on Ottawa, fix _msg field

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -39,6 +39,7 @@ data:
   # whereas the storage service has NO endpoints if local storage is destroyed. Swap this
   # one value to repoint every app — all S3 clients use ${COMMON_S3_ENDPOINT}.
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
+  VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
   # Garage: storage layout hand-managed per-node in clusters/talos-ottawa/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway

--- a/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
@@ -39,6 +39,7 @@ data:
   # whereas the storage service has NO endpoints if local storage is destroyed. Swap this
   # one value to repoint every app — all S3 clients use ${COMMON_S3_ENDPOINT}.
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
+  VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
   # Garage: storage layout hand-managed per-node in clusters/talos-robbinsdale/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway

--- a/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
@@ -39,6 +39,7 @@ data:
   # whereas the storage service has NO endpoints if local storage is destroyed. Swap this
   # one value to repoint every app — all S3 clients use ${COMMON_S3_ENDPOINT}.
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
+  VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
   # Garage: STORAGE layout is hand-managed per Spark node via GarageNode CRs in
   # clusters/talos-stpetersburg/apps/garage (decoupled from clusters/common so

--- a/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
+++ b/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
@@ -67,9 +67,10 @@ spec:
         [OUTPUT]
             Name                   loki
             Match                  kube.*
-            Host                   victoria-logs-victoria-logs-single-server.monitoring
+            Host                   ${VICTORIA_LOGS_HOST}
             Port                   9428
             Uri                    /insert/loki/api/v1/push
+            header                 VL-Msg-Field log
             labels                 cluster=${CLUSTER_NAME}, job=fluent-bit
             label_keys             $kubernetes['namespace_name'],$kubernetes['pod_name'],$kubernetes['container_name'],$stream
             remove_keys            kubernetes,stream
@@ -80,14 +81,14 @@ spec:
         [OUTPUT]
             Name                   loki
             Match                  talos.*
-            Host                   victoria-logs-victoria-logs-single-server.monitoring
+            Host                   ${VICTORIA_LOGS_HOST}
             Port                   9428
             Uri                    /insert/loki/api/v1/push
+            header                 VL-Msg-Field log
             labels                 cluster=${CLUSTER_NAME}, job=talos
             label_keys             $talos-service
             line_format            json
             compress               gzip
-
     extraPorts:
       - port: 5170
         containerPort: 5170

--- a/kubernetes/apps/base/victoria-logs/victoria-logs-forwarder/egress.yaml
+++ b/kubernetes/apps/base/victoria-logs/victoria-logs-forwarder/egress.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: victoria-logs-victoria-logs-single-server
+  namespace: monitoring
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: victoria-logs.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  externalName: placeholder
+  type: ExternalName
+  ports:
+    - name: http
+      port: 9428
+      protocol: TCP

--- a/kubernetes/apps/base/victoria-logs/victoria-logs-forwarder/kustomization.yaml
+++ b/kubernetes/apps/base/victoria-logs/victoria-logs-forwarder/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - egress.yaml

--- a/kubernetes/apps/base/victoria-logs/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs/victoria-logs/app/helmrelease.yaml
@@ -56,3 +56,13 @@ spec:
               - op: add
                 path: /spec/folder
                 value: VictoriaMetrics
+          - target:
+              kind: Service
+              name: victoria-logs-victoria-logs-single-server
+            patch: |
+              - op: add
+                path: /metadata/annotations/tailscale.com~1proxy-group
+                value: common-egress
+              - op: add
+                path: /metadata/annotations/tailscale.com~1tailnet-fqdn
+                value: victoria-logs.keiretsu.ts.net

--- a/kubernetes/apps/robbinsdale/victoria-logs/victoria-logs.yaml
+++ b/kubernetes/apps/robbinsdale/victoria-logs/victoria-logs.yaml
@@ -11,7 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: monitoring
-  path: ./kubernetes/apps/base/victoria-logs/victoria-logs/app
+  path: ./kubernetes/apps/base/victoria-logs/victoria-logs-forwarder
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/stpetersburg/victoria-logs/victoria-logs.yaml
+++ b/kubernetes/apps/stpetersburg/victoria-logs/victoria-logs.yaml
@@ -11,7 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: monitoring
-  path: ./kubernetes/apps/base/victoria-logs/victoria-logs/app
+  path: ./kubernetes/apps/base/victoria-logs/victoria-logs-forwarder
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

Centralizes log storage: VictoriaLogs runs **only on Ottawa** with its 50Gi Ceph PV. Robbinsdale and St. Pete forward logs across Tailscale — no local storage on those clusters.

### Changes

**Fix _msg field (the warning you saw)**
- Added `header VL-Msg-Field log` to Fluent Bit Loki output plugin
- VictoriaLogs now properly maps the `log` JSON field to `_msg`
- Without this, all ingested logs had `_msg: "missing _msg field"`

**Centralization**
- Added Tailscale egress annotations to Ottawa's VictoriaLogs Service so the Tailscale operator creates a cross-cluster route at `victoria-logs.keiretsu.ts.net`
- Created `kubernetes/apps/base/victoria-logs/victoria-logs-forwarder/` — just an ExternalName Service pointing to the Tailscale egress FQDN (no HelmRelease, no PV)
- Robbinsdale/St. Pete victoria-logs KS points to the forwarder path instead of the HelmRelease path
- Added `VICTORIA_LOGS_HOST` to per-cluster `cluster-settings` ConfigMaps (used by Fluent Bit via Flux substitution)

**Log flow:**
```
Robbinsdale fluent-bit → victoria-logs-victoria-logs-single-server.monitoring (ExternalName)
  → Tailscale egress (ts-victoria-logs-xxxxx.tailscale.svc.cluster.local)
  → Ottawa VictoriaLogs pod (50Gi Ceph PV, 7d retention)

St. Pete → same flow via Tailscale
Ottawa → direct to local service
```

### Storage savings
- Robbinsdale: frees 50Gi Ceph NVMe
- St. Petersburg: frees 50Gi local-path
- Ottawa: unchanged, 50Gi Ceph RBD