### PR TITLE
feat(teslamate): add TeslaMate deployment to Ottawa cluster

### DIFF
--- a/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/referencegrant.yaml
@@ -21,6 +21,9 @@ spec:
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: velero-system
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: teslamate
   to:
     - group: ""
       kind: Service

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./cnpg
   - ./k6
   - ./vllm
+  - ./teslamate

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/teslamate/dashboards.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/teslamate/dashboards.yaml
@@ -1,0 +1,322 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-overview
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/overview.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-charge-level
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charge-level.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-charges
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charges.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-charging-stats
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charging-stats.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-drives
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drives.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-drive-stats
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drive-stats.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-efficiency
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/efficiency.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-trip
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/trip.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-battery-health
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/battery-health.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-projected-range
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/projected-range.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-locations
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/locations.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-visited
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/visited.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-mileage
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/mileage.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-states
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/states.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-timeline
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/timeline.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-updates
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/updates.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-vampire-drain
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/vampire-drain.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-statistics
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/statistics.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-database-info
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/database-info.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/teslamate/internal-reports.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/teslamate/internal-reports.yaml
@@ -1,0 +1,67 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-internal-charge-details
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/internal/charge-details.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-internal-drive-details
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/internal/drive-details.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-internal-home
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/internal/home.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: teslamate-reports-dutch-tax
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: "168h"
+  folder: TeslaMate
+  url: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/reports/dutch-tax.json
+  datasources:
+    - inputName: DS_POSTGRES_TSLM
+      datasourceName: TeslaMate

--- a/kubernetes/apps/base/monitoring/grafana/dashboards/teslamate/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/teslamate/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dashboards.yaml
+  - internal-reports.yaml

--- a/kubernetes/apps/base/monitoring/grafana/datasources/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./mimir-robbinsdale.yaml
   - ./mimir-ottawa.yaml
   - ./mimir-stpetersburg.yaml
+  - ./teslamate.yaml

--- a/kubernetes/apps/base/monitoring/grafana/datasources/teslamate.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/teslamate.yaml
@@ -1,0 +1,34 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: teslamate-postgres
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  valuesFrom:
+    - targetPath: "secureJsonData.password"
+      valueFrom:
+        secretKeyRef:
+          name: teslamate-postgres-app
+          namespace: teslamate
+          key: password
+  datasource:
+    name: TeslaMate
+    type: postgres
+    access: proxy
+    url: teslamate-postgres-rw.teslamate.svc.cluster.local:5432
+    user: teslamate
+    secureJsonData:
+      password: "${password}"
+    jsonData:
+      database: teslamate
+      postgresVersion: 1600
+      sslmode: disable
+      connMaxLifetime: 14400
+      maxIdleConns: 2
+      maxOpenConns: 0
+    isDefault: false
+    editable: false

--- a/kubernetes/apps/base/teslamate/teslamate/app/deployment.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: teslamate
+  namespace: teslamate
+  labels:
+    app: teslamate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: teslamate
+  template:
+    metadata:
+      labels:
+        app: teslamate
+    spec:
+      containers:
+        - name: teslamate
+          image: teslamate/teslamate:4.0.1
+          ports:
+            - containerPort: 4000
+              name: http
+          env:
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: teslamate-secret
+                  key: ENCRYPTION_KEY
+            - name: DATABASE_USER
+              value: teslamate
+            - name: DATABASE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: teslamate-postgres-app
+                  key: password
+            - name: DATABASE_NAME
+              value: teslamate
+            - name: DATABASE_HOST
+              value: teslamate-postgres-rw.teslamate.svc.cluster.local
+            - name: DATABASE_PORT
+              value: "5432"
+            - name: DATABASE_SSL
+              value: "false"
+            - name: DISABLE_MQTT
+              value: "true"
+            - name: VIRTUAL_HOST
+              value: teslamate.keiretsu.top
+            - name: CHECK_ORIGIN
+              value: "true"
+            - name: TZ
+              value: America/Chicago
+          securityContext:
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000

--- a/kubernetes/apps/base/teslamate/teslamate/app/httproute.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/httproute.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: teslamate
+  namespace: teslamate
+spec:
+  parentRefs:
+    - name: private
+      namespace: home
+    - name: ts
+      namespace: home
+  hostnames:
+    - teslamate.keiretsu.top
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: teslamate
+          port: 4000
+          weight: 1
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: "X-Forwarded-Proto"
+                value: "https"
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/teslamate/teslamate/app/httproute.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/httproute.yaml
@@ -5,9 +5,17 @@ metadata:
   namespace: teslamate
 spec:
   parentRefs:
-    - name: private
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
       namespace: home
-    - name: ts
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
       namespace: home
   hostnames:
     - teslamate.keiretsu.top

--- a/kubernetes/apps/base/teslamate/teslamate/app/kustomization.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: teslamate
+resources:
+  - namespace.yaml
+  - pg.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - securitypolicy.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/teslamate/teslamate/app/namespace.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: teslamate

--- a/kubernetes/apps/base/teslamate/teslamate/app/pg.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/pg.yaml
@@ -1,0 +1,51 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: teslamate-postgres
+  namespace: teslamate
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  postgresql:
+    shared_preload_libraries: []
+  bootstrap:
+    initdb:
+      database: teslamate
+      owner: teslamate
+      dataChecksums: true
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 8Gi
+  # Enable Barman Cloud plugin for S3 backups
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: teslamate-s3-store
+        serverName: teslamate-postgres
+
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: keiretsu
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: teslamate-s3-store
+          serverName: teslamate-postgres
+---
+# S3 backup schedule using Barman Cloud
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: teslamate-postgres-s3
+  namespace: teslamate
+spec:
+  schedule: "0 0 23 * * *"  # Daily at 11 PM
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: teslamate-postgres

--- a/kubernetes/apps/base/teslamate/teslamate/app/secret.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: teslamate-secret
+  namespace: teslamate
+type: Opaque
+stringData:
+  ENCRYPTION_KEY: "${TESLAMATE_ENCRYPTION_KEY}"

--- a/kubernetes/apps/base/teslamate/teslamate/app/securitypolicy.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/securitypolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: teslamate-tinyauth
+  namespace: teslamate
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: teslamate
+  extAuth:
+    grpcService:
+      authority: tinyauth.home.svc.cluster.local
+      tinyauth.home.svc.cluster.local:
+        - name: tinyauth
+          port: 9000

--- a/kubernetes/apps/base/teslamate/teslamate/app/service.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: teslamate
+  namespace: teslamate
+  labels:
+    app: teslamate
+spec:
+  selector:
+    app: teslamate
+  ports:
+    - name: http
+      port: 4000
+      targetPort: 4000

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - ./kro-system
   - ./kube-system
   - ./lan
+  - ./teslamate
   - ./mimir
   - ./media
   - ./open-cluster-management

--- a/kubernetes/apps/ottawa/teslamate/kustomization.yaml
+++ b/kubernetes/apps/ottawa/teslamate/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - teslamate.yaml

--- a/kubernetes/apps/ottawa/teslamate/teslamate.yaml
+++ b/kubernetes/apps/ottawa/teslamate/teslamate.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app teslamate
+  namespace: flux-system
+spec:
+  targetNamespace: teslamate
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-system
+    - name: home-local-gateway
+  path: ./kubernetes/apps/base/teslamate/teslamate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-settings
+      - kind: Secret
+        name: common-secrets
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: true
+      - kind: Secret
+        name: cluster-secrets
+        optional: true


### PR DESCRIPTION
## Summary

Adds TeslaMate v4.0.1 — a self-hosted Tesla data logger — to the Ottawa cluster.

## Architecture

### TeslaMate namespace
| Resource | Details |
|----------|---------|
| **PostgreSQL** | CNPG Cluster, 2 instances, 8Gi, daily S3 backups via barman-cloud |
| **TeslaMate app** | Deployment (1 replica), reads ENCRYPTION_KEY from cluster-secrets |
| **HTTPRoute** | `teslamate.keiretsu.top` — **public** + private + ts gateways, behind tinyauth OAuth |
| **SecurityPolicy** | tinyauth OAuth |
| **MQTT** | Disabled (`DISABLE_MQTT=true`) |

### Grafana integration (existing monitoring Grafana)
- **Datasource**: PostgreSQL, password pulled from CNPG secret via GrafanaOperator `valuesFrom`
- **22 dashboards** loaded from teslamate-org/teslamate GitHub (auto-synced weekly)
- Dashboards in 'TeslaMate' folder

## Prerequisites
Already done — `TESLAMATE_ENCRYPTION_KEY` added to `cluster-secrets.sops.yaml`.

## Files changed
- 14 new files (teslamate base app + Ottawa cluster kustomization)
- 4 modified files (tinyauth referencegrant, grafana dashboards/datasources kustomizations, Ottawa kustomization)