### PR TITLE
feat: connect forgejo to tinyauth as OIDC provider

### DIFF
--- a/kubernetes/apps/base/auth/tinyauth/deployment.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/deployment.yaml
@@ -48,6 +48,21 @@ spec:
                   name: tinyauth-secret
                   key: tinyauth-secret
                   optional: true
+            # forgejo OIDC client — registered via `tinyauth oidc create forgejo`
+            - name: TINYAUTH_OIDC_CLIENTS_FORGEJO_CLIENTID
+              valueFrom:
+                secretKeyRef:
+                  name: tinyauth-secret
+                  key: forgejo-oidc-client-id
+            - name: TINYAUTH_OIDC_CLIENTS_FORGEJO_CLIENTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: tinyauth-secret
+                  key: forgejo-oidc-client-secret
+            - name: TINYAUTH_OIDC_CLIENTS_FORGEJO_TRUSTEDREDIRECTURIS
+              value: https://forgejo.keiretsu.top/user/oauth2/Tinyauth/callback
+            - name: TINYAUTH_OIDC_CLIENTS_FORGEJO_NAME
+              value: Forgejo
             - name: TINYAUTH_DATABASE_PATH
               value: /data/tinyauth.db
           volumeMounts:

--- a/kubernetes/apps/base/auth/tinyauth/secret.yaml
+++ b/kubernetes/apps/base/auth/tinyauth/secret.yaml
@@ -1,5 +1,6 @@
 ---
 # values come from ottawa cluster-secrets (sops) via flux substitution
+# forgejo-oidc-* are hardcoded — generated locally via `tinyauth oidc create forgejo`
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,6 @@ stringData:
   users: "${TINYAUTH_USERS}"
   # internal signing/encryption secret
   tinyauth-secret: "${TINYAUTH_SIGNING_SECRET}"
+  # forgejo OIDC client — registered via `tinyauth oidc create forgejo`
+  forgejo-oidc-client-id: "cbc9e28c-ba3a-4e5c-9245-af17cb0d08db"
+  forgejo-oidc-client-secret: "ta-XW8a2zvEeTZLreSn5iPVYWf8kpzcKODNvYPqoECWZLMJbKn2dBuD5eUMz8aY0"

--- a/kubernetes/apps/base/auth/tinyauth/tinyauth.env
+++ b/kubernetes/apps/base/auth/tinyauth/tinyauth.env
@@ -29,3 +29,7 @@ TINYAUTH_UI_WARNINGSENABLED=false
 # route's SecurityPolicy (EG authorization on Remote-Email), not here. adding a
 # user = append their google email here, then to the routes they should reach.
 TINYAUTH_OAUTH_WHITELIST=rajsinghcpre@gmail.com,kartikbharath@gmail.com
+# OIDC server mode — acts as an identity provider for downstream apps (e.g. Forgejo)
+# Keys are stored on the persistent volume (/data) — auto-created on first start
+TINYAUTH_OIDC_PRIVATEKEYPATH=/data/oidc/private.pem
+TINYAUTH_OIDC_PUBLICKEYPATH=/data/oidc/public.pem

--- a/kubernetes/apps/base/forgejo/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/helmrelease.yaml
@@ -65,7 +65,13 @@ spec:
         session:
           PROVIDER: db
         service:
-          DISABLE_REGISTRATION: "true"
+          DISABLE_REGISTRATION: "false"
+          ALLOW_ONLY_EXTERNAL_REGISTRATION: "true"
+          SHOW_REGISTRATION_BUTTON: "false"
+        openid:
+          ENABLE_OPENID_SIGNIN: "false"
+          ENABLE_OPENID_SIGNUP: "true"
+          WHITELISTED_URIS: auth.keiretsu.top
         storage:
           STORAGE_TYPE: minio
           MINIO_ENDPOINT: ${COMMON_S3_ENDPOINT}


### PR DESCRIPTION
## Summary

Connect Forgejo (`forgejo.keiretsu.top`) to Tinyauth (`auth.keiretsu.top`) as an OpenID Connect identity provider. Users authenticate through Tinyauth (Google OAuth) and can then sign into Forgejo without separate credentials.

## Changes

### Tinyauth (`kubernetes/apps/base/auth/tinyauth/`)

- **`tinyauth.env`** — Enable OIDC server mode (`TINYAUTH_OIDC_PRIVATEKEYPATH`, `TINYAUTH_OIDC_PUBLICKEYPATH`) — keys auto-created on the existing `/data` PVC
- **`deployment.yaml`** — Wire Forgejo OIDC client env vars (client ID/secret from `tinyauth-secret`, redirect URI, display name)
- **`secret.yaml`** — Add `forgejo-oidc-client-id` and `forgejo-oidc-client-secret` (generated via `tinyauth oidc create forgejo`)

### Forgejo (`kubernetes/apps/base/forgejo/forgejo/app/`)

- **`helmrelease.yaml`** — Enable external-only registration via OIDC, whitelist `auth.keiretsu.top` as the OIDC issuer, hide the local registration button

## Post-deploy Steps (CLI, inside the pod)

```bash
# Register Tinyauth as an OIDC auth source in Forgejo
kubectl exec -n forgejo deploy/forgejo -- forgejo admin auth add-oauth \
  --provider=openidConnect \
  --name=Tinyauth \
  --key=cbc9e28c-ba3a-4e5c-9245-af17cb0d08db \
  --secret=ta-XW8a2zvEeTZLreSn5iPVYWf8kpzcKODNvYPqoECWZLMJbKn2dBuD5eUMz8aY0 \
  --auto-discover-url=https://auth.keiretsu.top/.well-known/openid-configuration \
  --scopes=openid email profile groups
```

## Login Flow

```
User → forgejo.keiretsu.top → "Sign in with Tinyauth"
     → auth.keiretsu.top → Google OAuth
     → back to forgejo.keiretsu.top (logged in)
```