### PR TITLE
fix(cdn-site): GSLB-front rajsingh.info hosts via DNSEndpoint

### DIFF
--- a/kubernetes/apps/base/cloudflare/cloudflare/externaldns-keiretsu-top.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/externaldns-keiretsu-top.yaml
@@ -38,7 +38,14 @@ spec:
     policy: sync
     sources:
       - crd
+    # Also publish rajsingh.info DNSEndpoints (label dns-target=cloudflare) from
+    # this CRD-source instance — it already uses the rajsingh Cloudflare token.
+    # This is the gateway-owned-zone-safe publisher for cdn-site public CNAMEs:
+    # the rajsingh-info gateway-source external-dns runs --force-default-targets
+    # and cannot honor a per-route GSLB CNAME, so cdn-site emits a DNSEndpoint
+    # instead and excludes its route from the gateway-source (see #1651).
     domainFilters:
       - keiretsu.top
+      - rajsingh.info
     txtOwnerId: keiretsu-top
     txtPrefix: k8s.keiretsu.top.

--- a/kubernetes/components/cdn-site/dnsendpoint.yaml
+++ b/kubernetes/components/cdn-site/dnsendpoint.yaml
@@ -1,0 +1,27 @@
+---
+# Publish PUBLIC_HOST -> CDN_HOST as a DNSEndpoint for a CRD-source
+# external-dns (label dns-target=cloudflare). This is the gateway-owned-zone
+# safe path: unlike a per-route external-dns target annotation, a CRD
+# DNSEndpoint is not overridden by --force-default-targets on a gateway-source
+# external-dns, so the GSLB CNAME lands and stays stable across clusters.
+#
+# The inherited namespace is the consumer's (e.g. garage) — the CRD
+# external-dns reads DNSEndpoints by label across all namespaces, so this does
+# not need to live in cloudflare. The zone must be in a CRD external-dns
+# domainFilter (external-dns-cloudflare-keiretsu-top covers keiretsu.top and
+# rajsingh.info).
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: ${SITE}-cdn-dns
+  labels:
+    dns-target: cloudflare
+spec:
+  endpoints:
+    - dnsName: "${PUBLIC_HOST}"
+      recordType: CNAME
+      targets:
+        - "${CDN_HOST}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/components/cdn-site/httproute.yaml
+++ b/kubernetes/components/cdn-site/httproute.yaml
@@ -4,15 +4,14 @@ kind: HTTPRoute
 metadata:
   name: ${SITE}-cdn
   annotations:
-    # Publish PUBLIC_HOST -> CDN_HOST via the zone's gateway-watching external-dns.
-    # CDN_HOST is the k8gb-delegated GSLB name, so this inherits health-checked,
-    # multi-cluster resolution. DNS-only (grey) — the GSLB is the health-check /
-    # failover layer; a Cloudflare-proxied edge would be a per-site override.
-    # NB: "false" is a literal (kustomize keeps it quoted as a string). Do not
-    # turn this into a ${VAR}: kustomize strips the quotes and Flux substitution
-    # then yields a YAML boolean, which annotation values reject.
-    external-dns.alpha.kubernetes.io/target: "${CDN_HOST}"
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+    # Exclude from gateway-source external-dns so it does not publish
+    # PUBLIC_HOST itself. The public CNAME (PUBLIC_HOST -> CDN_HOST) is owned by
+    # the cdn-site DNSEndpoint, read by a CRD-source external-dns. This avoids
+    # the flap on gateway-owned zones (e.g. rajsingh.info) where a gateway-source
+    # external-dns runs --force-default-targets and would override any per-route
+    # target with ${LOCATION}.<zone>, fighting the CRD DNSEndpoint. The route
+    # still matches both hostnames so Envoy routes PUBLIC_HOST traffic.
+    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/components/cdn-site/kustomization.yaml
+++ b/kubernetes/components/cdn-site/kustomization.yaml
@@ -14,16 +14,23 @@
 # Generates:
 #   - HTTPRoute on the `public` gateway: matches both CDN_HOST and PUBLIC_HOST,
 #     URLRewrite Host -> <BUCKET>.${COMMON_DOMAIN} so Garage resolves the bucket,
-#     backend garage-gateway:3902. Carries the external-dns target annotation so
-#     the zone's gateway-watching external-dns publishes PUBLIC_HOST -> CDN_HOST.
-#   - Gslb (k8gb): health-checks garage-gateway per cluster and publishes CDN_HOST
-#     in the delegated cdn.${COMMON_DOMAIN} zone, weighted roundRobin.
+#     backend garage-gateway:3902. Excluded from gateway-source external-dns
+#     (external-dns.alpha.kubernetes.io/exclude) so it never publishes
+#     PUBLIC_HOST itself — the DNSEndpoint below owns the public CNAME.
+#   - DNSEndpoint (label dns-target=cloudflare): publishes PUBLIC_HOST ->
+#     CDN_HOST for a CRD-source external-dns. This is the gateway-owned-zone
+#     safe path (rajsingh.info): a per-route target annotation is ignored under
+#     --force-default-targets, but a CRD DNSEndpoint is not. The zone must be
+#     listed in a CRD external-dns domainFilter (external-dns-cloudflare-
+#     keiretsu-top covers keiretsu.top + rajsingh.info).
+#   - Gslb (k8gb): health-checks garage-gateway per cluster and publishes
+#     CDN_HOST in the delegated cdn.${COMMON_DOMAIN} zone, weighted roundRobin.
 #
 # Deploy in the `garage` namespace (same as garage-gateway) to avoid a
-# cross-namespace ReferenceGrant. For the public CNAME to land, the zone's
-# external-dns must honor per-route targets (no --force-default-targets).
+# cross-namespace ReferenceGrant.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - httproute.yaml
   - gslb.yaml
+  - dnsendpoint.yaml


### PR DESCRIPTION
## Summary

Fixes #1651. `cdn-site` currently publishes `PUBLIC_HOST -> CDN_HOST` via a per-route `external-dns.alpha.kubernetes.io/target` annotation on its `HTTPRoute`. For gateway-owned zones (`rajsingh.info`) this is ignored: the `external-dns-cloudflare-rajsingh-info` gateway-source external-dns runs `--force-default-targets`, so every public route resolves to `${LOCATION}.rajsingh.info` and any per-route GSLB CNAME is overridden. With the route running on all three clusters, `trades.rajsingh.info` flapped across each cluster's gateway target (`ottawa.killinit.cc`, `robbinsdale.lukehouge.com`, `stpetersburg.rajsingh.info`) → intermittent NXDOMAIN.

This mirrors the working `keiretsu.top` pattern (`k8gb-common/config/cnames.yaml`, served by the CRD-source `external-dns-cloudflare-keiretsu-top`) for `rajsingh.info`:

- **`cdn-site` component** — emit a `DNSEndpoint` (`PUBLIC_HOST -> CDN_HOST`, label `dns-target=cloudflare`) read by a CRD-source external-dns. A CRD `DNSEndpoint` is not subject to `--force-default-targets`, so the GSLB CNAME lands and stays stable across clusters.
- **`cdn-site` `HTTPRoute`** — add `external-dns.alpha.kubernetes.io/exclude: "true"` so the gateway-source external-dns no longer publishes `PUBLIC_HOST` itself, which would fight the CRD `DNSEndpoint` (the flap). The route still matches both `CDN_HOST` and `PUBLIC_HOST` so Envoy routes `PUBLIC_HOST` traffic. The old per-route `target` / `cloudflare-proxied` annotations are removed (the `DNSEndpoint` owns both now).
- **`external-dns-cloudflare-keiretsu-top`** — add `rajsingh.info` to `domainFilters`. This instance already uses the rajsingh Cloudflare token (`RAJSINGH_INFO_CLOUDFLARE_API_TOKEN`), so it can publish `rajsingh.info` `DNSEndpoint`s with no new secret and no dedicated CRD instance.

## Result

`trades.rajsingh.info -> trades.cdn.keiretsu.top` (k8gb health-checked across ottawa / robbinsdale / stpetersburg), stable, no flap. The pattern is generalized in the `cdn-site` component, so any `rajsingh.info` (or other zone listed in a CRD external-dns `domainFilter`) host can be GSLB-fronted the same way.

## Acceptance (#1651)

- [x] `trades.rajsingh.info` resolves to `trades.cdn.keiretsu.top` (stable, no flap), health-checked across clusters.
- [x] Pattern generalized in `cdn-site` so any `rajsingh.info` (or other gateway-owned-zone) host can be GSLB-fronted.

## Caveats / follow-ups

- The `external-dns.alpha.kubernetes.io/exclude` annotation on the `cdn-site` route excludes it from **all** gateway-source external-dns. Today the only `cdn-site` consumers are `keiretsu.top` (no gateway-source external-dns owns it — CRD only) and `rajsingh.info` (covered by the CRD instance above), so this is safe. A future `cdn-site` consumer on `killinit.cc` / `lukehouge.com` — whose public CNAME currently relies on the per-route gateway-source target — would need that zone added to a CRD external-dns `domainFilter` (or a dedicated CRD instance), since the route is now excluded from gateway-source publication.
- The `DNSEndpoint` inherits the consumer kustomization's namespace (e.g. `garage`) rather than `cloudflare`; the CRD external-dns reads `DNSEndpoint`s by label across all namespaces, so this is functionally equivalent to the `cnames.yaml` placement.

## Validation

```sh
make test   # flate render-test all three clusters
make diff   # rendered diff vs origin/main
```

Rendered output should show, per cluster, the new `DNSEndpoint/${SITE}-cdn-dns` in `garage`, the `HTTPRoute/${SITE}-cdn` with the exclude annotation (and no target annotation), and `external-dns-cloudflare-keiretsu-top` with `rajsingh.info` in `domainFilters`.