### PR TITLE
feat: deploy Tempo distributed tracing stack (Ottawa)

### DIFF
--- a/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
+++ b/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.6.17"
+      version: "0.6.18"
       sourceRef:
         kind: HelmRepository
         name: garage-operator

--- a/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
@@ -125,3 +125,23 @@ spec:
       read: true
       write: true
       owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: tempo
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: tempo
+  quotas:
+    maxSize: 200Gi
+    maxObjects: 10000000
+  keyPermissions:
+    - keyRef:
+        name: tempo-key
+        namespace: tempo
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - immich-postgres-key.yaml
   - tailscale-logs-key.yaml
   - mimir-key.yaml
+  - tempo-key.yaml

--- a/kubernetes/apps/base/garage/garage-keys/tempo-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/tempo-key.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: tempo-key
+  namespace: tempo
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Tempo Tracing Key"
+  secretTemplate:
+    name: tempo-storage
+    includeBucketName: true
+    bucketNameKey: bucket
+    accessKeyIdKey: access_key_id
+    secretAccessKeyKey: access_key_secret
+    additionalData:
+      endpoint: "http://${COMMON_S3_ENDPOINT}"
+  bucketPermissions:
+    - bucketRef:
+        name: tempo
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -49,3 +49,7 @@ spec:
       namespace: bhaiya
     - kind: GarageKey
       namespace: velero-system
+    - kind: GarageKey
+      namespace: tempo
+    - kind: GarageBucket
+      namespace: tempo

--- a/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/gitrepository.yaml
+++ b/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/gitrepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: tempo-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://github.com/grafana/tempo-operator
+  ref:
+    tag: v0.21.0

--- a/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/ks.yaml
+++ b/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/ks.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tempo-operator-system-install
+  namespace: flux-system
+spec:
+  targetNamespace: tempo-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: tempo-operator-system-install
+  path: ./config/default
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: tempo-operator
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute: {}
+    substituteFrom: []

--- a/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/kustomization.yaml
+++ b/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gitrepository.yaml
+  - ks.yaml

--- a/kubernetes/apps/base/tempo/tempo/httproute.yaml
+++ b/kubernetes/apps/base/tempo/tempo/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tempo-jaeger-query
+spec:
+  parentRefs:
+    - name: ts
+      namespace: home
+  hostnames:
+    - "tempo.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: tempo-tempo-query-frontend
+          namespace: tempo
+          port: 16686

--- a/kubernetes/apps/base/tempo/tempo/kustomization.yaml
+++ b/kubernetes/apps/base/tempo/tempo/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tempostack.yaml
+  - httproute.yaml
+  - referencegrant-jaeger.yaml

--- a/kubernetes/apps/base/tempo/tempo/referencegrant-jaeger.yaml
+++ b/kubernetes/apps/base/tempo/tempo/referencegrant-jaeger.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-tempo-jaeger-query
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: home
+  to:
+    - group: ""
+      kind: Service

--- a/kubernetes/apps/base/tempo/tempo/tempostack.yaml
+++ b/kubernetes/apps/base/tempo/tempo/tempostack.yaml
@@ -1,0 +1,35 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: tempo
+spec:
+  storage:
+    secret:
+      name: tempo-storage
+    type: s3
+  storageSize: 10Gi
+  retention:
+    global:
+      traces: 7d
+  resources:
+    total:
+      limits:
+        memory: 4Gi
+        cpu: 2000m
+  observability:
+    metrics:
+      createServiceMonitors: true
+      createPrometheusRules: true
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+      replicas: 1
+    distributor:
+      replicas: 1
+    ingester:
+      replicas: 1
+    compactor:
+      replicas: 1
+    querier:
+      replicas: 1

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -52,6 +52,8 @@ resources:
   - ./node-feature-discovery
   - ./tailscale
   - ./local-path-storage
+  - ./tempo-operator-system
+  - ./tempo
   - ./csi-addons
   - ./csi-driver-smb
   - ./tuppr

--- a/kubernetes/apps/ottawa/tempo-operator-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tempo-operator-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tempo-operator-system-install.yaml

--- a/kubernetes/apps/ottawa/tempo-operator-system/namespace.yaml
+++ b/kubernetes/apps/ottawa/tempo-operator-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tempo-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/tempo-operator-system/tempo-operator-system-install.yaml
+++ b/kubernetes/apps/ottawa/tempo-operator-system/tempo-operator-system-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tempo-operator-system-install
+  namespace: flux-system
+spec:
+  targetNamespace: tempo-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: tempo-operator-system-install
+  path: ./kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/tempo/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tempo/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tempo.yaml

--- a/kubernetes/apps/ottawa/tempo/namespace.yaml
+++ b/kubernetes/apps/ottawa/tempo/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tempo
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/tempo/tempo.yaml
+++ b/kubernetes/apps/ottawa/tempo/tempo.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tempo
+  namespace: flux-system
+spec:
+  targetNamespace: tempo
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage-keys
+    - name: tempo-operator-system-install
+  path: ./kubernetes/apps/base/tempo/tempo
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m


### PR DESCRIPTION
## Summary

Deploys a **Tempo distributed tracing stack** on the Ottawa cluster, backed by Garage S3 storage. Uses the garage-operator's new `includeBucketName` feature (v0.6.18) to auto-inject the bucket name into the S3 secret, satisfying the Tempo Operator's secret schema.

## Changes

### Garage Operator
- **Bump garage-operator → v0.6.18** — enables secretTemplate.includeBucketName support (PR #262, issue #261)

### Garage Bucket & Key
- **New tempo GarageBucket** — 200Gi quota, global alias tempo
- **New tempo-key GarageKey** (namespace: tempo) with:
  - `includeBucketName: true` → generates `bucket` key in the secret (required by Tempo Operator)
  - `bucketNameKey: bucket` — matches Tempo's expected secret key
  - `accessKeyIdKey: access_key_id` + `secretAccessKeyKey: access_key_secret` — Tempo defaults
  - `additionalData.endpoint: http://${COMMON_S3_ENDPOINT}`
- **ReferenceGrant** entries for tempo namespace

### Tempo Operator
- **Install tempo-operator v0.21.0** — `GitRepository` source pointing at `grafana/tempo-operator` (tag v0.21.0), built via Flux Kustomization at `path: ./config/default`
  - No committed manifests — Flux clones upstream and runs `kustomize build`
  - Creates `tempo-operator-system` namespace, TempoStack CRD, controller deployment
  - Requires cert-manager (already in common infra)

### Tempo Stack
- **New TempoStack CR** (namespace: tempo) with:
  - Backend: Garage S3 via `tempo-storage` secret (auto-generated by GarageKey)
  - Ingester PVC: 10Gi
  - Retention: 7 days
  - Jaeger Query UI enabled via HTTPRoute
  - ServiceMonitor + PrometheusRules enabled for observability
  - Components: 1x distributor, 1x ingester, 1x compactor, 1x querier, 1x query-frontend
- **HTTPRoute** at `tempo.${CLUSTER_DOMAIN}` → Jaeger Query UI (port 16686)
- **ReferenceGrant** for cross-namespace routing (home → tempo)

## Architecture

Applications send OTLP/Jaeger/Zipkin traces
    ↓ (ClusterIP, port 4317/4318/14268/9411)
Tempo Distributor
    ↓
Tempo Ingester → Garage S3 (tempo bucket)
    ↓
Tempo Querier → Query Frontend → Jaeger UI (tempo.${CLUSTER_DOMAIN})