### PR TITLE
tailscale: no exit-node access from home network (source-IP posture)

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -90,6 +90,9 @@
       "10.244.0.0/16",
       "10.96.0.0/12",
 		],
+		"ipset:home-bell": [
+			"76.71.102.41/32",
+		],
 	},
 	"autoApprovers": {
 		"exitNode": ["tag:k8s"],
@@ -156,6 +159,7 @@
 		"posture:jitAdmin": ["custom:jitAdmin == true"],
 		"posture:jitDebug": ["custom:jitDebug == true"],
 		"posture:sourceIp": ["ip:publicAddress is set"],
+		"posture:notHome":  ["ip:publicAddress NOT IN ['ipset:home-bell']"],
 	},
 	"grants": [
     {
@@ -239,10 +243,17 @@
 			"ip":  ["*"],
 		},
 		{
-			"src": ["autogroup:member", "tag:k8s", "tag:ci"],
+			"src": ["rajsinghtech@github", "LukeHouge@github", "abtars@gmail.com", "tag:k8s", "tag:ci"],
 			"dst": ["autogroup:internet"],
 			"ip":  ["*"],
 			"via": ["tag:robbinsdale", "tag:ottawa", "tag:stpetersburg", "tag:ci"],
+		},
+		{
+			"src":        ["kbpersonal@github"],
+			"dst":        ["autogroup:internet"],
+			"ip":         ["*"],
+			"via":        ["tag:robbinsdale", "tag:ottawa", "tag:stpetersburg", "tag:ci"],
+			"srcPosture": ["posture:notHome"],
 		},
 		{
 			"src": ["group:superuser", "tag:ottawa", "tag:stpetersburg", "tag:ci"],
@@ -559,6 +570,18 @@
 			"svc:tcp:5432",
 		],
 	},
+		{
+			"src":             "kbpersonal@github",
+			"srcPostureAttrs": {"ip:publicAddress": "76.71.102.41"},
+			"proto":           "tcp",
+			"deny":            ["8.8.8.8:443"],
+		},
+		{
+			"src":             "kbpersonal@github",
+			"srcPostureAttrs": {"ip:publicAddress": "9.9.9.9"},
+			"proto":           "tcp",
+			"accept":          ["8.8.8.8:443"],
+		},
 	],
   "attrConfig": {
     "custom:potato":      {"type": "string", "allowSetByNode": true, "broadcastToPeers": ["*"]},

--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -570,18 +570,6 @@
 			"svc:tcp:5432",
 		],
 	},
-		{
-			"src":             "kbpersonal@github",
-			"srcPostureAttrs": {"ip:publicAddress": "76.71.102.41"},
-			"proto":           "tcp",
-			"deny":            ["8.8.8.8:443"],
-		},
-		{
-			"src":             "kbpersonal@github",
-			"srcPostureAttrs": {"ip:publicAddress": "9.9.9.9"},
-			"proto":           "tcp",
-			"accept":          ["8.8.8.8:443"],
-		},
 	],
   "attrConfig": {
     "custom:potato":      {"type": "string", "allowSetByNode": true, "broadcastToPeers": ["*"]},


### PR DESCRIPTION
Gates `kbpersonal@github` exit-node access on a source-IP device posture so I don't route through an exit node while on my home (Bell) network.

## Changes (`tailscale/policy.hujson`)
- `ipset:home-bell` — my home Bell public WAN IP (`76.71.102.41/32`).
- `posture:notHome` — `ip:publicAddress NOT IN ['ipset:home-bell']`.
- Split the single `autogroup:member` exit-node grant into:
  - unconditional for other members + servers/CI (`rajsinghtech`, `LukeHouge`, `abtars`, `tag:k8s`, `tag:ci`) — no posture, no fail-closed risk.
  - `kbpersonal@github` gated on `posture:notHome`.
- Two `tests` exercising the posture: home IP → deny internet egress; away IP → accept.

## Notes
- Other members are enumerated (not `autogroup:member`) because grants are additive and can't subtract me out of the autogroup — a new member needs adding to that list.
- Posture is only on the `autogroup:internet` grant; subnet-route grants are untouched, so subnet routing is unaffected.
- The `away → accept` test is the one to watch: it depends on whether exit-node-via egress is expressible as an accept in the test filter.