### PR TITLE
feat(infisical): deploy Infisical on Ottawa with full production stack

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -34,6 +34,7 @@ jobs:
           unset FLATE_BASE
           flate test all \
             --path clusters/${{ matrix.cluster }}/flux/config \
+            --allow-missing-secrets \
             --no-progress
 
   diff:

--- a/clusters/common/flux/repositories/helm/infisical.yaml
+++ b/clusters/common/flux/repositories/helm/infisical.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: infisical
+  namespace: flux-system
+spec:
+  interval: 30m
+  url: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/

--- a/clusters/common/flux/repositories/helm/kustomization.yaml
+++ b/clusters/common/flux/repositories/helm/kustomization.yaml
@@ -89,3 +89,4 @@ resources:
   - ./vmware-tanzu.yaml
   - ./otwld.yaml
   - ./victoriametrics.yaml
+  - ./infisical.yaml

--- a/kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-store-infisical.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-store-infisical.yaml
@@ -1,0 +1,33 @@
+---
+# ClusterSecretStore for self-hosted Infisical
+# Requires a Machine Identity to be created in Infisical first.
+# Steps after Infisical is live:
+#   1. Create a Machine Identity with Universal Auth enabled
+#   2. Add it to the project with read permissions
+#   3. Create the infisical-credentials secret with clientId + clientSecret
+#   4. This store will become active automatically
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: infisical
+spec:
+  provider:
+    infisical:
+      # In-cluster service DNS — Infisical API runs on port 8080
+      hostAPI: http://infisical:8080
+      auth:
+        universalAuthCredentials:
+          clientId:
+            name: infisical-credentials
+            namespace: external-secrets
+            key: clientId
+          clientSecret:
+            name: infisical-credentials
+            namespace: external-secrets
+            key: clientSecret
+      secretsScope:
+        # These are placeholders — set the actual project slug and environment after setup
+        projectSlug: "default"
+        environmentSlug: "dev"
+        # Enable recursive secret path resolution
+        recursive: true

--- a/kubernetes/apps/base/external-secrets/external-secrets/config/kustomization.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/config/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 namespace: external-secrets
 resources:
   - ./cluster-secret-stores.yaml
+  - ./cluster-secret-store-infisical.yaml
   - ./rbac.yaml
   - ./remote-tokens-secret.yaml

--- a/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
+++ b/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.6.17"
+      version: "0.6.18"
       sourceRef:
         kind: HelmRepository
         name: garage-operator

--- a/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
@@ -145,3 +145,22 @@ spec:
       read: true
       write: true
       owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: infisical-postgres
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: infisical-postgres
+  quotas:
+    maxSize: 50Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: infisical-postgres-key
+        namespace: infisical
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/bucket.yaml
@@ -125,3 +125,23 @@ spec:
       read: true
       write: true
       owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: tempo
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: tempo
+  quotas:
+    maxSize: 200Gi
+    maxObjects: 10000000
+  keyPermissions:
+    - keyRef:
+        name: tempo-key
+        namespace: tempo
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys/infisical-postgres-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/infisical-postgres-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: infisical-postgres-key
+  namespace: infisical
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Infisical Postgres Backup Key"
+  secretTemplate:
+    name: infisical-s3-backup
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: infisical-postgres
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - tailscale-logs-key.yaml
   - mimir-key.yaml
   - tempo-key.yaml
+  - infisical-postgres-key.yaml

--- a/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - immich-postgres-key.yaml
   - tailscale-logs-key.yaml
   - mimir-key.yaml
+  - tempo-key.yaml

--- a/kubernetes/apps/base/garage/garage-keys/tempo-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys/tempo-key.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: tempo-key
+  namespace: tempo
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Tempo Tracing Key"
+  secretTemplate:
+    name: tempo-storage
+    includeBucketName: true
+    bucketNameKey: bucket
+    accessKeyIdKey: access_key_id
+    secretAccessKeyKey: access_key_secret
+    additionalData:
+      endpoint: "http://${COMMON_S3_ENDPOINT}"
+  bucketPermissions:
+    - bucketRef:
+        name: tempo
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -53,3 +53,5 @@ spec:
       namespace: tempo
     - kind: GarageBucket
       namespace: tempo
+    - kind: GarageKey
+      namespace: infisical

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -49,3 +49,7 @@ spec:
       namespace: bhaiya
     - kind: GarageKey
       namespace: velero-system
+    - kind: GarageKey
+      namespace: tempo
+    - kind: GarageBucket
+      namespace: tempo

--- a/kubernetes/apps/base/home/home-robbinsdale/frigate/frigate-config-backup.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/frigate/frigate-config-backup.yaml
@@ -1,5 +1,5 @@
 mqtt:
-  host: 10.50.10.11
+  host: 10.69.10.11
   port: 1883
   user: lhouge
   password: applegeek
@@ -66,6 +66,10 @@ go2rtc:
       - rtsp://frigate:Applegeek1@192.168.50.251:554/Streaming/Channels/1
     shop_2_sub:
       - rtsp://frigate:Applegeek1@192.168.50.251:554/Streaming/Channels/2
+    g4:
+      - rtspx://192.168.50.1:7441/sMsJ2Z0F1ZgtiyAv
+    g4_sub:
+      - rtspx://192.168.50.1:7441/S5OZvvlg1q3t5oMc
 cameras:
   alley_front:
     ffmpeg:
@@ -79,18 +83,22 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 9
     live:
-      stream_name: alley_front
+      streams:
+        alley_front: alley_front
     zones:
       alley:
         coordinates: 0,0,0.539,0,0.542,0.115,0.621,0.111,0.619,0,1,0,1,1,0,1
@@ -116,22 +124,30 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 10
     live:
-      stream_name: alley_back
+      streams:
+        alley_back: alley_back
     zones:
       alley:
-        coordinates: 0.54,0.004,0.587,0.307,0.663,0.305,0.755,0.439,0.723,0.005,1,0,1,1,0,1,0,0
+        coordinates: 
+          0.54,0.004,0.587,0.307,0.663,0.305,0.755,0.439,0.723,0.005,1,0,1,1,0,1,0,0
         loitering_time: 0
+        filters:
+          person:
+            max_area: 25000
     review:
       alerts:
         required_zones: alley
@@ -147,18 +163,22 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 5
     live:
-      stream_name: backyard
+      streams:
+        backyard: backyard
     zones:
       yard:
         coordinates: 
@@ -167,6 +187,15 @@ cameras:
     review:
       alerts:
         required_zones: yard
+        labels:
+          - cat
+          - dog
+          - person
+      detections:
+        labels:
+          - cat
+          - dog
+          - person
   house_side:
     ffmpeg:
       inputs:
@@ -179,18 +208,22 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 1
     live:
-      stream_name: house_side
+      streams:
+        house_side: house_side
     review:
       detections:
         labels:
@@ -202,6 +235,25 @@ cameras:
           - cat
           - dog
           - person
+    objects:
+      filters:
+        car:
+          mask:
+            - 1,0.884,0,0.87,0,1,1,1
+            - 1,0.674,0.79,0.671,0.792,1,1,1
+      genai:
+        prompt: Examine the person in these images from the {camera} security 
+          camera at the side of the house. What are they doing, and how might 
+          their actions suggest their purpose (e.g., delivering something, 
+          approaching, leaving)? If they are carrying or interacting with a 
+          package, include details about its source or destination. For 
+          additional context, this camera is placed on the side entrance of our 
+          house, looking at the driveway, gate to our backyard, and garage. This
+          is the main entrance to our house off of the driveway and most often 
+          used by residents coming from the garage or their car parked on the 
+          driveway, or sometimes by guests.
+        objects:
+          - person
   shop_1:
     ffmpeg:
       inputs:
@@ -210,20 +262,24 @@ cameras:
           roles:
             - record
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     objects:
       track: []
     ui:
       order: 8
     live:
-      stream_name: shop_2
+      streams:
+        shop_1: shop_1
   shop_2:
     ffmpeg:
       inputs:
@@ -232,20 +288,24 @@ cameras:
           roles:
             - record
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     objects:
       track: []
     ui:
       order: 7
     live:
-      stream_name: shop_2
+      streams:
+        shop_2: shop_2
   driveway:
     ffmpeg:
       inputs:
@@ -258,41 +318,66 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 0
     live:
-      stream_name: driveway
+      streams:
+        driveway: driveway
     zones:
       not_road:
         coordinates: 
           0.205,0,0.211,0.139,0.316,0.109,0.444,0.091,0.616,0.083,0.752,0.099,0.755,0,1,0,1,1,0,1,0,0
-        inertia: 3
-        loitering_time: 0
         objects:
           - cat
           - dog
           - person
           - suitecase
-      # car_valid:
-      #   coordinates: 0.216,0.149,0,0.491,0,1,0.456,1,0.49,0.109
-      #   loitering_time: 1
-      #   objects:
-      #     - car
-      #     - bus
-      #   inertia: 10
+      car_valid:
+        coordinates: 0.397,0.094,0.314,0.211,0.088,0.675,0,1,0.588,1,0.53,0.112
+        objects: car
+        filters:
+          car:
+            max_area: 60000
+        inertia: 3
+        loitering_time: 0
     review:
       alerts:
         required_zones:
-          # - car_valid
+          - car_valid
           - not_road
+    objects:
+      filters:
+        car:
+          mask:
+            - 0,0.844,1,0.831,1,0.928,1,1,0,1
+            - 0.634,0.522,0.642,0.835,0.917,0.839,0.899,0.521
+            - 0.572,0.126,0.571,0.284,0.731,0.295,0.73,0.129
+            - 0.038,0.362,0.043,0.67,0.271,0.668,0.268,0.351
+      genai:
+        prompt: Examine the person in these images from the {camera} security 
+          camera at the front driveway of the house. What are they doing, and 
+          how might their actions suggest their purpose (e.g., delivering 
+          something, approaching, leaving)? If they are carrying or interacting 
+          with a package, include details about its source or destination. For 
+          additional context, this camera is placed on the front of our garage, 
+          looking out onto the driveway in front, and the house to the right. 
+          One of the 2 entrances to our house is the door directly to the right,
+          and the gate to our backyard is behind and to the right. Residents 
+          often park on the driveway or in the garage and enter the house 
+          through the side entrance.
+        objects:
+          - person
   backyard_front:
     ffmpeg:
       inputs:
@@ -305,23 +390,28 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 4
     live:
-      stream_name: backyard_front
+      streams:
+        backyard_front: backyard_front
     zones:
       yard:
         coordinates: 
-          0.421,0.21,0.581,0.185,0.744,0.176,0.904,0.194,0.999,0.221,1,1,0,1,0,0,0.351,0.005,0.355,0.051,0.409,0.093
+          0.587,0.068,0.771,0.053,0.934,0.068,1,0.078,1,1,0,1,0,0,0.38,0,0.383,0.094,0.409,0.093
         loitering_time: 0
+        inertia: 3
     review:
       alerts:
         required_zones: yard
@@ -337,18 +427,22 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 3
     live:
-      stream_name: garage
+      streams:
+        garage: garage
     review:
       detections:
         labels:
@@ -360,6 +454,10 @@ cameras:
           - cat
           - dog
           - person
+    objects:
+      filters:
+        person:
+          min_score: 0.65
   backyard_back:
     ffmpeg:
       inputs:
@@ -372,23 +470,28 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 6
     live:
-      stream_name: backyard_back
+      streams:
+        backyard_back: backyard_back
     zones:
       yard:
         coordinates: 
-          0.007,0.336,0.218,0.211,0.391,0.139,0.509,0.112,0.57,0.09,0.602,0.039,0.64,0.032,0.675,0.056,0.677,0.084,0.761,0.095,0.829,0.096,0.885,0.104,0.927,0.111,0.932,0.042,1,0,1,1,0,1
+          0,0.301,0.223,0.149,0.39,0.075,0.502,0.04,0.569,0.014,0.57,0,0.675,0,0.713,0.015,0.752,0.017,0.789,0.028,0.837,0.041,0.933,0.07,0.934,0,1,0,1,1,0,1
         loitering_time: 0
+        inertia: 3
     review:
       alerts:
         required_zones: yard
@@ -404,14 +507,17 @@ cameras:
           roles:
             - detect
     record:
-      enabled: True
-      retain:
-        days: 10
-        mode: all
-      events:
+      enabled: true
+      alerts:
         retain:
-          default: 30
-          mode: motion
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
     ui:
       order: 2
     review:
@@ -421,8 +527,73 @@ cameras:
     zones:
       front_yard:
         coordinates: 0,0,0,1,1,1,1,0.495,0.763,0.29,0.471,0.099,0.474,0
+        filters:
+          person:
+            min_area: 1000
     live:
-      stream_name: front_door
+      streams:
+        front_door: front_door
+    objects:
+      genai:
+        prompt: Examine the person in these images from the {camera} security 
+          camera at the front door. What are they doing, and how might their 
+          actions suggest their purpose (e.g., delivering something, 
+          approaching, leaving)? If they are carrying or interacting with a 
+          package, include details about its source or destination. For 
+          additional context, this camera is placed on our front porch, looking 
+          at the door and walkway up to the house from the street. This is the 
+          second main entrance for the house and commonly used for mail, 
+          deliveries, and guests. The door in the camera view leads into our 
+          living room.
+        objects:
+          - person
+        required_zones:
+          - front_yard
+  g4:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/g4
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/g4_sub
+          input_args: preset-rtsp-restream
+          roles:
+            - audio
+            - detect
+    audio:
+      enabled: true
+      listen:
+        - bark
+    record:
+      enabled: true
+      alerts:
+        retain:
+          days: 60
+      detections:
+        retain:
+          days: 60
+      continuous:
+        days: 5
+      motion:
+        days: 0
+    live:
+      streams:
+        g4_instant: g4_instant
+    review:
+      detections:
+        labels:
+          - cat
+          - dog
+          - person
+      alerts:
+        labels:
+          - cat
+          - dog
+          - person
+detect:
+  enabled: True
+
 birdseye:
   restream: true
 # Optional: Object configuration
@@ -431,8 +602,7 @@ objects:
   # Optional: list of objects to track from labelmap.txt (default: shown below)
   track:
     - person
-    # - car
-    - bus
+    - car
     - cat
     - dog
     - suitecase
@@ -440,6 +610,8 @@ objects:
     person:
       threshold: 0.70
 # Optional
+  genai:
+    enabled: true
 ui:
   # Optional: Set the default live mode for cameras in the UI (default: shown below)
   # live_mode: mse
@@ -496,7 +668,7 @@ snapshots:
       # person: 15
   # Optional: quality of the encoded jpeg, 0-100 (default: shown below)
   quality: 70
-version: 0.14
+version: 0.17-0
 camera_groups:
   Birdseye:
     order: 1
@@ -518,6 +690,65 @@ camera_groups:
       - house_side
       - shop_1
       - shop_2
+  Entrances:
+    order: 3
+    icon: LuDoorOpen
+    cameras:
+      - driveway
+      - house_side
+      - front_door
+  Outside:
+    order: 4
+    icon: LuTrees
+    cameras:
+      - driveway
+      - house_side
+      - front_door
+      - backyard_front
+      - backyard
+      - backyard_back
+      - alley_front
+      - alley_back
+  Backyard:
+    order: 5
+    icon: LuRockingChair
+    cameras:
+      - backyard_front
+      - backyard
+      - backyard_back
+  Inside:
+    order: 6
+    icon: LuWarehouse
+    cameras:
+      - garage
+      - shop_1
+      - shop_2
+  Fav:
+    order: 7
+    icon: LuStar
+    cameras:
+      - driveway
+      - house_side
+      - front_door
+      - garage
+      - backyard_front
+      - backyard
+      - backyard_back
+      - shop_2
+      - shop_1
+      - alley_front
+      - alley_back
 logger:
   logs:
     frigate.record.maintainer: debug
+notifications:
+  enabled: 'true'
+  email: Lukehouge@gmail.com
+semantic_search:
+  enabled: true
+  reindex: false
+  model_size: large
+genai:
+  provider: gemini
+  api_key: TODO
+  model: gemini-1.5-flash

--- a/kubernetes/apps/base/infisical/infisical/app/dragonfly.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/dragonfly.yaml
@@ -1,0 +1,21 @@
+---
+# Dragonfly (Redis-compatible) for Infisical session/caching
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly-infisical
+spec:
+  replicas: 2
+  args:
+    - --maxmemory=512M
+    - --proactor_threads=2
+  authentication:
+    passwordFromSecret:
+      name: infisical-dragonfly-secret
+      key: password
+  resources:
+    requests:
+      cpu: 25m
+      memory: 512Mi
+    limits:
+      memory: 768Mi

--- a/kubernetes/apps/base/infisical/infisical/app/helmrelease.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/helmrelease.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: infisical
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: infisical-standalone
+      version: 1.x
+      sourceRef:
+        kind: HelmRepository
+        name: infisical
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: infisical-values
+      valuesKey: values.yaml
+      optional: false

--- a/kubernetes/apps/base/infisical/infisical/app/httproute.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/httproute.yaml
@@ -1,0 +1,67 @@
+---
+# Envoy Gateway HTTPRoute — exposes Infisical via Tailscale (ts) and private/public gateways
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: infisical
+  annotations:
+    item.homer.rajsingh.info/name: "Infisical"
+    item.homer.rajsingh.info/subtitle: "Secret Management"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/infisical.svg"
+    item.homer.rajsingh.info/keywords: "secrets, vault, configuration"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-key"
+spec:
+  hostnames:
+    - infisical.${CLUSTER_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: infisical
+          port: 8080
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: infisical-public
+  annotations:
+    item.homer.rajsingh.info/name: "Infisical"
+    item.homer.rajsingh.info/subtitle: "Secret Management"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/infisical.svg"
+    item.homer.rajsingh.info/keywords: "secrets, vault, configuration"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-key"
+spec:
+  hostnames:
+    - infisical.${COMMON_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: infisical
+          port: 8080
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/infisical/infisical/app/kustomization.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: infisical
+resources:
+  - helmrelease.yaml
+  - pg.yaml
+  - s3-backup.yaml
+  - dragonfly.yaml
+  - httproute.yaml
+  - secret.sops.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: infisical-values
+    files:
+      - values.yaml

--- a/kubernetes/apps/base/infisical/infisical/app/pg.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/pg.yaml
@@ -1,0 +1,59 @@
+---
+# CNPG-managed PostgreSQL for Infisical
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: infisical-postgres
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "enabled"
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: infisicalDB
+      owner: infisical
+      dataChecksums: true
+      postInitApplicationSQL:
+        - ALTER USER infisical WITH SUPERUSER;
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 10Gi
+    storageClass: ceph-block-replicated
+
+  # Barman Cloud plugin for automated WAL archiving to Garage S3
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: infisical-s3-store
+        serverName: infisical-postgres
+
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: keiretsu
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: infisical-s3-store
+          serverName: infisical-postgres
+
+  # Node maintenance window to keep PVCs on node drains
+  nodeMaintenanceWindow:
+    reusePVC: false
+---
+# Daily scheduled S3 backup
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: infisical-postgres-s3
+spec:
+  schedule: "0 0 23 * * *"  # Daily at 11 PM
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: infisical-postgres

--- a/kubernetes/apps/base/infisical/infisical/app/s3-backup.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/s3-backup.yaml
@@ -1,0 +1,22 @@
+---
+# Barman Cloud ObjectStore — defines S3 destination for CNPG WAL backups
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: infisical-s3-store
+spec:
+  configuration:
+    destinationPath: s3://infisical-postgres/${LOCATION}/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: infisical-s3-backup
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: infisical-s3-backup
+        key: AWS_SECRET_ACCESS_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"

--- a/kubernetes/apps/base/infisical/infisical/app/secret.sops.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/secret.sops.yaml
@@ -1,0 +1,30 @@
+---
+# Infisical secrets
+# REQUIRED: encrypt this file with `sops --encrypt secret.sops.yaml` before committing
+# Generate with: openssl rand -hex 16  (ENCRYPTION_KEY)
+#                openssl rand -base64 32  (AUTH_SECRET)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: infisical-secrets
+type: Opaque
+stringData:
+  # Required: 32-char hex string (openssl rand -hex 16)
+  ENCRYPTION_KEY: "122e7127d2ae373a425c1d164eb5765b"
+  # Required: 44-char base64 string (openssl rand -base64 32)
+  AUTH_SECRET: "lfb+kVVETKbm8Bn+lS/p1RFPCCkmWZCWliKuMs9wglc="
+  # Required: absolute URL including protocol
+  SITE_URL: "https://infisical.keiretsu.top"
+  # Redis connection (Dragonfly). Password must match infisical-dragonfly-secret below.
+  # TODO: Replace both passwords with a random value before going live.
+  REDIS_URL: "redis://default:r3d15p4ssw0rd@dragonfly-infisical:6379"
+---
+# Dragonfly password — shared between Dragonfly CR and Infisical REDIS_URL
+# Change the password in BOTH places if you rotate it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: infisical-dragonfly-secret
+type: Opaque
+stringData:
+  password: "r3d15p4ssw0rd"

--- a/kubernetes/apps/base/infisical/infisical/app/values.yaml
+++ b/kubernetes/apps/base/infisical/infisical/app/values.yaml
@@ -1,0 +1,53 @@
+# Infisical Helm values — production configuration for Ottawa cluster
+# External Postgres via CNPG, Redis via Dragonfly, Envoy Gateway for ingress
+nameOverride: ""
+
+infisical:
+  enabled: true
+  name: infisical
+  fullnameOverride: "infisical"
+  replicaCount: 2
+
+  # No built-in postgres — we use CNPG
+  # No built-in redis — we use Dragonfly
+  # No built-in nginx ingress — we use Envoy Gateway HTTPRoutes
+
+  image:
+    repository: infisical/infisical
+    pullPolicy: IfNotPresent
+    imagePullSecrets: []
+
+  kubeSecretRef: "infisical-secrets"
+
+  service:
+    type: ClusterIP
+    annotations: {}
+
+  resources:
+    limits:
+      memory: 1000Mi
+    requests:
+      cpu: 350m
+
+  podAnnotations: {}
+  deploymentAnnotations: {}
+  affinity: {}
+  tolerations: []
+  nodeSelector: {}
+  topologySpreadConstraints: []
+
+postgresql:
+  enabled: false
+  useExistingPostgresSecret:
+    enabled: true
+    existingConnectionStringSecret:
+      name: infisical-postgres-app
+      key: uri
+
+redis:
+  enabled: false
+
+ingress:
+  enabled: false
+  nginx:
+    enabled: false

--- a/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/gitrepository.yaml
+++ b/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/gitrepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: tempo-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://github.com/grafana/tempo-operator
+  ref:
+    tag: v0.21.0

--- a/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/ks.yaml
+++ b/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/ks.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tempo-operator-system-install
+  namespace: flux-system
+spec:
+  targetNamespace: tempo-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: tempo-operator-system-install
+  path: ./config/default
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: tempo-operator
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute: {}
+    substituteFrom: []

--- a/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/kustomization.yaml
+++ b/kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gitrepository.yaml
+  - ks.yaml

--- a/kubernetes/apps/base/tempo/tempo/httproute.yaml
+++ b/kubernetes/apps/base/tempo/tempo/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tempo-jaeger-query
+spec:
+  parentRefs:
+    - name: ts
+      namespace: home
+  hostnames:
+    - "tempo.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: tempo-tempo-query-frontend
+          namespace: tempo
+          port: 16686

--- a/kubernetes/apps/base/tempo/tempo/kustomization.yaml
+++ b/kubernetes/apps/base/tempo/tempo/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tempostack.yaml
+  - httproute.yaml
+  - referencegrant-jaeger.yaml

--- a/kubernetes/apps/base/tempo/tempo/referencegrant-jaeger.yaml
+++ b/kubernetes/apps/base/tempo/tempo/referencegrant-jaeger.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-tempo-jaeger-query
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: home
+  to:
+    - group: ""
+      kind: Service

--- a/kubernetes/apps/base/tempo/tempo/tempostack.yaml
+++ b/kubernetes/apps/base/tempo/tempo/tempostack.yaml
@@ -1,0 +1,35 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: tempo
+spec:
+  storage:
+    secret:
+      name: tempo-storage
+    type: s3
+  storageSize: 10Gi
+  retention:
+    global:
+      traces: 7d
+  resources:
+    total:
+      limits:
+        memory: 4Gi
+        cpu: 2000m
+  observability:
+    metrics:
+      createServiceMonitors: true
+      createPrometheusRules: true
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+      replicas: 1
+    distributor:
+      replicas: 1
+    ingester:
+      replicas: 1
+    compactor:
+      replicas: 1
+    querier:
+      replicas: 1

--- a/kubernetes/apps/ottawa/infisical/infisical.yaml
+++ b/kubernetes/apps/ottawa/infisical/infisical.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app infisical
+  namespace: flux-system
+spec:
+  targetNamespace: infisical
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-system
+    - name: dragonfly-operator-system
+    - name: garage
+  path: ./kubernetes/apps/base/infisical/infisical/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/infisical/kustomization.yaml
+++ b/kubernetes/apps/ottawa/infisical/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./infisical.yaml

--- a/kubernetes/apps/ottawa/infisical/namespace.yaml
+++ b/kubernetes/apps/ottawa/infisical/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: infisical

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - ./homer-operator
   - ./hubble-ui
   - ./immich
+  - ./infisical
   - ./k8gb
   - ./kener
   - ./kro-system

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -52,6 +52,8 @@ resources:
   - ./node-feature-discovery
   - ./tailscale
   - ./local-path-storage
+  - ./tempo-operator-system
+  - ./tempo
   - ./csi-addons
   - ./csi-driver-smb
   - ./tuppr

--- a/kubernetes/apps/ottawa/tempo-operator-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tempo-operator-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tempo-operator-system-install.yaml

--- a/kubernetes/apps/ottawa/tempo-operator-system/namespace.yaml
+++ b/kubernetes/apps/ottawa/tempo-operator-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tempo-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/tempo-operator-system/tempo-operator-system-install.yaml
+++ b/kubernetes/apps/ottawa/tempo-operator-system/tempo-operator-system-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tempo-operator-system-install
+  namespace: flux-system
+spec:
+  targetNamespace: tempo-operator-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: tempo-operator-system-install
+  path: ./kubernetes/apps/base/tempo-operator-system/tempo-operator-system-install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/tempo/kustomization.yaml
+++ b/kubernetes/apps/ottawa/tempo/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tempo.yaml

--- a/kubernetes/apps/ottawa/tempo/namespace.yaml
+++ b/kubernetes/apps/ottawa/tempo/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tempo
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/tempo/tempo.yaml
+++ b/kubernetes/apps/ottawa/tempo/tempo.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tempo
+  namespace: flux-system
+spec:
+  targetNamespace: tempo
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage-keys
+    - name: tempo-operator-system-install
+  path: ./kubernetes/apps/base/tempo/tempo
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/kubernetes/apps/ottawa/velero/schedules/infisical-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/infisical-backup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: infisical-backup
+  namespace: velero-system
+spec:
+  schedule: "0 10 * * *"  # Daily at 10 AM
+  template:
+    ttl: 720h  # 30 days
+    includedNamespaces:
+      - infisical
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./hermes-backup.yaml
   - ./home-backup.yaml
   - ./bhaiya-backup.yaml
+  - ./infisical-backup.yaml


### PR DESCRIPTION
## Deploy Infisical - Open Source Secret Management

Adds full Infisical deployment on the **Ottawa cluster** with production-grade backing services and multiple backup layers.

### What's in this PR

| Component | Details |
|-----------|---------|
| **Infisical App** | `infisical-standalone` Helm chart, 2 replicas, 1000Mi memory limit |
| **PostgreSQL** | CNPG cluster 2 instances, 10Gi ceph-block, WAL archiving to Garage S3 (30d) |
| **Redis** | Dragonfly, 2 replicas, 512Mi |
| **Ingress** | Envoy Gateway HTTPRoute - `infisical.killinit.cc` (ts) + `infisical.keiretsu.top` (public/private) |
| **Postgres Backups** | Barman Cloud → Garage S3, daily @ 11PM, 30d retention |
| **PVC Backups** | Velero schedule, daily @ 10AM, 30d retention |
| **ESO Integration** | ClusterSecretStore for External Secrets Operator using Universal Auth |

### Pre-merge requirements

- [ ] `sops --encrypt kubernetes/apps/base/infisical/infisical/app/secret.sops.yaml`

### Post-deploy setup

1. Access `https://infisical.keiretsu.top` and create initial admin account
2. Create a **Machine Identity** with Universal Auth
3. Create the ESO credentials secret:
   ```
   kubectl create secret generic infisical-credentials -n external-secrets      --from-literal=clientId=<id> --from-literal=clientSecret=<secret>
   ```
4. Update `projectSlug` in ClusterSecretStore if not using default project