### PR TITLE
fix(tuppr): correct garage health check to v1beta2 tier-aware replica fields

### DIFF
--- a/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-ottawa/config/kubernetes-upgrade.yaml
@@ -20,11 +20,14 @@ spec:
       expr: status.ceph.health != "HEALTH_ERR" && !(has(status.ceph.details) && "PG_AVAILABILITY" in status.ceph.details)
       description: Ceph must have no inactive PGs before upgrading next node
       timeout: 30m
-    - apiVersion: garage.rajsingh.info/v1beta1
+    - apiVersion: garage.rajsingh.info/v1beta2
       kind: GarageCluster
       name: garage
       namespace: garage
-      expr: status.phase == 'Running' && status.readyReplicas == object.spec.replicas
+      expr: |
+        status.phase == 'Running' &&
+          status.storageReadyReplicas >= status.storageReplicas &&
+          status.gatewayReadyReplicas >= status.gatewayReplicas
       description: Garage cluster must be running with all replicas ready
       timeout: 10m
     - apiVersion: postgresql.cnpg.io/v1

--- a/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kubernetes-upgrade.yaml
@@ -20,11 +20,14 @@ spec:
       expr: status.ceph.health != "HEALTH_ERR" && !(has(status.ceph.details) && "PG_AVAILABILITY" in status.ceph.details)
       description: Ceph must have no inactive PGs before upgrading next node
       timeout: 30m
-    - apiVersion: garage.rajsingh.info/v1beta1
+    - apiVersion: garage.rajsingh.info/v1beta2
       kind: GarageCluster
       name: garage
       namespace: garage
-      expr: status.phase == 'Running' && status.readyReplicas == object.spec.replicas
+      expr: |
+        status.phase == 'Running' &&
+          status.storageReadyReplicas >= status.storageReplicas &&
+          status.gatewayReadyReplicas >= status.gatewayReplicas
       description: Garage cluster must be running with all replicas ready
       timeout: 10m
     - apiVersion: postgresql.cnpg.io/v1


### PR DESCRIPTION
Fixes the tuppr Garage health check on ottawa and robbinsdale, which currently can never pass and has the Ottawa kubernetes upgrade (v1.36.1 → v1.36.2) stuck in HealthChecking.

The old check read the CR as v1beta1 and compared `status.readyReplicas == object.spec.replicas`. Under the v1beta2 tiered schema those fields measure different things (aggregate ready vs storage-tier desired), so on Ottawa it evaluates `7 == 1` → always false.

New check uses v1beta2 and compares per tier:

```yaml
expr: |
  status.phase == 'Running' &&
    status.storageReadyReplicas >= status.storageReplicas &&
    status.gatewayReadyReplicas >= status.gatewayReplicas
```

Left for manual merge: merging unblocks tuppr and resumes node drains. Garage is currently degraded (storageNodesOk 9/12, 3 stale storage roles, unfinished resync, stpetersburg partitioned) and already lost the garage-webadmin image from the zot bucket during this upgrade. This check does not gate on quorum/resync, so converge garage first, then merge.
