### PR TITLE
hold(tuppr): pin robbinsdale k8s to v1.36.1 while TalosUpgrade is failed

### DIFF
--- a/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/base/tuppr/tuppr-config-robbinsdale/config/kubernetes-upgrade.yaml
@@ -5,8 +5,10 @@ metadata:
   name: kubernetes
 spec:
   kubernetes:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.36.2
+    # HOLD at current v1.36.1: robbinsdale TalosUpgrade is Failed; do not upgrade k8s until Talos recovers.
+    # Renovate tracking intentionally removed so the version stays pinned; restore the
+    # "# renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet" line to resume.
+    version: v1.36.1
   healthChecks:
     - apiVersion: v1
       kind: Node


### PR DESCRIPTION
Pins robbinsdale's k8s upgrade target to its current v1.36.1 (current == target → tuppr has nothing to drain) while the robbinsdale TalosUpgrade is in a Failed state.

Why now: the merged garage health-check fix (#1810) also unblocks robbinsdale's KubernetesUpgrade. Robbinsdale's 3 control-plane nodes are all Ready, target was v1.36.2, and the only remaining gates are accidental (tuppr still on a stale reconcile + a transient failing Ceph check). When those clear it would drain a control-plane node while Talos can't safely cycle nodes.

Renovate tracking on this line is intentionally removed so it stays pinned; restore the `# renovate:` comment and bump back to v1.36.2 once Talos recovers (~2 days).

Scope: robbinsdale only. Ottawa is unaffected and proceeding normally.
