### PR TITLE
feat(gatus): migrate to gatus-sidecar chart v0.3.6 across all clusters

### DIFF
--- a/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/configmap.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/configmap.yaml
@@ -1,0 +1,216 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatus-config-ottawa
+  namespace: gatus
+data:
+  config.yaml: |
+    alerting:
+      discord:
+        webhook-url: "${discord-webhook-url}"
+        failure-threshold: 2
+        success-threshold: 1
+
+    ui:
+      title: "K8s Ottawa Status"
+      description: "GitOps-managed Kubernetes cluster monitoring"
+      header: "K8s-Ottawa Infrastructure Dashboard"
+      logo: "https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png"
+      link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+      buttons:
+        - name: "GitOps Repository"
+          link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+
+    storage:
+      type: postgres
+      config:
+        address: postgres://gatus-postgres.gatus:5432
+        user: gatus
+        password: "${gatus-pg-password}"
+
+    # Static endpoints — everything else is auto-discovered by the sidecar via HTTPRoutes
+    endpoints:
+      # === External ═══════════════════════════
+      - name: Internet
+        group: External
+        url: https://1.1.1.1
+        interval: 60s
+        client:
+          dns-resolver: "tcp://8.8.8.8:53"
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Cross-Cluster ══════════════════════
+      - name: K8s Ottawa Operator
+        group: Cross-Cluster
+        url: https://ottawa-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: K8s Robbinsdale Operator
+        group: Cross-Cluster
+        url: https://robbinsdale-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: K8s StPetersburg Operator
+        group: Cross-Cluster
+        url: https://stpetersburg-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Nodes ══════════════════════════════
+      - name: Rei (Node)
+        group: Nodes
+        url: tcp://rei.killinit.internal:6443
+        interval: 60s
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Asuka (Node)
+        group: Nodes
+        url: tcp://asuka.killinit.internal:6443
+        interval: 60s
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Kaji (Node)
+        group: Nodes
+        url: tcp://kaji.killinit.internal:6443
+        interval: 60s
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Nagato (NAS)
+        group: Nodes
+        url: tcp://nagato.killinit.internal:445
+        interval: 60s
+        client:
+          insecure: true
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: JetKVM
+        group: Nodes
+        url: tcp://jetkvm.killinit.internal:80
+        interval: 60s
+        client:
+          insecure: true
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Control Plane ═════════════════════
+      - name: etcd (rei)
+        group: Control Plane
+        url: http://rei.killinit.internal:2381/metrics
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 500"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: etcd (asuka)
+        group: Control Plane
+        url: http://asuka.killinit.internal:2381/metrics
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 500"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: etcd (kaji)
+        group: Control Plane
+        url: http://kaji.killinit.internal:2381/metrics
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 500"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Kubernetes API Ready
+        group: Control Plane
+        url: https://k8s.killinit.internal:6443/readyz
+        interval: 60s
+        client:
+          insecure: true
+        conditions:
+          - "[STATUS] == 401"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Storage ═══════════════════════════
+      - name: Ceph MGR Metrics
+        group: Storage
+        url: http://rook-ceph-mgr.rook-ceph:9283
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Garage Robbinsdale (Cross-Cluster)
+        group: Storage
+        url: tcp://robbinsdale-garage.garage:3900
+        interval: 60s
+        client:
+          timeout: 30s
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Garage StPetersburg (Cross-Cluster)
+        group: Storage
+        url: tcp://stpetersburg-garage.garage:3900
+        interval: 60s
+        client:
+          timeout: 30s
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: discord
+            send-on-resolved: true

--- a/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gatus-sidecar
+      version: "0.3.6"
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    priorityClassName: "infra-critical"
+    # Forces a Cilium identity whose low byte != 0x08, avoiding a collision with
+    # Tailscale's LinuxBypassMark (0x80000/0xff0000) that diverts ProxyGroup egress
+    # traffic out eth0 instead of tailscale0. Do not remove without verifying
+    # the resulting identity hex; ~1 in 256 identities will reproduce the bug.
+    podLabels:
+      fwmark-workaround: v1
+    podAnnotations:
+      checksum/webhook: "${DISCORD_WEBHOOK_URL}"
+
+    gatus:
+      image:
+        tag: v5.36.0
+      logLevel: INFO
+      env:
+        TZ: America/Chicago
+      envFrom:
+        - secretRef:
+            name: gatus
+
+    sidecar:
+      enabled: true
+      logLevel: info
+      gatewayNames:
+        - public
+        - ts
+        - private
+      kinds:
+        ingress:
+          enable: false
+          auto: false
+        httproute:
+          enable: true
+          auto: true
+        service:
+          enable: true
+          auto: false
+        ingressroute:
+          enable: false
+          auto: false
+      defaultInterval: 1m
+      probePaths: true
+
+    config:
+      existingConfigMap: gatus-config-ottawa
+      items:
+        - key: config.yaml
+          path: config.yaml
+
+    httpRoute:
+      enabled: true
+      annotations:
+        item.homer.rajsingh.info/name: "Gatus"
+        item.homer.rajsingh.info/subtitle: "Service Monitoring"
+        item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/gatus.svg"
+        item.homer.rajsingh.info/keywords: "monitoring, uptime, status"
+        service.homer.rajsingh.info/name: "Infrastructure"
+        service.homer.rajsingh.info/icon: "fas fa-server"
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: public
+          namespace: home
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: ts
+          namespace: home
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: private
+          namespace: home
+      hostnames:
+        - "status.${CLUSTER_DOMAIN}"
+
+    persistence:
+      enabled: true
+      storageClass: ceph-block-replicated
+      size: 1Gi
+
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi

--- a/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gatus
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/secret.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatus
+  namespace: gatus
+type: Opaque
+stringData:
+  discord-webhook-url: "${DISCORD_WEBHOOK_URL}"

--- a/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/configmap.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/configmap.yaml
@@ -1,0 +1,194 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatus-config-robbinsdale
+  namespace: gatus
+data:
+  config.yaml: |
+    alerting:
+      discord:
+        webhook-url: "${discord-webhook-url}"
+        failure-threshold: 2
+        success-threshold: 1
+
+    ui:
+      title: "K8s Robbinsdale Status"
+      description: "GitOps-managed Kubernetes cluster monitoring"
+      header: "K8s-Robbinsdale Infrastructure Dashboard"
+      logo: "https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png"
+      link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+      buttons:
+        - name: "GitOps Repository"
+          link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+
+    endpoints:
+      # === External ═══════════════════════════
+      - name: Internet
+        group: External
+        url: https://1.1.1.1
+        interval: 60s
+        client:
+          dns-resolver: "tcp://8.8.8.8:53"
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Websites ═══════════════════════════
+      - name: Raj Singh Portfolio
+        group: Websites
+        url: https://www.rajsingh.info
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Luke Houge Portfolio
+        group: Websites
+        url: https://www.lukehouge.com
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Cloudflared Tunnel
+        group: Websites
+        url: https://status.rajsingh.info
+        interval: 60s
+        client:
+          dns-resolver: "tcp://1.1.1.1:53"
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Cross-Cluster ══════════════════════
+      - name: K8s Ottawa Operator
+        group: Cross-Cluster
+        url: https://ottawa-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: K8s Robbinsdale Operator
+        group: Cross-Cluster
+        url: https://robbinsdale-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: K8s StPetersburg Operator
+        group: Cross-Cluster
+        url: https://stpetersburg-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Nodes ══════════════════════════════
+      - name: Stone (Node)
+        group: Nodes
+        url: tcp://stone.local:6443
+        interval: 60s
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Tank (Node)
+        group: Nodes
+        url: tcp://tank.local:6443
+        interval: 60s
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Titan (Node)
+        group: Nodes
+        url: tcp://titan.local:6443
+        interval: 60s
+        conditions:
+          - "[CONNECTED] == true"
+          - "[RESPONSE_TIME] < 1000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Ubiquiti UNAS Pro
+        group: Nodes
+        url: https://nas.local
+        interval: 60s
+        client:
+          insecure: true
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 3000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Control Plane ═════════════════════
+      - name: Kubernetes API Ready
+        group: Control Plane
+        url: https://k8s.robbinsdale.local:6443/readyz
+        interval: 60s
+        client:
+          insecure: true
+        conditions:
+          - "[STATUS] == 401"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Storage ═══════════════════════════
+      - name: Garage Ottawa
+        group: Storage
+        url: tcp://ottawa-garage.garage:3900
+        interval: 60s
+        client:
+          timeout: 30s
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Garage StPetersburg
+        group: Storage
+        url: tcp://stpetersburg-garage.garage:3900
+        interval: 60s
+        client:
+          timeout: 30s
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: discord
+            send-on-resolved: true

--- a/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gatus-sidecar
+      version: "0.3.6"
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    priorityClassName: "infra-critical"
+    podLabels:
+      fwmark-workaround: v1
+    podAnnotations:
+      checksum/webhook: "${GATUS_DISCORD_WEBHOOK_URL}"
+
+    gatus:
+      image:
+        tag: v5.36.0
+      logLevel: INFO
+      env:
+        TZ: America/Chicago
+      envFrom:
+        - secretRef:
+            name: gatus
+
+    sidecar:
+      enabled: true
+      logLevel: info
+      gatewayNames:
+        - public
+        - ts
+        - private
+      kinds:
+        ingress:
+          enable: false
+          auto: false
+        httproute:
+          enable: true
+          auto: true
+        service:
+          enable: true
+          auto: false
+        ingressroute:
+          enable: false
+          auto: false
+      defaultInterval: 1m
+      probePaths: true
+
+    config:
+      existingConfigMap: gatus-config-robbinsdale
+      items:
+        - key: config.yaml
+          path: config.yaml
+
+    httpRoute:
+      enabled: true
+      annotations:
+        item.homer.rajsingh.info/name: "Gatus"
+        item.homer.rajsingh.info/subtitle: "Service Monitoring"
+        item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/gatus.svg"
+        item.homer.rajsingh.info/keywords: "monitoring, uptime, status"
+        service.homer.rajsingh.info/name: "Infrastructure"
+        service.homer.rajsingh.info/icon: "fas fa-server"
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: public
+          namespace: home
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: ts
+          namespace: home
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: private
+          namespace: home
+      hostnames:
+        - "status.${CLUSTER_DOMAIN}"
+
+    persistence:
+      enabled: true
+      storageClass: ceph-block-replicated-nvme
+      size: 1Gi
+
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi

--- a/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gatus
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/secret.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatus
+  namespace: gatus
+type: Opaque
+stringData:
+  discord-webhook-url: ${GATUS_DISCORD_WEBHOOK_URL}

--- a/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/configmap.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/configmap.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatus-config-stpetersburg
+  namespace: gatus
+data:
+  config.yaml: |
+    alerting:
+      discord:
+        webhook-url: "${discord-webhook-url}"
+        failure-threshold: 2
+        success-threshold: 1
+
+    ui:
+      title: "K8s St. Petersburg Status"
+      description: "GitOps-managed GPU cluster monitoring"
+      header: "K8s-StPetersburg GPU Infrastructure Dashboard"
+      link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+      buttons:
+        - name: "GitOps Repository"
+          link: "https://github.com/keiretsu-labs/kubernetes-manifests"
+
+    endpoints:
+      # === External ═══════════════════════════
+      - name: Internet
+        group: External
+        url: https://1.1.1.1
+        interval: 60s
+        client:
+          dns-resolver: "tcp://8.8.8.8:53"
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Cross-Cluster ══════════════════════
+      - name: K8s Ottawa Operator
+        group: Cross-Cluster
+        url: https://ottawa-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: K8s Robbinsdale Operator
+        group: Cross-Cluster
+        url: https://robbinsdale-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: K8s StPetersburg Operator
+        group: Cross-Cluster
+        url: https://stpetersburg-k8s-operator.keiretsu.ts.net:443/readyz
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Control Plane ═════════════════════
+      - name: Kubernetes API Ready
+        group: Control Plane
+        url: https://k8s.stpetersburg.internal:6443/readyz
+        interval: 60s
+        client:
+          insecure: true
+        conditions:
+          - "[STATUS] == 401"
+          - "[RESPONSE_TIME] < 2000"
+          - "[CERTIFICATE_EXPIRATION] > 168h"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+
+      # === Storage ═══════════════════════════
+      - name: Garage Ottawa
+        group: Storage
+        url: tcp://ottawa-garage.garage:3900
+        interval: 60s
+        client:
+          timeout: 30s
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: discord
+            send-on-resolved: true
+      - name: Garage Robbinsdale
+        group: Storage
+        url: tcp://robbinsdale-garage.garage:3900
+        interval: 60s
+        client:
+          timeout: 30s
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: discord
+            send-on-resolved: true

--- a/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gatus-sidecar
+      version: "0.3.6"
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    priorityClassName: "infra-critical"
+    podLabels:
+      fwmark-workaround: v1
+    podAnnotations:
+      checksum/webhook: "${DISCORD_WEBHOOK_URL}"
+
+    gatus:
+      image:
+        tag: v5.36.0
+      logLevel: INFO
+      env:
+        TZ: America/Chicago
+      envFrom:
+        - secretRef:
+            name: gatus
+
+    sidecar:
+      enabled: true
+      logLevel: info
+      gatewayNames:
+        - public
+        - ts
+        - private
+      kinds:
+        ingress:
+          enable: false
+          auto: false
+        httproute:
+          enable: true
+          auto: true
+        service:
+          enable: true
+          auto: false
+        ingressroute:
+          enable: false
+          auto: false
+      defaultInterval: 1m
+      probePaths: true
+
+    config:
+      existingConfigMap: gatus-config-stpetersburg
+      items:
+        - key: config.yaml
+          path: config.yaml
+
+    httpRoute:
+      enabled: true
+      annotations:
+        item.homer.rajsingh.info/name: "Gatus"
+        item.homer.rajsingh.info/subtitle: "Service Monitoring"
+        item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/gatus.svg"
+        item.homer.rajsingh.info/keywords: "monitoring, uptime, status"
+        service.homer.rajsingh.info/name: "Infrastructure"
+        service.homer.rajsingh.info/icon: "fas fa-server"
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: public
+          namespace: home
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: ts
+          namespace: home
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: private
+          namespace: home
+      hostnames:
+        - "status.${CLUSTER_DOMAIN}"
+
+    persistence:
+      enabled: true
+      storageClass: local-path
+      size: 1Gi
+
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi

--- a/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/kustomization.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gatus
+resources:
+  - helmrelease.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/secret.yaml
+++ b/kubernetes/apps/base/gatus/gatus-sidecar-stpete/app/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatus
+  namespace: gatus
+type: Opaque
+stringData:
+  discord-webhook-url: ${DISCORD_WEBHOOK_URL}

--- a/kubernetes/apps/ottawa/gatus/gatus.yaml
+++ b/kubernetes/apps/ottawa/gatus/gatus.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  path: ./kubernetes/apps/base/gatus/gatus-ottawa/app
+  path: ./kubernetes/apps/base/gatus/gatus-sidecar-ottawa/app
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/robbinsdale/gatus/gatus.yaml
+++ b/kubernetes/apps/robbinsdale/gatus/gatus.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  path: ./kubernetes/apps/base/gatus/gatus-robbinsdale/app
+  path: ./kubernetes/apps/base/gatus/gatus-sidecar-robbinsdale/app
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/stpetersburg/gatus/gatus.yaml
+++ b/kubernetes/apps/stpetersburg/gatus/gatus.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  path: ./kubernetes/apps/base/gatus/gatus/app
+  path: ./kubernetes/apps/base/gatus/gatus-sidecar-stpete/app
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

Migrate all 3 clusters from the standalone `twin/gatus` chart to the `home-operations/gatus-sidecar` OCI chart (v0.3.6) for automatic HTTPRoute discovery.

## What changed

- **New base dirs**: `kubernetes/apps/base/gatus/gatus-sidecar-{cluster}/app/`
  - `helmrelease.yaml` — Uses `home-operations/gatus-sidecar` OCI chart with sidecar auto-discovery of HTTPRoutes
  - `configmap.yaml` — Static endpoints (external/infra only; ~85% of old inline endpoints now auto-discovered)
  - `secret.yaml` — Discord webhook from cluster vars
- **Updated Flux Kustomizations**: All 3 cluster-level `gatus.yaml` files now point to the sidecar base dirs
- **Old configs preserved** under `kubernetes/apps/base/gatus/gatus/`, `gatus-ottawa/`, `gatus-robbinsdale/` (now dead code)

## Static endpoints retained (sidecar handles the rest)

| Cluster | Static endpoints |
|---------|-----------------|
| ottawa  | Internet, cross-cluster Tailscale, nodes (rei/asuka/kaji), NAS (nagato), JetKVM, etcd, K8s API, Ceph MGR, cross-cluster Garage |
| robbinsdale | Internet, websites (rajsingh/lukehouge), cross-cluster Tailscale, nodes (stone/tank/titan), UNAS Pro, K8s API, cross-cluster Garage |
| stpetersburg | Internet, cross-cluster Tailscale, K8s API, cross-cluster Garage |

## Storage

- Ottawa: 1Gi `ceph-block-replicated` PVC
- Robbinsdale: 1Gi `ceph-block-replicated-nvme` PVC
- StPetersburg: 1Gi `local-path` PVC

## HelmRelease highlights

- Sidecar watches HTTPRoutes on `public`, `ts`, `private` gateways
- Gatus v5.36.0, Cilium fwmark workaround retained
- Priority class: `infra-critical`
- Gatus UI exposed via chart-native HTTPRoute at `status.${CLUSTER_DOMAIN}`