### PR TITLE
frigate(ottawa): add user emails, Lua redirect, and DNS cnames

### DIFF
--- a/kubernetes/apps/base/home/home-ottawa/frigate/kustomization.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./securitypolicy.yaml
   - ./unifi-talkback-secret.yaml
   - ./webrtc-routes.yaml
+  - ./tinyauth-redirect-lua.yaml

--- a/kubernetes/apps/base/home/home-ottawa/frigate/securitypolicy.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/securitypolicy.yaml
@@ -3,7 +3,7 @@
 # tinyauth does authN only (google login, injects remote-email); the per-user
 # authorization decision lives in this policy's authorization block. EG's RBAC
 # filter runs after extAuth, so it matches on the header tinyauth injects.
-# frigate is shared — raj + kartik.
+# frigate is shared — raj, kartik, ypb141163, bharathgk, suchitra95.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
@@ -42,3 +42,6 @@ spec:
               values:
                 - rajsinghcpre@gmail.com
                 - kartikbharath@gmail.com
+                - ypb141163@gmail.com
+                - bharathgk@gmail.com
+                - suchitra95@gmail.com

--- a/kubernetes/apps/base/home/home-ottawa/frigate/tinyauth-redirect-lua.yaml
+++ b/kubernetes/apps/base/home/home-ottawa/frigate/tinyauth-redirect-lua.yaml
@@ -1,0 +1,33 @@
+# tinyauth returns 401 with x-tinyauth-location for unauthenticated requests
+# (NGINX-compatible pattern using error_page 401). Envoy Gateway's ext_authz
+# passes the 401 straight to the client instead of redirecting. This Lua
+# response script catches that pattern and converts it to a proper 302 redirect
+# that the browser follows to the Google OAuth login page.
+#
+# IMPORTANT: This MUST target the HTTPRoute (not Gateway). In EG v1.8.1,
+# Gateway-level Lua runs before per-route ext_authz in the filter chain, so
+# it never sees the ext_authz local reply. Route-level Lua runs after and
+# can intercept and convert the 401.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyExtensionPolicy
+metadata:
+  name: frigate-tinyauth-redirect
+  namespace: home
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: frigate
+  lua:
+    - inline: |
+        function envoy_on_response(response_handle)
+          local headers = response_handle:headers()
+          if headers:get(":status") == "401" then
+            local location = headers:get("x-tinyauth-location")
+            if location then
+              headers:replace(":status", "302")
+              headers:add("Location", location)
+              headers:remove("x-tinyauth-location")
+            end
+          end
+        end

--- a/kubernetes/apps/base/k8gb/k8gb-common/config/cnames.yaml
+++ b/kubernetes/apps/base/k8gb/k8gb-common/config/cnames.yaml
@@ -130,6 +130,28 @@ spec:
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"
+    - dnsName: "infisical.${COMMON_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "ottawa.${COMMON_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
+    # frigate NVR behind tinyauth on the public envoy gateway
+    - dnsName: "frigate.${COMMON_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "ottawa.${COMMON_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
+    - dnsName: "frigate.${LOCATION}.${COMMON_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "ottawa.${COMMON_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
 ---
 # Wildcard CNAMEs that only Cloudflare can serve. UniFi's static-DNS API rejects
 # wildcard hostnames (400 Invalid Hostname), so these are isolated under a


### PR DESCRIPTION
**Clean PR — only frigate changes, no unrelated commits**

Changes:
1. **SecurityPolicy** — added 3 emails: `ypb141163@gmail.com`, `bharathgk@gmail.com`, `suchitra95@gmail.com`
2. **EnvoyExtensionPolicy** — new `frigate-tinyauth-redirect` Lua redirect for 401→302 login flow
3. **DNS** — `frigate.keiretsu.top` → CNAME `ottawa.keiretsu.top` and `frigate.ottawa.keiretsu.top` → CNAME `ottawa.keiretsu.top`
4. **Kustomization** — wired in the new Lua redirect file

Files changed: 4 files (+60/-1)