### PR TITLE
frigate(ottawa): user emails, Lua redirect, DNS cnames + *.ottawa wildcard cert

### DIFF
--- a/kubernetes/apps/base/home/home/local-gateway/certificate-location.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/certificate-location.yaml
@@ -1,15 +1,15 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: wildcard-agents-${COMMON_DOMAIN//./-}
+  name: wildcard-location-${COMMON_DOMAIN//./-}
 spec:
   dnsNames:
-    - '*.agents.${COMMON_DOMAIN}'
+    - '*.${LOCATION}.${COMMON_DOMAIN}'
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
     name: keiretsu-top
-  secretName: wildcard-agents-${COMMON_DOMAIN//./-}
+  secretName: wildcard-ottawa-${COMMON_DOMAIN//./-}
   usages:
     - digital signature
     - key encipherment

--- a/kubernetes/apps/base/home/home/local-gateway/gateway-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/gateway-public.yaml
@@ -107,6 +107,19 @@ spec:
         - group: ''
           kind: Secret
           name: wildcard-hermes-keiretsu-top
+    - name: wildcard-location-keiretsu-top-https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${LOCATION}.keiretsu.top"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - group: ''
+          kind: Secret
+          name: wildcard-ottawa-keiretsu-top
     - name: wildcard-bhaiya-keiretsu-top-https
       protocol: HTTPS
       port: 443

--- a/kubernetes/apps/base/home/home/local-gateway/kustomization.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - certificate-agents.yaml
   - certificate-hermes.yaml
   - certificate-bhaiya.yaml
+  - certificate-location.yaml


### PR DESCRIPTION
**Clean PR — two commits, only frigate+gateway changes**

Commit 1: frigate config
- SecurityPolicy: +3 emails (ypb141163, bharathgk, suchitra95)
- EnvoyExtensionPolicy: frigate-tinyauth-redirect (401→302)
- DNS CNAMEs: frigate.keiretsu.top + frigate.ottawa.keiretsu.top → ottawa.keiretsu.top

Commit 2: TLS for location subdomains
- Certificate: wildcard-ottawa-keiretsu-top for `*.ottawa.keiretsu.top`
- Gateway listener: `wildcard-location-keiretsu-top-https` on public gateway

This enables https://frigate.ottawa.keiretsu.top with valid TLS.