### PR TITLE
components: limit-range request-floor (pilot: cloudflare)

### DIFF
--- a/kubernetes/apps/base/cloudflare/cloudflare/kustomization.yaml
+++ b/kubernetes/apps/base/cloudflare/cloudflare/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cloudflare
+components:
+  - ../../../../components/limit-range
 resources:
   - ddns-keiretsu-top.yaml
   - ddns-rajsingh-info.yaml

--- a/kubernetes/components/limit-range/kustomization.yaml
+++ b/kubernetes/components/limit-range/kustomization.yaml
@@ -1,0 +1,20 @@
+# limit-range: give every container in a namespace a memory/CPU request FLOOR
+# it doesn't already set. Fixes the fleet-wide "60% of pods are BestEffort"
+# problem that drives node overcommit + random OOM-kills. See limitrange.yaml
+# for the rationale.
+#
+# Opt in from a base app dir (the kustomization that sets `namespace:` — the
+# LimitRange inherits it and lands in the right namespace on every cluster that
+# carries the app's pointer):
+#
+#   namespace: <ns>
+#   components:
+#     - ../../../../components/limit-range      # adjust relative depth
+#
+# Floor-only by design: it never rejects a pod and adds no limit, so rollout is
+# safe. Bounding runaway pods with default *limits* is a per-namespace phase-2
+# change that should be sized from real p95 usage, not guessed globally.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - limitrange.yaml

--- a/kubernetes/components/limit-range/limitrange.yaml
+++ b/kubernetes/components/limit-range/limitrange.yaml
@@ -1,0 +1,25 @@
+---
+# Memory/CPU request FLOOR for every container in the namespace that ships no
+# requests of its own. Purely additive — LimitRange defaultRequest only fills in
+# missing values, it never rejects a pod and imposes no limit (no new OOM-kill
+# ceiling). Containers keep whatever they already declare.
+#
+# Why this matters (fleet-wide): ~60% of running pods currently declare no
+# memory request, so they land as BestEffort. Two consequences:
+#   1. The scheduler packs nodes off phantom "~30% used" numbers and overcommits
+#      memory limits to 95–117% of allocatable — the setup for a node OOM.
+#   2. The kernel OOM-killer scores victims by (usage − request); a zero request
+#      scores worst, so the pods with no floor die FIRST — often not the pod
+#      that caused the pressure. OOMs feel random as a result.
+# Giving every container a small request moves it BestEffort→Burstable, makes the
+# scheduler honest, and reshapes who the kernel sacrifices under pressure.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: request-floor
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 25m
+        memory: 64Mi


### PR DESCRIPTION
## What

Adds a reusable kustomize `Component` — `kubernetes/components/limit-range/` — that sets a memory/CPU **`defaultRequest`** (64Mi / 25m) for any container in a namespace that ships no requests of its own. Wired into the `cloudflare` base app as the first pilot; it deploys to all three clusters via the existing pointer.

**Floor-only by design:** `defaultRequest` only fills in missing values — it never rejects a pod and imposes no limit, so there's no new OOM-kill ceiling. Rollout is safe.

## Why

Fleet audit (ottawa/robbinsdale/stpetersburg):

| Cluster | Running pods | No mem limit | Guaranteed | Node limit oversubscription |
|---|---|---|---|---|
| ottawa | 392 | 247 (63%) | 3 | 94–97% on 3/4 nodes |
| robbinsdale | 283 | 193 (68%) | 3 | 63–85% |
| stpetersburg | 194 | 115 (59%) | 3 | orin-0 **226%**, sparks 110–117% |

~60% of pods declare no memory request → land BestEffort. Two consequences:
1. The scheduler packs nodes off phantom "~30% used" numbers and overcommits limits to 95–117% of allocatable — the setup for node OOM.
2. The kernel OOM-killer scores by `(usage − request)`; a zero request scores worst and dies first — often not the culprit. OOMs look random.

A request floor makes scheduler reservations honest and reshapes OOM-victim ordering, without introducing kill ceilings.

## Rollout

- **This PR:** cloudflare pilot (tiny, disposable pods on all clusters).
- **Next:** add the same `components:` line per namespace — one owner each (external-secrets has two kustomizations targeting its ns, needs care to avoid a duplicate LimitRange).
- **Phase 2:** bound bursty families (arc runners, kopia/velero jobs, prometheus WAL) with default *limits* sized from live p95.
- **Phase 3:** install VPA (recommend mode — not present on any cluster today) to set requests from data.
- Assign the existing `infra-critical`/`high`/`default` priorityClasses to singletons.

## Validation

`make test-talos-ottawa` — cloudflare-app Kustomization + all external-dns HelmReleases render green. LimitRange renders namespaced to `cloudflare`. (Pre-existing unrelated `GitRepository/bhaiya` offline-secret failure only.)