### PR TITLE
velero: bound repository-maintenance jobs (memory LimitRange)

### DIFF
--- a/kubernetes/apps/base/velero/velero/kustomization.yaml
+++ b/kubernetes/apps/base/velero/velero/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ./namespace.yaml
   - ./velero-key.yaml
   - ./helmrelease.yaml
+  - ./limitrange.yaml
   - ./servicemonitor.yaml
   - ./dashboard-configmap.yaml
   - ./grafana-dashboard.yaml

--- a/kubernetes/apps/base/velero/velero/limitrange.yaml
+++ b/kubernetes/apps/base/velero/velero/limitrange.yaml
@@ -1,0 +1,28 @@
+---
+# Bound velero's repository-maintenance (kopia) jobs. Velero spawns them with
+# NO memory limit, and they burst to ~1 GiB (measured peak 1040Mi on ottawa,
+# 14d) — an unbounded batch family that can push a node into OOM. A LimitRange
+# is used instead of the velero chart's maintenance-job resource keys because it
+# is chart-version-proof and also catches the ad-hoc UUID-named job pods.
+#
+# Scope: only fills containers that set no memory limit, so velero-server and
+# node-agent (which already declare limits) are untouched. defaultRequest is set
+# explicitly so the default LIMIT does not silently pull the request up to 2Gi
+# (LimitRange sets request=limit when only `default` is given). Memory only —
+# leaving cpu unbounded is fine for restartable batch jobs.
+#
+# Interplay with the cluster-wide memory-request-floor MutatingAdmissionPolicy:
+# both target a missing memory request; whichever admission stage runs first
+# wins (64Mi from the policy or 256Mi here), and the 2Gi limit applies either
+# way. Bounding, not the exact request, is the point.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: velero-maintenance-bounds
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        memory: 256Mi
+      default:
+        memory: 2Gi


### PR DESCRIPTION
## What
Adds a `velero-system` LimitRange capping container memory at **2Gi** (request floor 256Mi). Phase 2 of the fleet OOM-hygiene work (follows the memory-request-floor MAP, #1868).

## Why
Velero spawns kopia **repository-maintenance jobs with no memory limit**. Measured peak working set (Mimir, 14d):

| cluster | peak maintenance-job memory |
|---|---|
| ottawa | **1040Mi** |
| stpetersburg | 628Mi |
| robbinsdale | 723Mi |

That's the one genuinely unbounded bursty family left after the audit — a runaway maintenance job can push a node toward OOM. (Checked the others: prometheus is already bounded at 1Gi/2Gi in agent mode; arc runners peak 40–63Mi.)

## Why a LimitRange, not the chart's maintenance-job resource keys
- Chart-version-proof, and catches the ad-hoc UUID-named job pods.
- Only fills containers with **no** memory limit → velero-server and node-agent (which already declare limits) are untouched.
- `defaultRequest` is set explicitly so the default limit doesn't silently pull the request up to 2Gi (LimitRange sets request=limit when only `default` is given).
- Memory only — cpu stays unbounded, fine for restartable batch.

## Verified live (stpetersburg, where the MAP is already active)
A no-request pod in `velero-system` → `requests{memory:256Mi}` + `limits{memory:2Gi}`, Burstable. Deterministic alongside the memory-request-floor MAP: the LimitRange applies its request first, the MAP then sees memory present and skips. `make test` green on all clusters.

## Remaining follow-ups
- VPA recommend mode (not installed on any cluster) to set requests from data fleet-wide.
- Assign existing `infra-critical/high/default` priorityClasses to singletons.