### PR TITLE
vpa-system: VPA recommender-only (fleet-wide right-sizing data)

### DIFF
--- a/clusters/common/flux/repositories/helm/kustomization.yaml
+++ b/clusters/common/flux/repositories/helm/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ./envoy-gateway.yaml
   - ./external-dns.yaml
   - ./external-secrets.yaml
+  - ./fairwinds.yaml
   - ./nvidia.yaml
   - ./nvidia-device-plugin.yaml
   - ./fluent.yaml

--- a/kubernetes/apps/base/vpa-system/vpa/helmrelease.yaml
+++ b/kubernetes/apps/base/vpa-system/vpa/helmrelease.yaml
@@ -1,0 +1,51 @@
+---
+# Vertical Pod Autoscaler — RECOMMENDER ONLY.
+#
+# The updater and admission-controller are disabled, so VPA physically cannot
+# evict or mutate any pod: it only computes recommendations you read with
+#   kubectl get vpa -A
+#   kubectl describe vpa <name>            # target / lowerBound / upperBound
+# Create VerticalPodAutoscaler CRs with updateMode: "Off" for the workloads you
+# want sized; the recommender fills in .status.recommendation from usage history
+# (metrics-server backed). Nothing changes on the cluster until a human copies a
+# recommendation into a request. This is the data source that replaces guessing
+# at the 64Mi memory-request floor.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vpa
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: vpa
+      version: 4.12.3
+      sourceRef:
+        kind: HelmRepository
+        name: fairwinds
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    recommender:
+      enabled: true
+      replicaCount: 1
+      priorityClassName: infra-default
+      extraArgs:
+        pod-recommendation-min-cpu-millicores: 15
+        pod-recommendation-min-memory-mb: 100
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+    # recommend-only: no eviction, no pod mutation
+    updater:
+      enabled: false
+    admissionController:
+      enabled: false

--- a/kubernetes/apps/base/vpa-system/vpa/kustomization.yaml
+++ b/kubernetes/apps/base/vpa-system/vpa/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -59,6 +59,7 @@ resources:
   - ./k8s-gpu-dra-driver
   - ./rook-ceph
   - ./velero
+  - ./vpa-system
   - ./victoria-logs
   - ./victoria-logs/victoria-logs.yaml
   - ./woodpecker

--- a/kubernetes/apps/ottawa/vpa-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/vpa-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./vpa.yaml

--- a/kubernetes/apps/ottawa/vpa-system/namespace.yaml
+++ b/kubernetes/apps/ottawa/vpa-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vpa-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/vpa-system/vpa.yaml
+++ b/kubernetes/apps/ottawa/vpa-system/vpa.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vpa
+  namespace: flux-system
+spec:
+  targetNamespace: vpa-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/vpa-system/vpa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -46,5 +46,6 @@ resources:
   - ./tinyauth-egress
   - ./rook-ceph
   - ./velero
+  - ./vpa-system
   - ./victoria-logs
   - ./victoria-logs/victoria-logs.yaml

--- a/kubernetes/apps/robbinsdale/vpa-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/vpa-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./vpa.yaml

--- a/kubernetes/apps/robbinsdale/vpa-system/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/vpa-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vpa-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/robbinsdale/vpa-system/vpa.yaml
+++ b/kubernetes/apps/robbinsdale/vpa-system/vpa.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vpa
+  namespace: flux-system
+spec:
+  targetNamespace: vpa-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/vpa-system/vpa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -44,5 +44,6 @@ resources:
   - ./spiderpool
   - ./gpu-operator
   - ./velero
+  - ./vpa-system
   - ./victoria-logs
   - ./victoria-logs/victoria-logs.yaml

--- a/kubernetes/apps/stpetersburg/vpa-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/vpa-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./vpa.yaml

--- a/kubernetes/apps/stpetersburg/vpa-system/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/vpa-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vpa-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/stpetersburg/vpa-system/vpa.yaml
+++ b/kubernetes/apps/stpetersburg/vpa-system/vpa.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vpa
+  namespace: flux-system
+spec:
+  targetNamespace: vpa-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/vpa-system/vpa
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m


### PR DESCRIPTION
## What
Installs the Fairwinds **`vpa`** chart on all three clusters with **only the recommender** enabled (`updater.enabled: false`, `admissionController.enabled: false`). Also registers the `fairwinds` HelmRepository, which had a source file in the repo but was never listed in the helm-repos kustomization (so it wasn't deployed anywhere — render caught this).

## Why recommender-only
VPA physically **cannot evict or mutate any pod** in this mode — it only computes recommendations you read with:
```
kubectl get vpa -A
kubectl describe vpa <name>     # target / lowerBound / upperBound
```
Zero blast radius. This is the data source that replaces guessing at the 64Mi memory-request floor from the MAP (#1868): create `VerticalPodAutoscaler` CRs with `updateMode: "Off"` for the workloads worth sizing, let the recommender fill in `.status.recommendation` from usage history, then copy values into requests by hand. Nothing changes automatically.

`metrics-server` (the recommender's dependency) is already running on all three clusters.

## Validation
`make test` renders green on all three clusters (fixed the `fairwinds not ready: dependency not found` error by registering the repo). It's a HelmRelease so live verification is post-merge:
- recommender pod `Running` in `vpa-system`
- create a sample `VerticalPodAutoscaler` (updateMode Off) and confirm `kubectl describe vpa` populates a recommendation after a few minutes.

## Notes
- Deployed as a new `vpa-system` namespace + pointer per cluster (standard overlay pattern).
- Follow-up (optional): point the recommender at Mimir for longer history, or add Goldilocks for a recommendations dashboard + auto-VPA creation — deferred to avoid extra moving parts.