### PR TITLE
monitoring: prometheus agent priorityClass (infra-high)

### DIFF
--- a/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
@@ -40,6 +40,10 @@ spec:
       # tax a full server pays, dropping RSS from multi-GB to a few hundred MB.
       agentMode: true
       prometheusSpec:
+        # Observability agent — keep it above default workloads under memory
+        # pressure so it isn't the first thing evicted (its sibling alertmanager
+        # below already uses infra-high).
+        priorityClassName: infra-high
         externalLabels:
           cluster: ${CLUSTER_NAME}
         externalUrl: https://prometheus.${CLUSTER_DOMAIN}


### PR DESCRIPTION
## What
Adds `priorityClassName: infra-high` to the prometheus agent's `prometheusSpec`.

## Why
The agent had no priority class while its sibling alertmanager in the **same** values file already uses `infra-high`. Under node memory pressure the metrics agent was therefore among the first candidates for eviction/OOM. Matching it to `infra-high` keeps observability alive during contention.

## Scope note
This is a *targeted* fill, not a sweep — the audit showed priority assignment is already largely handled:
- cilium and coredns get built-in `system-node-critical` / `system-cluster-critical` from their charts.
- cert-manager, external-secrets, tailscale operator, garage, rook-ceph, local-path, fluent-bit, gatus, alertmanager, etc. already carry the `infra-*` classes.

Remaining lower-priority gaps (envoy-gateway, k8gb, spiderpool) are deferred — they're multi-component charts that warrant their own change, and none are as exposed as the metrics agent.

## Validation
`make test` green on all clusters. `infra-high` PriorityClass already exists live (defined in `kubernetes/apps/base/tailscale/resources/priorityclasses.yaml`, used by alertmanager).