### PR TITLE
priorityclass: fill envoy-gateway + k8gb gaps (infra-high)

### DIFF
--- a/kubernetes/apps/base/envoy-gateway-system/envoy-gw-common/install/helmrelease.yaml
+++ b/kubernetes/apps/base/envoy-gateway-system/envoy-gw-common/install/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
     crds: CreateReplace
   releaseName: envoy-gateway
   values:
+    deployment:
+      # Keep the gateway control plane above default workloads under memory
+      # pressure; the data-plane proxies carry the same class via their
+      # EnvoyProxy CRs (home namespace).
+      priorityClassName: infra-high
     config:
       envoyGateway:
         extensionApis:

--- a/kubernetes/apps/base/home/home/local-gateway/envoyproxy-private.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoyproxy-private.yaml
@@ -15,6 +15,7 @@ spec:
       envoyDeployment:
         replicas: 2
         pod:
+          priorityClassName: infra-high
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists

--- a/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
@@ -15,6 +15,7 @@ spec:
       envoyDeployment:
         replicas: 2
         pod:
+          priorityClassName: infra-high
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists

--- a/kubernetes/apps/base/home/home/tailscale-gateway/envoyproxy.yaml
+++ b/kubernetes/apps/base/home/home/tailscale-gateway/envoyproxy.yaml
@@ -15,6 +15,7 @@ spec:
       envoyDeployment:
         replicas: 2
         pod:
+          priorityClassName: infra-high
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists

--- a/kubernetes/apps/base/k8gb/k8gb-common/app/helmrelease.yaml
+++ b/kubernetes/apps/base/k8gb/k8gb-common/app/helmrelease.yaml
@@ -14,6 +14,18 @@ spec:
         kind: HelmRepository
         name: k8gb
         namespace: flux-system
+  # The k8gb chart exposes no priorityClassName for the controller Deployment
+  # (only the bundled coredns does, set below), so patch it in post-render.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: k8gb
+            patch: |
+              - op: add
+                path: /spec/template/spec/priorityClassName
+                value: infra-high
   values:
     k8gb:
       imageRepo: ghcr.io/rajsinghtech/k8gb
@@ -47,6 +59,7 @@ spec:
 
     coredns:
       replicaCount: 3
+      priorityClassName: infra-high
       serviceType: LoadBalancer
       service:
         loadBalancerIP: "${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.10.53"


### PR DESCRIPTION
## What
Completes critical-singleton priorityClass coverage — the deferred gaps from the OOM-hygiene work.

Audit result: **spiderpool already runs `system-node-critical`** (chart default, verified live), so only envoy-gateway and k8gb were actually uncovered:

| component | how |
|---|---|
| envoy-gateway controller | `values.deployment.priorityClassName` |
| envoy data-plane proxies (ts / private / public) | `priorityClassName` in each `EnvoyProxy` CR's `envoyDeployment.pod` |
| k8gb bundled coredns | `values.coredns.priorityClassName` |
| k8gb controller | Flux **postRenderer** kustomize patch (chart exposes no priorityClassName) |

## Why infra-high
The envoy proxies carry live ingress traffic, matching the tailscale ingress/egress proxies which already use `infra-high`. Cluster-critical components (cilium, coredns) already carry built-in `system-*-critical`, so `infra-high` is the right tier for this application-infra layer — above default workloads, below node/cluster-critical.

## Validation
- `make test` green on all three clusters (envoy-gateway + k8gb HelmReleases render clean).
- k8gb controller postRenderer verified locally: `helm template | kustomize` with the same patch yields `priorityClassName: infra-high` on the `k8gb` Deployment.
- Live verification post-merge: confirm the envoy proxy pods, k8gb, and k8gb-coredns pods roll with `infra-high`.