### PR TITLE
priorityclass: cover the envoy-ai-gateway (infra-high)

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/ai-gateway.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/ai-gateway.yaml
@@ -29,6 +29,7 @@ spec:
       envoyDeployment:
         replicas: 1
         pod:
+          priorityClassName: infra-high
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/kubernetes/apps/base/envoy-ai-gateway-system/envoy-ai-gw-common/install/helmrelease.yaml
+++ b/kubernetes/apps/base/envoy-ai-gateway-system/envoy-ai-gw-common/install/helmrelease.yaml
@@ -21,3 +21,15 @@ spec:
   releaseName: aieg
   install:
     createNamespace: false
+  # The ai-gateway-helm chart exposes no priorityClassName for its controller
+  # Deployment, so patch it in post-render (matches the k8gb controller pattern).
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: ai-gateway-controller
+            patch: |
+              - op: add
+                path: /spec/template/spec/priorityClassName
+                value: infra-high


### PR DESCRIPTION
## What
Fills the last ingress priorityClass gap — the envoy-ai-gateway:
- **ai-gateway data-plane proxy** → `priorityClassName` under the `EnvoyProxy` CR's `envoyDeployment.pod` (ai namespace, stpetersburg-only)
- **ai-gateway controller** → Flux **postRenderer** kustomize patch (the `ai-gateway-helm` chart exposes no priorityClassName, identical situation to k8gb; controller runs on all three clusters)

`infra-high`, matching the rest of the ingress data plane and the tailscale proxies.

## Validation
- `make test` green on all three clusters.
- The controller postRenderer patch is byte-identical to the k8gb controller patch already verified working live (k8gb controller carries `infra-high` on all clusters). Post-merge live check: ai-gateway-controller (all clusters) + the ai-gateway data-plane proxy (stpetersburg) roll with `infra-high`.