### PR TITLE
priority-classes: move infra-* out of tailscale into a standalone app

### DIFF
--- a/kubernetes/apps/base/kube-system/priority-classes/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/priority-classes/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./priorityclasses.yaml

--- a/kubernetes/apps/base/kube-system/priority-classes/app/priorityclasses.yaml
+++ b/kubernetes/apps/base/kube-system/priority-classes/app/priorityclasses.yaml
@@ -1,3 +1,10 @@
+# Cluster-foundational PriorityClasses. Referenced by name across the whole
+# fleet (cert-manager, prometheus, garage, rook, tailscale proxies, envoy +
+# ai gateways, k8gb, ...). Kept in a standalone app — NOT inside any workload
+# app — so a single app's failure/suspension can never prune these out from
+# under everything that references them (a missing PriorityClass fails pod
+# admission cluster-wide). Deployed early via the kube-system overlay.
+---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/kubernetes/apps/base/tailscale/resources/kustomization.yaml
+++ b/kubernetes/apps/base/tailscale/resources/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ./proxygroup.yaml
   - ./recorder.yaml
   - ./egress.yaml
-  - ./priorityclasses.yaml
   - ./tailnet.yaml
   # - ./tsjustworks-proxygroup.yaml
   # Dashboards

--- a/kubernetes/apps/ottawa/kube-system/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kube-system/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./cilium.yaml
   - ./irqbalance.yaml
   - ./memory-request-floor.yaml
+  - ./priority-classes.yaml

--- a/kubernetes/apps/ottawa/kube-system/priority-classes.yaml
+++ b/kubernetes/apps/ottawa/kube-system/priority-classes.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app priority-classes
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/priority-classes/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/tailscale/tailscale.yaml
+++ b/kubernetes/apps/ottawa/tailscale/tailscale.yaml
@@ -31,6 +31,7 @@ spec:
   path: ./kubernetes/apps/base/tailscale/resources
   dependsOn:
     - name: tailscale-operator
+    - name: priority-classes
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/robbinsdale/kube-system/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kube-system/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./csi-secrets-store.yaml
   - ./cilium.yaml
   - ./memory-request-floor.yaml
+  - ./priority-classes.yaml

--- a/kubernetes/apps/robbinsdale/kube-system/priority-classes.yaml
+++ b/kubernetes/apps/robbinsdale/kube-system/priority-classes.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app priority-classes
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/priority-classes/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/robbinsdale/tailscale/tailscale.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale/tailscale.yaml
@@ -31,6 +31,7 @@ spec:
   path: ./kubernetes/apps/base/tailscale/resources
   dependsOn:
     - name: tailscale-operator
+    - name: priority-classes
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/stpetersburg/kube-system/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kube-system/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./cilium.yaml
   - ./irqbalance.yaml
   - ./memory-request-floor.yaml
+  - ./priority-classes.yaml

--- a/kubernetes/apps/stpetersburg/kube-system/priority-classes.yaml
+++ b/kubernetes/apps/stpetersburg/kube-system/priority-classes.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app priority-classes
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/base/kube-system/priority-classes/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/tailscale/tailscale.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale/tailscale.yaml
@@ -31,6 +31,7 @@ spec:
   path: ./kubernetes/apps/base/tailscale/resources
   dependsOn:
     - name: tailscale-operator
+    - name: priority-classes
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## What
Moves the `infra-critical` / `infra-high` / `infra-default` PriorityClasses out of the `tailscale-operator-resources` Kustomization into a dedicated **`priority-classes`** app (`base/kube-system/priority-classes`, pointer in each kube-system overlay).

## Why
These are cluster-foundational — referenced by name across the whole fleet (cert-manager, prometheus, garage, rook, tailscale proxies, envoy + ai gateways, k8gb, …). Living inside the tailscale app meant a tailscale failure/suspension could prune them, and a missing PriorityClass **fails pod admission cluster-wide**. A foundational primitive shouldn't be able to be taken down by one workload app.

## Zero-gap migration (the careful part)
Deleting a PriorityClass out from under running references would break new-pod admission during any prune window, so this avoids a gap entirely:

1. The new `priority-classes` Kustomization **adopts** the existing objects — Flux overwrites the `kustomize.toolkit.fluxcd.io/name` ownership labels to `priority-classes`.
2. `tailscale-operator-resources` now `dependsOn: priority-classes`, so Flux won't let it run GC until the new app is Ready and owns the objects.
3. Flux's prune is **label-gated** — once the objects are labeled `priority-classes`, the tailscale Kustomization's GC skips them (it only deletes objects it still owns). No deletion, no gap.
4. The `value` fields are unchanged, so adoption is a metadata-only apply — no PriorityClass immutability conflict.

## Validation
- Renders **3** PriorityClasses from the new app, **0** from tailscale resources.
- `make test` green on all three clusters.
- Post-merge live check: `kubectl get priorityclass infra-{critical,high,default}` still present on all clusters, and their `kustomize.toolkit.fluxcd.io/name` label now reads `priority-classes` (proves adoption, not delete+recreate).