### PR TITLE
fix(garage): stage identity-specific SMB RPC endpoints

### DIFF
--- a/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
+++ b/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.6.22"
+      version: "0.6.24"
       sourceRef:
         kind: HelmRepository
         name: garage-operator

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/service-ts-storage.yaml
@@ -1,3 +1,6 @@
+# One identity-specific L4 endpoint per Garage storage node. Garage authenticates
+# the expected NodeID during its RPC handshake, so a shared regional service
+# cannot safely load-balance these connections across different node keys.
 apiVersion: v1
 kind: Service
 metadata:
@@ -75,5 +78,25 @@ spec:
       targetPort: 3901
   selector:
     statefulset.kubernetes.io/pod-name: ottawa-garage-localpath-rei-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-smb
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-smb-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: ottawa-garage-smb-0
   type: LoadBalancer
   loadBalancerClass: tailscale

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/service-ts-storage.yaml
@@ -1,3 +1,6 @@
+# One identity-specific L4 endpoint per Garage storage node. Garage authenticates
+# the expected NodeID during its RPC handshake, so a shared regional service
+# cannot safely load-balance these connections across different node keys.
 apiVersion: v1
 kind: Service
 metadata:
@@ -55,5 +58,25 @@ spec:
       targetPort: 3901
   selector:
     statefulset.kubernetes.io/pod-name: robbinsdale-garage-localpath-stone-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: robbinsdale-garage-smb
+    tailscale.com/tags: "tag:k8s,tag:robbinsdale"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-storage-smb-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: 3901
+  selector:
+    statefulset.kubernetes.io/pod-name: robbinsdale-garage-smb-0
   type: LoadBalancer
   loadBalancerClass: tailscale

--- a/kubernetes/apps/base/immich/immich-robbinsdale/app/helmrelease.yaml
+++ b/kubernetes/apps/base/immich/immich-robbinsdale/app/helmrelease.yaml
@@ -16,7 +16,6 @@ spec:
     remediation:
       retries: 3
     timeout: 15m
-  interval: 30m
   upgrade:
     cleanupOnFail: false
     remediation:


### PR DESCRIPTION
## Summary
- deploy garage-operator chart v0.6.24
- create pod-pinned Tailscale RPC endpoints for Ottawa and Robbinsdale SMB nodes
- document why every Garage node requires an identity-specific L4 endpoint

## No-downtime rollout
This stage only adds Services and rolls the operator. It does not modify GarageNode specs, node IDs, PVCs, layouts, or Garage pod templates. SMB `rpcPublicAddr` changes will follow one region at a time after this stage is healthy.

## Validation
- rendered Ottawa and Robbinsdale GarageNode kustomizations with `kubectl kustomize`
- parsed rendered YAML
- inventoried every manual storage node and pod-pinned endpoint
- `git diff --check`