### PR TITLE
fix(garage): update operator to v0.6.25

### DIFF
--- a/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
+++ b/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.6.24"
+      version: "0.6.25"
       sourceRef:
         kind: HelmRepository
         name: garage-operator


### PR DESCRIPTION
## Summary
Deploy garage-operator v0.6.25 so previously known nodes can repair layout RPC metadata while their pods are offline.

## Safety
Operator-only rolling deployment; no Garage pod templates, node identities, PVCs, capacities, zones, or routes change. The chart and multi-arch image have both been published successfully.

## Validation
Upstream PR #280 passed unit, lint, single/multi-cluster, API, layout, IPv6, COSI, external gateway, amd64, and arm64 workflows.