### PR TITLE
fix(garage): update operator to v0.6.26

### DIFF
--- a/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
+++ b/kubernetes/apps/base/garage-operator-system/garage-operator-system-install/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: garage-operator
-      version: "0.6.25"
+      version: "0.6.26"
       sourceRef:
         kind: HelmRepository
         name: garage-operator


### PR DESCRIPTION
Deploy v0.6.26, completing offline-node layout metadata repair for pods whose stale Kubernetes phase remains Running. Operator-only rollout; no Garage pods, identities, PVCs, capacities, or zones change. Upstream PR #281 passed every required workflow and the chart plus amd64/arm64 image are published.