### PR TITLE
fix(garage): advertise Ottawa SMB RPC endpoint

### DIFF
--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-smb.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/ottawa-garage-smb.yaml
@@ -25,6 +25,10 @@ spec:
     - cluster:garage/garage
     - tier:storage
     - garage-storage-0-0
+  # Dedicated identity-specific RPC endpoint, provisioned and verified before
+  # this config change. Never point multiple Garage node IDs at one L4 VIP.
+  network:
+    rpcPublicAddr: "ottawa-garage-smb.keiretsu.ts.net:3901"
   storage:
     metadata:
       existingClaim: metadata-garage-0


### PR DESCRIPTION
Stage 2 of the no-downtime federation rollout. Advertise the already-provisioned, pod-pinned `ottawa-garage-smb` RPC endpoint. This rolls only Ottawa SMB; all other Garage nodes remain untouched. Node ID, PVCs, capacity, zone, and layout assignment are preserved. The Tailscale Service is already ready at `100.111.204.125`.