### PR TITLE
fix(garage): advertise Robbinsdale SMB RPC endpoint

### DIFF
--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-smb.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/robbinsdale-garage-smb.yaml
@@ -29,6 +29,10 @@ spec:
     - cluster:garage/garage
     - tier:storage
     - garage-storage-0-0
+  # Dedicated identity-specific RPC endpoint, provisioned and verified before
+  # this config change. Never point multiple Garage node IDs at one L4 VIP.
+  network:
+    rpcPublicAddr: "robbinsdale-garage-smb.keiretsu.ts.net:3901"
   storage:
     metadata:
       existingClaim: metadata-garage-ceph


### PR DESCRIPTION
Final regional Garage restart in the no-downtime federation rollout. Ottawa SMB has already rolled, rejoined healthy with the same NodeID, and publishes its direct RPC address. This change advertises the already-ready, pod-pinned `robbinsdale-garage-smb` endpoint and rolls only that one Garage pod. Node ID, PVCs, capacity, zone, and layout assignment remain unchanged.