### PR TITLE
fix(garage): publish resolvable federation RPC DNS

### DIFF
--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/garage-rpc-dns.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/garage-rpc-dns.yaml
@@ -1,0 +1,69 @@
+# Publicly resolvable, tailnet-only Garage RPC records. Garage resolves peer
+# hostnames inside Kubernetes pods, where Tailscale MagicDNS (*.ts.net) is not
+# available. These records expose only CGNAT addresses: they are resolvable by
+# CoreDNS but remain unreachable outside the tailnet. Cloudflare proxying must
+# stay disabled. Kept centrally in Ottawa so one ExternalDNS owner manages the
+# federation-wide record set.
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: garage-federation-rpc
+  labels:
+    dns-target: cloudflare
+spec:
+  endpoints:
+    - dnsName: ottawa-gw-0.keiretsu.top
+      recordType: A
+      targets: ["100.69.81.228"]
+    - dnsName: ottawa-gw-1.keiretsu.top
+      recordType: A
+      targets: ["100.102.15.143"]
+    - dnsName: ottawa-garage-asuka.keiretsu.top
+      recordType: A
+      targets: ["100.85.83.136"]
+    - dnsName: ottawa-garage-kaji.keiretsu.top
+      recordType: A
+      targets: ["100.116.245.242"]
+    - dnsName: ottawa-garage-rei.keiretsu.top
+      recordType: A
+      targets: ["100.75.189.135"]
+    - dnsName: ottawa-garage-shiro.keiretsu.top
+      recordType: A
+      targets: ["100.109.75.230"]
+    - dnsName: ottawa-garage-smb.keiretsu.top
+      recordType: A
+      targets: ["100.111.204.125"]
+    - dnsName: robbinsdale-gw-0.keiretsu.top
+      recordType: A
+      targets: ["100.75.116.69"]
+    - dnsName: robbinsdale-gw-1.keiretsu.top
+      recordType: A
+      targets: ["100.117.27.18"]
+    - dnsName: robbinsdale-garage-stone.keiretsu.top
+      recordType: A
+      targets: ["100.73.151.11"]
+    - dnsName: robbinsdale-garage-tank.keiretsu.top
+      recordType: A
+      targets: ["100.127.15.116"]
+    - dnsName: robbinsdale-garage-titan.keiretsu.top
+      recordType: A
+      targets: ["100.119.255.12"]
+    - dnsName: robbinsdale-garage-smb.keiretsu.top
+      recordType: A
+      targets: ["100.118.250.220"]
+    - dnsName: stpetersburg-gw-0.keiretsu.top
+      recordType: A
+      targets: ["100.91.106.10"]
+    - dnsName: stpetersburg-gw-1.keiretsu.top
+      recordType: A
+      targets: ["100.86.74.93"]
+    - dnsName: stpetersburg-garage-spark-0.keiretsu.top
+      recordType: A
+      targets: ["100.101.101.253"]
+    - dnsName: stpetersburg-garage-spark-1.keiretsu.top
+      recordType: A
+      targets: ["100.77.197.170"]
+    - dnsName: stpetersburg-garage-orin-0.keiretsu.top
+      recordType: A
+      targets: ["100.105.37.70"]

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ottawa-garage-localpath-asuka.yaml
   - ottawa-garage-localpath-rei.yaml
   - service-ts-storage.yaml
+  - garage-rpc-dns.yaml


### PR DESCRIPTION
## Summary
Publish Cloudflare DNS-only A records for every per-node Garage RPC Tailscale endpoint. Garage resolves peer addresses inside Kubernetes pods, where MagicDNS `.ts.net` names return NXDOMAIN; these `.keiretsu.top` records resolve through CoreDNS while their 100.64/10 targets remain tailnet-only.

## Safety
DNS resources only. No Garage pods, layouts, identities, capacities, zones, PVCs, or routes change. This is staged before switching any configured RPC names.