### PR TITLE
chore(spurfire): deploy public-copy cleanup

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
@@ -12,8 +12,8 @@ spec:
     fullnameOverride: spurfire
     image:
       repository: ghcr.io/rajsinghtech/spurfire-server
-      tag: "sha-5117b71ff31941808d2c1c09b58736c0fc4f50f4"
-      digest: "sha256:e7f1a5a3a4815673061e164794f1dd68a446659e2ded7b6bfd8a3d876df6e437"
+      tag: "sha-32eed847693f93b267e1965b47369ba03330f99a"
+      digest: "sha256:34eb839ebdb5d502ba93da25a4cb613716b40e77e9d3fa1e600f20a373155bc0"
       pullPolicy: IfNotPresent
     # Public staging remains zero-mutation until API authentication and a
     # fresh dedicated organization OAuth client are deployed together.

--- a/kubernetes/apps/base/spurfire/spurfire/ocirepository.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/ocirepository.yaml
@@ -9,6 +9,6 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: "0.1.3-main.17.1.sha-5117b71ff319"
-    digest: "sha256:d1cbc6eca34972bb86f48e01097367b92af9ee4da9fe582ee1b1ccbc74f837d5"
+    tag: "0.2.0-main.36.1.sha-32eed847693f"
+    digest: "sha256:27b48f5d5e2f8702464f32d1f8138715fe169c55d025d4c0b364a6a9b09cc7ce"
   url: oci://ghcr.io/rajsinghtech/charts/spurfire-control


### PR DESCRIPTION
## Summary
- pin the Spurfire control service to source `32eed847693f93b267e1965b47369ba03330f99a`
- pin the signed `0.2.0-main.36.1` OCI chart and multi-architecture image by digest
- keep the hosted deployment in zero-mutation dry-run mode with no OAuth secret attached

## Validation
- upstream package workflow passed metadata, Rust, Helm, secret, amd64, arm64, signing, provenance, and artifact verification gates
- rendered base and deployment overlay successfully with `kustomize build`
- asserted `dryRun: true`, `provisioningMode: dry_run`, empty `existingSecret`, and exact image/chart digest pins