### PR TITLE
chore(spurfire): pin sanitized public snapshot

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
@@ -12,8 +12,8 @@ spec:
     fullnameOverride: spurfire
     image:
       repository: ghcr.io/rajsinghtech/spurfire-server
-      tag: "sha-32eed847693f93b267e1965b47369ba03330f99a"
-      digest: "sha256:34eb839ebdb5d502ba93da25a4cb613716b40e77e9d3fa1e600f20a373155bc0"
+      tag: "sha-786886089691982bf854e48554b989bc00775c71"
+      digest: "sha256:5a3b6db9668c764349e662889f5535a757142c8c2560c26ff28968009a476228"
       pullPolicy: IfNotPresent
     # Public staging remains zero-mutation until API authentication and a
     # fresh dedicated organization OAuth client are deployed together.

--- a/kubernetes/apps/base/spurfire/spurfire/ocirepository.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/ocirepository.yaml
@@ -9,6 +9,6 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: "0.2.0-main.36.1.sha-32eed847693f"
-    digest: "sha256:27b48f5d5e2f8702464f32d1f8138715fe169c55d025d4c0b364a6a9b09cc7ce"
+    tag: "0.2.0-main.38.1.sha-786886089691"
+    digest: "sha256:02fa84cedef98d48156aa070761f18f5b77a619645e564497bc45e91fbc06559"
   url: oci://ghcr.io/rajsinghtech/charts/spurfire-control


### PR DESCRIPTION
## Summary
- pin the hosted Spurfire service to final sanitized source revision `786886089691982bf854e48554b989bc00775c71`
- pin the signed multi-architecture image and OCI chart by digest
- retain zero-mutation dry-run values and no OAuth Secret attachment

## Validation
- upstream CI and package runs passed all source, client, Godot, Helm, secret, amd64, arm64, signing, provenance, and artifact-verification gates
- published chart values use generic deployment coordinates
- base and deployment overlay render successfully
- assertions confirm exact digest pins, `dryRun: true`, `provisioningMode: dry_run`, and empty `existingSecret`