### PR TITLE
chore(tools): streamline agent repo navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,22 @@ integration for cross-cluster networking and access.
   changes go through Git and Flux. (`kubectl patch` is OK for live testing —
   `kubectl apply` can't resolve Flux `${VARIABLE}` substitutions.)
 - **Verify with `tools/check.sh`** (or `tools/check.sh <cluster>`) — runs the
-  CI render gate (`make test`), silent on success, ~50 lines on failure. Do
-  NOT run raw `make test` or `kustomize build`; they dump thousands of lines.
+  CI render gate (`make test`), prints exactly one `✓ render OK: …` line on
+  success and ~50 lines on failure. Do NOT run raw `make test` or `kustomize
+  build`; they dump thousands of lines. The full 3-cluster run can exceed a
+  short (120s) tool timeout when cold — if only one cluster changed, scope it
+  (`tools/check.sh talos-ottawa`) or raise the timeout.
 - **Find before you read.** Use `tools/where.sh <pattern> <file>` (grep -n)
   to locate sections, then read narrow windows. Don't re-read large files.
-  To locate an app (base dir + which clusters deploy it) in one call, use
-  `tools/app.sh <name>` instead of a manual find + cross-tree grep.
+  All `tools/*.sh` are anchored to the repo root, so they work from any cwd —
+  no `cd` prefix needed. One-call lookups:
+  - `tools/app.sh <name>` — where an app is defined + which clusters deploy it;
+    `tools/app.sh --list` — full `app | base path | clusters` inventory.
+  - `tools/refs.sh <name>` — every tracked file that references a name (for a
+    decommission sweep); exits non-zero when nothing references it.
+  - `tools/orphans.sh` — kustomization↔disk drift (listed-but-missing targets,
+    unlisted/dead YAML). Exit 1 = discrepancies.
+  - `tools/kc.sh <ot|rb|sp> …` — kubectl for a cluster (see Live cluster access).
 - **Secrets are SOPS-encrypted** (`*.sops.yaml`, PGP key
   FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5). Never commit plaintext secrets,
   kubeconfigs, `talsecret.yaml`, or decrypted `*.dec` files.
@@ -125,11 +135,27 @@ postBuild:
 
 ## Live cluster access
 
-- kubeconfig: `.kube/config` in the repo root (all three clusters); also
-  `/workspace/kubernetes-manifests/.kube/config` in container environments.
-- kubectl contexts: `ottawa-k8s-operator.keiretsu.ts.net`,
-  `robbinsdale-k8s-operator.keiretsu.ts.net`; St. Petersburg via
-  `--kubeconfig ~/.kube/stpetersburg`.
+- **Use `tools/kc.sh <cluster> <kubectl args…>`** — it sets the one canonical
+  `KUBECONFIG` and the right `--context`, execs kubectl (args + exit code pass
+  through), and works from any cwd. Don't re-export `KUBECONFIG`, retype the
+  full context, or `cd` first.
+
+  ```bash
+  tools/kc.sh ot -n media get pods    # ottawa
+  tools/kc.sh rb get ns               # robbinsdale
+  tools/kc.sh sp get nodes            # stpetersburg
+  ```
+
+  | alias            | kubeconfig            | context                                   |
+  |------------------|-----------------------|-------------------------------------------|
+  | `ot`/`ottawa`      | `<repo>/.kube/config` | `ottawa-k8s-operator.keiretsu.ts.net`       |
+  | `rb`/`robbinsdale` | `<repo>/.kube/config` | `robbinsdale-k8s-operator.keiretsu.ts.net`  |
+  | `sp`/`stpetersburg`| `~/.kube/stpetersburg`  | (none)                                    |
+
+- The one canonical kubeconfig is `.kube/config` in the repo root (all three
+  clusters). Container environments symlink/copy it to
+  `/workspace/kubernetes-manifests/.kube/config`; do not guess that path on the
+  host — prefer `tools/kc.sh`.
 - Pod/service CIDRs per site: Robbinsdale 10.1/10.0/10.50, Ottawa
   10.3/10.2/10.169, St. Petersburg 10.5/10.4/10.73 (pods/services/LB, /16s).
 
@@ -137,6 +163,13 @@ postBuild:
 
 ```bash
 tools/check.sh [cluster]   # CI render gate — the sole verify command
+                           # (one ✓ line on success; scope by cluster if only
+                           #  one changed — full run can exceed a 120s timeout)
+tools/tests/run.sh         # offline self-tests for the tools/ helpers
+tools/app.sh <name> | --list   # locate an app / full deploy inventory
+tools/refs.sh <name>       # every tracked file referencing <name>
+tools/orphans.sh           # kustomization ↔ disk drift
+tools/kc.sh <ot|rb|sp> …   # kubectl for a cluster (root kubeconfig + context)
 make diff                  # rendered diff vs origin/main
 flux get all -A            # Flux status (live cluster)
 flux reconcile kustomization <app> -n flux-system

--- a/docs/prompt-notes.md
+++ b/docs/prompt-notes.md
@@ -9,8 +9,10 @@ Running log for the orchestrator to fold into future phase prompts.
 - **Give exact YAML file paths** to read/port. Agents respected the read-only
   boundary and used exact paths.
 - **One app per run; keep phases to a few files.** Prevents context overflow.
-- **`tools/check.sh` adopted by later phases** — silent on success, ~50 lines on
-  failure. Keep telling agents to use it instead of raw `make test`.
+- **`tools/check.sh` adopted by later phases** — one `✓ render OK: …` line on
+  success, ~50 lines on failure. The positive signal stops agents re-running it
+  to check (silent success was distrusted). Keep telling agents to use it
+  instead of raw `make test`.
 
 ## Failed / costly (and the fix)
 
@@ -32,9 +34,11 @@ Running log for the orchestrator to fold into future phase prompts.
 1. "Before reading reference sources, check `docs/` for already-distilled facts.
    Only read the specific sections you still need."
 2. "Verify with `tools/check.sh` (or `tools/check.sh <cluster>`) — it runs the
-   full CI gate (`make test`) and is silent on success / ~50 lines on failure.
-   Do NOT run raw `make test` or `kustomize build` yourself — that dumps full
-   output into your context."
+   full CI gate (`make test`), prints one `✓ render OK: …` line on success /
+   ~50 lines on failure. Do NOT run raw `make test` or `kustomize build`
+   yourself — that dumps full output into your context. The full 3-cluster run
+   can exceed a short (120s) timeout when cold; scope to the changed cluster
+   (`tools/check.sh talos-ottawa`) when only one cluster changed."
 3. "To find a specific section in your own files, use `tools/where.sh <pattern>
    <file>` (or `grep -n`) instead of re-reading the whole file. Only re-read
    if you need surrounding context for an edit."

--- a/docs/toolsmith.md
+++ b/docs/toolsmith.md
@@ -29,9 +29,12 @@ Look for:
 ## Outputs (all inside this repo)
 
 - `tools/*.sh` — small helper scripts build agents can run instead of verbose
-  commands. Must be executable, silent on success, and print only the relevant
-  failure excerpt. Canonical example: `tools/check.sh` → runs `make test` for
-  all clusters (or single with arg); on failure prints only first ~50 lines.
+  commands. Must be executable, anchored to the repo root (work from any cwd),
+  quiet (a short positive line at most on success — `check.sh` prints one
+  `✓ render OK: …` line so agents don't re-run to confirm), and print only the
+  relevant failure excerpt. `tools/check.sh` → runs `make test` for all clusters
+  (or single with arg); on failure prints only first ~50 lines. Cover new
+  helpers with a deterministic offline case in `tools/tests/run.sh`.
 - `docs/` — condensed reference distillations (YAML patterns, Flux CRD templates,
   variable substitution gotchas, SOPS workflow, etc.) so future agents don't
   re-read large files for facts already established.

--- a/tools/app.sh
+++ b/tools/app.sh
@@ -1,32 +1,74 @@
 #!/usr/bin/env bash
 # tools/app.sh — locate an app across base manifests and per-cluster overlays.
 # Answers "where is <app> defined and which clusters deploy it?" in one shot,
-# instead of fanning a find + cross-tree grep into agent context.
+# instead of fanning a find + cross-tree grep into agent context. Anchored to
+# the script's own location, so it works from any cwd.
 #
 # Usage:
 #   tools/app.sh <name>          # case-insensitive substring match
-# Matches base dirs (kubernetes/apps/base/<ns>/<app>*) by directory name and
-# per-cluster pointer files (kubernetes/apps/<loc>/<ns>/<app>.yaml) by filename.
+#   tools/app.sh --list          # full inventory: app | base path | clusters
+#
+# <name> matches base dirs (kubernetes/apps/base/<ns>/<app>*) by directory name
+# and per-cluster pointer files (kubernetes/apps/<loc>/<ns>/<app>.yaml) by name.
+# --list derives each row from the pointers' spec.path, so it reflects what is
+# actually deployed and where; its first column is the base-path leaf, not the
+# Flux Kustomization metadata.name.
 set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+APPS="$ROOT/kubernetes/apps"
+LOCS="ottawa robbinsdale stpetersburg"
 
-[ $# -ge 1 ] || { echo "usage: $0 <app-name-substring>" >&2; exit 2; }
+list_inventory() {
+  {
+    for loc in $LOCS; do
+      d="$APPS/$loc"
+      [ -d "$d" ] || continue
+      # tag every pointer path: line with its cluster
+      grep -rn --include='*.yaml' -E '^[[:space:]]*path:[[:space:]]*\.?/?kubernetes/apps/base/' "$d" 2>/dev/null \
+        | sed "s|^|$loc\t|"
+    done
+  } | awk -F'\t' '
+    {
+      loc=$1
+      line=$2
+      # line is "file:lineno:  path: ./kubernetes/apps/base/..."; strip file:lineno:
+      sub(/^[^:]*:[^:]*:/, "", line)
+      sub(/^[[:space:]]*path:[[:space:]]*/, "", line)
+      sub(/[[:space:]]*(#.*)?$/, "", line)
+      sub(/^\.\//, "", line)
+      bp=line
+      m=split(bp, seg, "/")
+      leaf=seg[m]
+      if (leaf=="app" && m>1) leaf=seg[m-1]
+      if (index(seen[bp], "|"loc"|")==0) { seen[bp]=seen[bp] "|"loc"|"; clusters[bp]=clusters[bp] (clusters[bp]==""?"":" ") loc }
+      app[bp]=leaf
+    }
+    END { for (bp in app) printf "%-28s %-46s %s\n", app[bp], bp, clusters[bp] }
+  ' | sort
+}
+
+if [ $# -ge 1 ] && [ "$1" = "--list" ]; then
+  list_inventory
+  exit 0
+fi
+
+[ $# -ge 1 ] || { echo "usage: ${0##*/} <app-name-substring> | --list" >&2; exit 2; }
 q="$1"
-root="kubernetes/apps"
 found=0
 
-base_hits=$(find "$root/base" -mindepth 2 -maxdepth 2 -type d -iname "*$q*" 2>/dev/null | sort || true)
+base_hits=$(find "$APPS/base" -mindepth 2 -maxdepth 2 -type d -iname "*$q*" 2>/dev/null | sort || true)
 if [ -n "$base_hits" ]; then
   found=1
   echo "base manifests:"
-  printf '  %s\n' $base_hits
+  printf '%s\n' "$base_hits" | sed 's/^/  /'
 fi
 
-for c in ottawa robbinsdale stpetersburg; do
-  hits=$(find "$root/$c" -type f -iname "*$q*.yaml" 2>/dev/null | sort || true)
+for c in $LOCS; do
+  hits=$(find "$APPS/$c" -type f -iname "*$q*.yaml" 2>/dev/null | sort || true)
   [ -n "$hits" ] || continue
   found=1
   echo "$c pointers:"
-  printf '  %s\n' $hits
+  printf '%s\n' "$hits" | sed 's/^/  /'
 done
 
 [ "$found" = 1 ] || { echo "no base dir or pointer matching '*$q*'" >&2; exit 1; }

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # tools/check.sh — the kubernetes-manifests acceptance gate for kustomize/flux.
-# Silent on success. On failure prints only the first ~50 lines of the failing
-# step, so build agents don't dump full output into their context.
+# Prints exactly one line on success; on failure prints only the first ~50 lines
+# of the failing step, so build agents don't dump full output into their context.
+# Anchored to the repo root, so it runs from any cwd.
+#
+# NOTE: the full 3-cluster render can exceed a short (120s) tool timeout when
+# cold. If only one cluster changed, scope it: `tools/check.sh talos-ottawa`.
 #
 # Usage:
 #   tools/check.sh                       # full gate (render-test all clusters)
 #   tools/check.sh <cluster>             # single cluster, e.g. tools/check.sh talos-ottawa
 #   tools/check.sh --quick               # quick check (just syntax, no full render)
 set -euo pipefail
+cd -- "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 QUICK=0
 TARGET=""
@@ -44,17 +49,19 @@ if [ "$QUICK" = 1 ]; then
   # Quick syntax check: validate kustomize build on a representative sample
   for dir in kubernetes/apps/base/*/; do
     [ -d "$dir" ] || continue
-    ns=$(basename "$dir")
     for app in "$dir"*/; do
       [ -d "$app" ] || continue
       run_capped "syntax: $app" kustomize build --enable-helm "$app"
     done
   done
+  echo "✓ syntax OK"
   exit 0
 fi
 
 if [ -n "$TARGET" ]; then
   run_capped "render" make "test-$TARGET"
+  echo "✓ render OK: $TARGET"
 else
   run_capped "render" make test
+  echo "✓ render OK: talos-ottawa talos-robbinsdale talos-stpetersburg"
 fi

--- a/tools/kc.sh
+++ b/tools/kc.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# tools/kc.sh — kubectl wrapper: repo-root kubeconfig + short cluster aliases.
+# Kills the per-call KUBECONFIG export + full --context retype. Works from any
+# cwd (anchored to the script's own location, not $PWD), execs kubectl so args
+# and exit code pass straight through.
+#
+# Usage:
+#   tools/kc.sh <cluster> [kubectl args...]
+#   tools/kc.sh ot -n media get pods
+#   tools/kc.sh rb get ns
+#   tools/kc.sh sp get nodes
+#
+# Clusters:
+#   ot | ottawa        repo .kube/config, context ottawa-k8s-operator.keiretsu.ts.net
+#   rb | robbinsdale   repo .kube/config, context robbinsdale-k8s-operator.keiretsu.ts.net
+#   sp | stpetersburg  ~/.kube/stpetersburg (no --context)
+set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat >&2 <<EOF
+usage: ${0##*/} <cluster> [kubectl args...]
+clusters:
+  ot | ottawa        -> $ROOT/.kube/config, context ottawa-k8s-operator.keiretsu.ts.net
+  rb | robbinsdale   -> $ROOT/.kube/config, context robbinsdale-k8s-operator.keiretsu.ts.net
+  sp | stpetersburg  -> ~/.kube/stpetersburg
+examples:
+  ${0##*/} ot -n media get pods
+  ${0##*/} rb get ns
+EOF
+}
+
+[ $# -ge 1 ] || { usage; exit 2; }
+
+context=""
+case "$1" in
+  ot|ottawa)       kubeconfig="$ROOT/.kube/config";  context="ottawa-k8s-operator.keiretsu.ts.net" ;;
+  rb|robbinsdale)  kubeconfig="$ROOT/.kube/config";  context="robbinsdale-k8s-operator.keiretsu.ts.net" ;;
+  sp|stpetersburg) kubeconfig="$HOME/.kube/stpetersburg" ;;
+  -h|--help)       usage; exit 0 ;;
+  *) echo "kc.sh: unknown cluster '$1' (valid: ot|ottawa rb|robbinsdale sp|stpetersburg)" >&2
+     usage; exit 2 ;;
+esac
+shift
+
+export KUBECONFIG="$kubeconfig"
+if [ -n "$context" ]; then
+  exec kubectl --context "$context" "$@"
+fi
+exec kubectl "$@"

--- a/tools/orphans.sh
+++ b/tools/orphans.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# tools/orphans.sh — kustomization <-> disk drift detector for kubernetes/apps.
+# Reports two discrepancy classes, prints nothing else:
+#   MISSING   a resources/components/crds/bases/patch entry points at a local
+#             target that does not exist (would break the render)
+#   UNLISTED  a YAML file sits next to a kustomization.yaml that never names it
+#             (plausibly dead / left behind by a decommission)
+# Remote URLs (http, git::, oci, github.com, ?ref=) and generated files
+# (*.dec, *.bak, *.tmp) are ignored to avoid false positives.
+#
+# Exit 0 = clean, 1 = discrepancies found, 2 = bad usage.
+#
+# Usage:
+#   tools/orphans.sh            # scan kubernetes/apps
+#   tools/orphans.sh <dir>      # scan an arbitrary tree (used by tests)
+set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN="${1:-$ROOT/kubernetes/apps}"
+[ -d "$SCAN" ] || { echo "orphans.sh: not a directory: $SCAN" >&2; exit 2; }
+
+report="$(mktemp)"
+trap 'rm -f "$report"' EXIT
+
+is_remote() {
+  case "$1" in
+    *://*|github.com/*|gitlab.com/*|git@*|*'?ref='*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Pull resource-ish list entries and patch paths out of a kustomization.yaml.
+entries() {
+  awk '
+    /^[A-Za-z].*:/ {
+      key=$0; sub(/:.*/,"",key)
+      mode=(key=="resources"||key=="components"||key=="crds"||key=="bases")?"r":((key=="patches")?"p":"")
+      next
+    }
+    {
+      v=""; ptype=""
+      if (mode=="r" && $0 ~ /^[[:space:]]+-[[:space:]]/)      { v=$0; sub(/^[[:space:]]*-[[:space:]]*/,"",v); ptype="r" }
+      else if (mode=="p" && $0 ~ /path:[[:space:]]/)          { v=$0; sub(/^.*path:[[:space:]]*/,"",v); ptype="p" }
+      if (v!="") {
+        sub(/[[:space:]]*#.*/,"",v); sub(/[[:space:]]+$/,"",v); gsub(/"/,"",v)
+        # patch entries: only .yaml/.yml file refs (skip inline JSON6902 path: /..., hostPaths)
+        if (v!="" && (ptype=="r" || v ~ /\.ya?ml$/)) print v
+      }
+    }
+  ' "$1"
+}
+
+while IFS= read -r kfile; do
+  kdir=$(dirname "$kfile")
+
+  # check 1: listed-but-missing local targets
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    is_remote "$entry" && continue
+    [ -e "$kdir/$entry" ] || printf 'MISSING   %s  ->  %s\n' "${kfile#"$ROOT"/}" "$entry" >>"$report"
+  done < <(entries "$kfile")
+
+  # check 2: sibling YAML absent from this kustomization and from a direct
+  # parent reference (some overlays hoist child/file.yaml one level up).
+  for f in "$kdir"/*.yaml "$kdir"/*.yml; do
+    [ -e "$f" ] || continue
+    b=$(basename "$f")
+    [ "$b" = kustomization.yaml ] && continue
+    case "$b" in *.dec|*.dec.yaml|*.bak|*.tmp) continue ;; esac
+    grep -qF -- "$b" "$kfile" && continue
+    parent="$(dirname "$kdir")/kustomization.yaml"
+    rel="$(basename "$kdir")/$b"
+    [ -f "$parent" ] && grep -qF -- "$rel" "$parent" && continue
+    printf 'UNLISTED  %s\n' "${f#"$ROOT"/}" >>"$report"
+  done
+done < <(find "$SCAN" -type f -name kustomization.yaml)
+
+if [ -s "$report" ]; then
+  sort "$report"
+  exit 1
+fi
+exit 0

--- a/tools/refs.sh
+++ b/tools/refs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# tools/refs.sh — list every Git-tracked file that references <name>, so a
+# decommission (or "what points at X?") is one call instead of an ad-hoc
+# find/grep sweep. Prints FILE PATHS only — never file contents or secret
+# values — as a stable, unique list.
+#
+# Searches tracked files only (so .git and gitignored generated/session files
+# are excluded); also excludes .kube and *.dec/*.decrypted/*.bak/*.tmp
+# defensively. Exit 0 with paths on a match; exit 1 when no tracked path or
+# file content matches. A no-match result does not cover live/external state.
+#
+# Usage:
+#   tools/refs.sh <name>
+#   tools/refs.sh infisical
+set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+[ $# -ge 1 ] || { echo "usage: ${0##*/} <name>" >&2; exit 2; }
+name="$1"
+cd "$ROOT"
+
+# Restrict to tracked files, drop credential/generated paths.
+excludes=(
+  ':(exclude).kube/**'
+  ':(exclude).hermes/**'
+  ':(exclude)**/*.dec'
+  ':(exclude)**/*.decrypted'
+  ':(exclude)**/*.bak'
+  ':(exclude)**/*.tmp'
+)
+
+results="$(
+  {
+    # files whose *contents* mention the name (fixed string, case-insensitive)
+    git grep -I -F -i -l -e "$name" -- . "${excludes[@]}" 2>/dev/null || true
+    # files whose *path* mentions the name
+    git ls-files -- . "${excludes[@]}" 2>/dev/null | grep -i -F -- "$name" || true
+  } | sort -u
+)"
+
+[ -n "$results" ] || { echo "refs.sh: no tracked file references '$name'" >&2; exit 1; }
+printf '%s\n' "$results"

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# tools/tests/run.sh — deterministic, offline self-tests for the tools/ helpers.
+# No live cluster calls: kubectl/make are stubbed on PATH; orphans/where use
+# temp fixtures and read-only repo lookups. Run: tools/tests/run.sh
+set -u
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+T="$ROOT/tools"
+pass=0; fail=0
+
+ok()   { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+# assert LABEL CMD...  -> ok when CMD succeeds (grep reads stdin via <<< herestring)
+assert() { local l="$1"; shift; if "$@"; then ok "$l"; else bad "$l"; fi; }
+# refute LABEL CMD...  -> ok when CMD fails
+refute() { local l="$1"; shift; if "$@"; then bad "$l"; else ok "$l"; fi; }
+# exits  LABEL WANT CMD... -> ok when CMD's exit code equals WANT
+exits()  { local l="$1" w="$2"; shift 2; "$@" >/dev/null 2>&1; local g=$?
+           if [ "$g" = "$w" ]; then ok "$l (exit $g)"; else bad "$l (want $w got $g)"; fi; }
+section() { printf '\n# %s\n' "$1"; }
+
+# ---------------------------------------------------------------- kc.sh
+section "kc.sh"
+stub="$(mktemp -d)"
+cat >"$stub/kubectl" <<'EOF'
+#!/usr/bin/env bash
+echo "KUBECONFIG=$KUBECONFIG"
+echo "ARGS=$*"
+exit 7
+EOF
+chmod +x "$stub/kubectl"
+
+exits  "no args -> usage exit 2"   2 "$T/kc.sh"
+exits  "bad alias -> exit 2"       2 "$T/kc.sh" xx get ns
+assert "bad alias lists valid aliases" grep -qi 'valid:' <<<"$("$T/kc.sh" xx 2>&1)"
+
+out="$(PATH="$stub:$PATH" "$T/kc.sh" ot -n media get pods 2>&1)"; ec=$?
+assert "ot -> repo kubeconfig"     grep -q "KUBECONFIG=$ROOT/.kube/config" <<<"$out"
+assert "ot -> ottawa context"      grep -q -- '--context ottawa-k8s-operator.keiretsu.ts.net' <<<"$out"
+assert "ot -> args passthrough"    grep -q -- 'ARGS=--context ottawa-k8s-operator.keiretsu.ts.net -n media get pods' <<<"$out"
+assert "ot -> exit code passthrough (7)" test "$ec" = 7
+
+rbout="$(PATH="$stub:$PATH" "$T/kc.sh" rb get ns 2>&1)"
+assert "rb -> robbinsdale context" grep -q 'robbinsdale-k8s-operator.keiretsu.ts.net' <<<"$rbout"
+
+spout="$(PATH="$stub:$PATH" "$T/kc.sh" sp get nodes 2>&1)"
+assert "sp -> ~/.kube/stpetersburg" grep -q 'KUBECONFIG=.*/.kube/stpetersburg' <<<"$spout"
+refute "sp -> no --context"         grep -q -- '--context' <<<"$spout"
+rm -rf "$stub"
+
+# ---------------------------------------------------------------- app.sh
+section "app.sh"
+list1="$("$T/app.sh" --list)"; list2="$("$T/app.sh" --list)"
+assert "--list nonempty"           test -n "$list1"
+assert "--list stable across runs" test "$list1" = "$list2"
+assert "--list sorted+unique"      test "$list1" = "$(printf '%s\n' "$list1" | sort -u)"
+assert "--list has immich row"     grep -q 'immich .*kubernetes/apps/base/immich/immich.* ottawa' <<<"$list1"
+# shellcheck disable=SC2016  # $2 is an awk field, not a shell expansion
+assert "--list rows well-formed"   awk 'NF<3 || $2 !~ /^kubernetes\/apps\/base\// {b=1} END{exit b+0}' <<<"$list1"
+subout="$( (cd /tmp && "$T/app.sh" immich) 2>&1 )"
+assert "substring immich (from /tmp)"  grep -q 'base manifests:' <<<"$subout"
+exits  "substring no-match -> exit 1"  1 sh -c "cd /tmp && '$T/app.sh' zzz-nope-xyz"
+
+# ---------------------------------------------------------------- refs.sh
+section "refs.sh"
+refs="$( (cd /tmp && "$T/refs.sh" immich) )"; ec=$?
+assert "immich -> exit 0"          test "$ec" = 0
+assert "immich -> nonempty"        test -n "$refs"
+assert "output sorted+unique"      test "$refs" = "$(printf '%s\n' "$refs" | sort -u)"
+allfiles=1; while IFS= read -r p; do [ -f "$ROOT/$p" ] || allfiles=0; done <<<"$refs"
+assert "output lines are file paths" test "$allfiles" = 1
+exits  "no-match -> exit 1"         1 "$T/refs.sh" zzz-nonexistent-xyz
+exits  "no args -> exit 2"          2 "$T/refs.sh"
+
+# ---------------------------------------------------------------- orphans.sh
+section "orphans.sh"
+fx="$(mktemp -d)"
+mkdir -p "$fx/clean" "$fx/dirty"
+cat >"$fx/clean/kustomization.yaml" <<'EOF'
+resources:
+  - a.yaml
+  - b.yaml
+  - https://example.com/remote.yaml
+EOF
+: >"$fx/clean/a.yaml"; : >"$fx/clean/b.yaml"
+exits  "clean fixture -> exit 0"    0 "$T/orphans.sh" "$fx/clean"
+assert "clean fixture -> no output" test -z "$("$T/orphans.sh" "$fx/clean" 2>&1)"
+
+mkdir -p "$fx/parent/child"
+cat >"$fx/parent/kustomization.yaml" <<'EOF'
+resources:
+  - child/live.yaml
+EOF
+: >"$fx/parent/child/kustomization.yaml"
+: >"$fx/parent/child/live.yaml"
+exits  "direct parent reference -> not orphaned" 0 "$T/orphans.sh" "$fx/parent"
+
+cat >"$fx/dirty/kustomization.yaml" <<'EOF'
+resources:
+  - present.yaml
+  - gone.yaml
+  - https://example.com/remote.yaml
+patches:
+  - path: patchme.yaml
+  - patch: |-
+      - op: add
+        path: /metadata/labels/x
+    target:
+      kind: Deployment
+EOF
+: >"$fx/dirty/present.yaml"; : >"$fx/dirty/patchme.yaml"
+: >"$fx/dirty/orphan.yaml"; : >"$fx/dirty/leftover.dec.yaml"
+dout="$("$T/orphans.sh" "$fx/dirty" 2>&1)"; dec=$?
+assert "dirty -> exit 1"                test "$dec" = 1
+assert "flags missing resource"         grep -q 'MISSING.*gone.yaml' <<<"$dout"
+assert "flags unlisted sibling"         grep -q 'UNLISTED.*orphan.yaml' <<<"$dout"
+refute "ignores remote URL"             grep -q 'remote.yaml' <<<"$dout"
+refute "ignores inline JSON6902 path"   grep -q '/metadata/labels' <<<"$dout"
+refute "ignores generated .dec.yaml"    grep -q 'leftover.dec.yaml' <<<"$dout"
+refute "listed patch not flagged"       grep -q 'patchme.yaml' <<<"$dout"
+rm -rf "$fx"
+
+# ---------------------------------------------------------------- where.sh
+section "where.sh"
+whereout="$( (cd /tmp && "$T/where.sh" 'resources' kubernetes/apps/base/immich/immich/app/kustomization.yaml) )"
+assert "root-anchored repo-relative path (from /tmp)" grep -q 'resources' <<<"$whereout"
+upperwhere="$( (cd /tmp && "$T/where.sh" 'RESOURCES' kubernetes/apps/base/immich/immich/app/kustomization.yaml) )"
+assert "pattern matching is case-insensitive" test -n "$upperwhere"
+exits  "missing file -> exit 1"     1 "$T/where.sh" foo /no/such/file.xyz
+
+# ---------------------------------------------------------------- check.sh (stubbed make; no real render)
+section "check.sh (stubbed make)"
+mstub="$(mktemp -d)"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$mstub/make"; chmod +x "$mstub/make"
+sout="$(PATH="$mstub:$PATH" "$T/check.sh" 2>/dev/null)"; sec=$?
+assert "success -> exit 0"              test "$sec" = 0
+assert "success prints exactly 1 line"  test "$(printf '%s\n' "$sout" | grep -c .)" = 1
+assert "success line format"            grep -q '^✓ render OK:' <<<"$sout"
+printf '#!/usr/bin/env bash\necho "render Error: boom"; exit 1\n' >"$mstub/make"; chmod +x "$mstub/make"
+fout="$(PATH="$mstub:$PATH" "$T/check.sh" 2>/dev/null)"; fec=$?
+assert "failure -> exit 1"              test "$fec" = 1
+assert "failure -> nothing on stdout"   test -z "$fout"
+rm -rf "$mstub"
+
+# ---------------------------------------------------------------- summary
+printf '\n== %d passed, %d failed ==\n' "$pass" "$fail"
+[ "$fail" = 0 ]

--- a/tools/where.sh
+++ b/tools/where.sh
@@ -6,7 +6,10 @@
 # Usage:
 #   tools/where.sh <pattern> <file>            # case-insensitive grep -n
 #   tools/where.sh <pattern> <file> [extra rg/grep flags]
+# <file> is tried as given first, then relative to the repo root, so a
+# repo-relative path resolves from any cwd.
 set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 if [ $# -lt 2 ]; then
   echo "usage: $0 <pattern> <file> [grep flags...]" >&2
@@ -14,13 +17,16 @@ if [ $# -lt 2 ]; then
 fi
 PATTERN="$1"; FILE="$2"; shift 2
 
+if [ ! -f "$FILE" ] && [ -f "$ROOT/$FILE" ]; then
+  FILE="$ROOT/$FILE"
+fi
 if [ ! -f "$FILE" ]; then
   echo "$0: not a file: $FILE" >&2
   exit 1
 fi
 
 if command -v rg >/dev/null 2>&1; then
-  rg -n --no-heading --color never "$@" "$PATTERN" "$FILE" || true
+  rg -n -i --no-heading --color never "$@" "$PATTERN" "$FILE" || true
 else
-  grep -n --color=never "$@" "$PATTERN" "$FILE" || true
+  grep -n -i --color=never "$@" "$PATTERN" "$FILE" || true
 fi


### PR DESCRIPTION
## Summary

- add a root-anchored `kc.sh` wrapper for short, consistent cluster selection
- add deterministic app inventory, tracked-reference lookup, and kustomization/orphan diagnostics
- make existing navigation and verification helpers work from any cwd
- print one concise render-success line so agents do not rerun silent checks
- add 41 offline tests for helper behavior and update agent guidance

## Why

An audit of 28 local Claude Code sessions (excluding four primarily focused on St. Petersburg) found that live-cluster boilerplate and ad-hoc navigation dominated tool use:

- repeated kubeconfig exports, full context names, and repo `cd` prefixes across hundreds of commands
- repeated manual tree/reference sweeps despite existing helpers
- full kustomization-to-disk audits timing out when rebuilt ad hoc
- silent successful checks being rerun because models lacked a positive completion signal

These helpers turn those recurring multi-command searches into small, stable interfaces while keeping output bounded.

## Validation

- `tools/tests/run.sh` — **41 passed, 0 failed**
- `shellcheck` on every changed/new helper — passed
- `git diff --check` — passed
- `tools/check.sh talos-ottawa` — same pre-existing result as `origin/main`: **113 passed, 121 skipped, 7 failed**
- `tools/check.sh talos-robbinsdale` — same pre-existing result as `origin/main`: **220 passed, 4 failed**

The render failures are unchanged from the base branch and are existing chart-source/post-render issues. No product manifests or secrets are changed.
