### PR TITLE
feat(tools): add bounded pod triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,12 @@ postBuild:
   | `rb`/`robbinsdale` | `<repo>/.kube/config` | `robbinsdale-k8s-operator.keiretsu.ts.net`  |
   | `sp`/`stpetersburg`| `~/.kube/stpetersburg`  | (none)                                    |
 
+- **Compact pod triage:** `tools/ktriage.sh <ot|rb|sp> <ns> <pod>` prints one
+  pod's bounded read-only summary — phase/node/IP, container + init states,
+  not-True conditions, latest 10 events, a 20-line log tail (plus previous logs
+  for restarted containers) — instead of a 200–800-line `get pod -o yaml`. It
+  routes every call through `kc.sh` and issues only `get`/`logs`. Exit 4 = pod
+  read OK but a later section was unavailable (marked inline).
 - The one canonical kubeconfig is `.kube/config` in the repo root (all three
   clusters). Container environments symlink/copy it to
   `/workspace/kubernetes-manifests/.kube/config`; do not guess that path on the
@@ -170,6 +176,7 @@ tools/app.sh <name> | --list   # locate an app / full deploy inventory
 tools/refs.sh <name>       # every tracked file referencing <name>
 tools/orphans.sh           # kustomization ↔ disk drift
 tools/kc.sh <ot|rb|sp> …   # kubectl for a cluster (root kubeconfig + context)
+tools/ktriage.sh <ot|rb|sp> <ns> <pod>   # bounded read-only pod triage (vs -o yaml)
 make diff                  # rendered diff vs origin/main
 flux get all -A            # Flux status (live cluster)
 flux reconcile kustomization <app> -n flux-system

--- a/docs/toolsmith.md
+++ b/docs/toolsmith.md
@@ -47,6 +47,8 @@ Look for:
 
 - Never modify `kubernetes/apps/base/` product manifests unless fixing a bug
   surfaced by the orchestrator.
-- Keep each helper under ~50 lines; no new dependencies.
+- Keep lookup helpers under ~50 lines. A bounded diagnostic helper may be
+  longer when its safety, failure handling, and output caps have offline tests.
+  Add no new dependencies.
 - End your run with a short summary: what you changed, and the top 3 token sinks
   found with estimated savings.

--- a/tools/ktriage.sh
+++ b/tools/ktriage.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# tools/ktriage.sh — compact, read-only pod triage. Replaces a 200-800 line
+# `kubectl get pod -o yaml` dump with the few things worth reading: status,
+# container/init states, non-True conditions, the latest events, and a short
+# log tail (plus a previous-log tail for restarted containers).
+#
+# All Kubernetes access goes through tools/kc.sh; only read-only get/logs verbs
+# are ever issued (a closed set — this cannot exec/apply/delete/patch). Bounds
+# are enforced locally with tail/cut, so oversized server output can't blow up
+# the summary even if kubectl ignores --tail. macOS bash 3.2 clean; no jq /
+# python / full YAML/JSON.
+#
+# Exit: 2 = usage / bad cluster (a bad alias inherits kc.sh's exit 2). If the
+# initial pod read fails, nothing else is printed and its kubectl exit code is
+# propagated. 4 = the pod read succeeded but one or more later sections
+# (states / conditions / events / current logs) were unavailable — each is
+# marked inline and the useful output is still emitted first. 0 = all read.
+#
+# Usage:
+#   tools/ktriage.sh <ot|rb|sp> <namespace> <pod>
+#   tools/ktriage.sh ot media immich-server-0
+set -u
+DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+KC="$DIR/kc.sh"
+
+usage() {
+  cat >&2 <<EOF
+usage: ${0##*/} <ot|rb|sp> <namespace> <pod>
+example: ${0##*/} ot media immich-server-0
+EOF
+}
+
+[ $# -eq 3 ] || { usage; exit 2; }
+cluster="$1"; ns="$2"; pod="$3"
+
+# Every call: routed through kc.sh (cluster->context) with a fail-fast timeout.
+kc() { "$KC" "$cluster" --request-timeout=10s "$@"; }
+
+# Set to 4 the moment a section fails *after* the pod-read gate, so a transient
+# API/timeout error is never silently rendered as an empty/"(none)" section.
+degraded=0
+
+# jsonpath row for a *ContainerStatuses list: 6 tab-separated fields ->
+# name  ready  restarts  waiting/terminated-reason  running-startedAt  message
+state_jsonpath() {
+  printf '%s' '{range '"$1"'[*]}{.name}{"\t"}{.ready}{"\t"}{.restartCount}{"\t"}{.state.waiting.reason}{.state.terminated.reason}{"\t"}{.state.running.startedAt}{"\t"}{.state.waiting.message}{.state.terminated.message}{"\n"}{end}'
+}
+
+# ---- summary (also the existence / API gate) -----------------------------
+summary="$(kc -n "$ns" get pod "$pod" \
+  -o custom-columns=PHASE:.status.phase,NODE:.spec.nodeName,PODIP:.status.podIP,START:.status.startTime \
+  --no-headers 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  printf 'ktriage: cannot read pod %s/%s on %s (kubectl exit %s)\n' "$ns" "$pod" "$cluster" "$rc" >&2
+  printf '%s\n' "$summary" | head -3 | cut -c1-160 >&2
+  exit "$rc"
+fi
+# Parse the data row (last non-blank line) so a kubectl stderr warning folded
+# in by the 2>&1 above can't be misread as the pod's fields.
+read -r phase node ip start <<EOF
+$(printf '%s\n' "$summary" | grep -v '^[[:space:]]*$' | tail -1)
+EOF
+printf '# pod %s/%s @ %s\n' "$ns" "$pod" "$cluster"
+printf 'PHASE=%s NODE=%s IP=%s START=%s\n' "${phase:-?}" "${node:-?}" "${ip:-?}" "${start:-?}"
+
+# ---- container + init states ---------------------------------------------
+# Regular containers first (their names/restart counts drive the log section);
+# init containers after, display-only.
+names=(); rests=()
+print_states() {  # $1=label  $2=jsonpath-root  $3=collect(1/0)
+  local label="$1" root="$2" collect="$3" out rc name ready rest reason running msg
+  out="$(kc -n "$ns" get pod "$pod" -o jsonpath="$(state_jsonpath "$root")" 2>/dev/null)"; rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf '%s: (unavailable: kubectl exit %s)\n' "$label" "$rc"; degraded=4; return 0
+  fi
+  [ -n "$out" ] || return 0
+  printf '%s:\n' "$label"
+  while IFS=$'\t' read -r name ready rest reason running msg; do
+    # A real *ContainerStatuses row always carries a boolean ready field; any
+    # other line is a wrapped fragment of a multi-line container message — skip
+    # it so it can't print a junk row or be fetched as a phantom container.
+    case "$ready" in true|false) ;; *) continue ;; esac
+    [ -n "$name" ] || continue
+    [ -n "$reason" ] || { [ -n "$running" ] && reason="Running"; }
+    [ -n "$reason" ] || reason="?"
+    if [ -n "$msg" ]; then
+      printf '  %s ready=%s restarts=%s %s — %s\n' \
+        "$name" "$ready" "$rest" "$reason" "$(printf '%s' "$msg" | cut -c1-140)"
+    else
+      printf '  %s ready=%s restarts=%s %s\n' "$name" "$ready" "$rest" "$reason"
+    fi
+    if [ "$collect" = 1 ]; then
+      case "$rest" in ''|*[!0-9]*) rest=0 ;; esac
+      names+=("$name"); rests+=("$rest")
+    fi
+  done <<EOF
+$out
+EOF
+}
+print_states "containers"      ".status.containerStatuses"      1
+print_states "init containers" ".status.initContainerStatuses"  0
+
+# ---- non-True conditions -------------------------------------------------
+cond="$(kc -n "$ns" get pod "$pod" \
+  -o jsonpath='{range .status.conditions[?(@.status!="True")]}{.type}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}' \
+  2>/dev/null)"; crc=$?
+if [ "$crc" -ne 0 ]; then
+  printf 'conditions: (unavailable: kubectl exit %s)\n' "$crc"; degraded=4
+elif [ -n "$cond" ]; then
+  printf 'conditions (not True):\n'
+  while IFS=$'\t' read -r ctype creason cmsg; do
+    [ -n "$ctype" ] || continue
+    if [ -n "$cmsg" ]; then
+      printf '  %s %s %s\n' "$ctype" "${creason:-?}" "$(printf '%s' "$cmsg" | cut -c1-140)"
+    else
+      printf '  %s %s\n' "$ctype" "${creason:-?}"
+    fi
+  done <<EOF
+$cond
+EOF
+fi
+
+# ---- events (latest 10) --------------------------------------------------
+ev="$(kc -n "$ns" get events \
+  --field-selector "involvedObject.name=$pod" --sort-by=.lastTimestamp \
+  -o custom-columns=LAST:.lastTimestamp,TYPE:.type,REASON:.reason,MSG:.message \
+  --no-headers 2>/dev/null)"; erc=$?
+printf 'events (latest 10):\n'
+if [ "$erc" -ne 0 ]; then
+  printf '  (unavailable: kubectl exit %s)\n' "$erc"; degraded=4
+elif [ -n "$ev" ]; then
+  printf '%s\n' "$ev" | tail -10 | cut -c1-160 | sed 's/^/  /'
+else
+  printf '  (none)\n'
+fi
+
+# ---- logs (tail 20 per container; previous only when restarted) ----------
+emit_log() {  # $1=container  $2=label  $3=previous-flag-or-empty
+  local ctr="$1" label="$2" prev="$3" log lrc
+  if [ -n "$prev" ]; then
+    log="$(kc -n "$ns" logs "$pod" -c "$ctr" "$prev" --tail=20 2>&1)"; lrc=$?
+  else
+    log="$(kc -n "$ns" logs "$pod" -c "$ctr" --tail=20 2>&1)"; lrc=$?
+  fi
+  printf '  %s (%s, tail 20):\n' "$ctr" "$label"
+  if [ "$lrc" -ne 0 ]; then
+    printf '    (no %s logs: %s)\n' "$label" "$(printf '%s' "$log" | head -1 | cut -c1-140)"
+    # A missing *current* log is a real read failure; a missing *previous* log
+    # (rotated/GC'd) is expected for a restarted container, so don't degrade on it.
+    [ "$label" = current ] && degraded=4
+    return 0
+  fi
+  [ -n "$log" ] || { printf '    (no output)\n'; return 0; }
+  printf '%s\n' "$log" | tail -20 | cut -c1-200 | sed 's/^/    /'
+}
+
+printf 'logs:\n'
+if [ "${#names[@]}" -eq 0 ]; then
+  printf '  (no containers)\n'
+fi
+i=0
+while [ "$i" -lt "${#names[@]}" ]; do
+  emit_log "${names[$i]}" current ""
+  [ "${rests[$i]}" -gt 0 ] && emit_log "${names[$i]}" previous --previous
+  i=$((i + 1))
+done
+
+exit "$degraded"

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -48,6 +48,167 @@ assert "sp -> ~/.kube/stpetersburg" grep -q 'KUBECONFIG=.*/.kube/stpetersburg' <
 refute "sp -> no --context"         grep -q -- '--context' <<<"$spout"
 rm -rf "$stub"
 
+# ---------------------------------------------------------------- ktriage.sh
+# Stubs kubectl (reached through kc.sh's exec) and dispatches on args. Every
+# call is appended to $KUBECTL_CALLS so the read-only contract is checkable.
+# Oversized fixtures (100 log lines, 15 events) prove the tail/cut bounds hold;
+# the degraded_* fixtures fail one section after the pod-read gate to prove a
+# later failure degrades (exit 4 + inline marker) instead of reading as empty.
+section "ktriage.sh"
+kstub="$(mktemp -d)"
+cat >"$kstub/kubectl" <<'STUB'
+#!/usr/bin/env bash
+[ -n "${KUBECTL_CALLS:-}" ] && printf '%s\n' "$*" >>"$KUBECTL_CALLS"
+args="$*"
+case "$args" in
+  *--previous*) awk 'BEGIN{for(i=1;i<=100;i++)print "PREVLOG-"i}'; exit 0 ;;
+  *logs*)       awk 'BEGIN{for(i=1;i<=100;i++)print "LOGLINE-"i}'; exit 0 ;;
+esac
+case "${KT_FIXTURE:-crash}" in
+  apifail)
+    case "$args" in
+      *custom-columns=PHASE*) echo 'Error from server (NotFound): pods "ghost" not found' >&2; exit 1 ;;
+    esac
+    exit 0 ;;
+  ok)
+    case "$args" in
+      *"get events"*)          awk 'BEGIN{for(i=1;i<=2;i++)printf "2026-07-18T00:0%d:00Z Normal Started okEVT%d container started\n",i,i}'; exit 0 ;;
+      *initContainerStatuses*) exit 0 ;;
+      *containerStatuses*)     printf 'web\ttrue\t0\t\t2026-07-18T00:00:00Z\t\n'; exit 0 ;;
+      *conditions*)            exit 0 ;;
+      *custom-columns=PHASE*)  printf 'Running node-1 10.3.2.9 2026-07-18T00:00:00Z\n'; exit 0 ;;
+    esac ;;
+  degraded_events)
+    # summary/states/conditions succeed; only the events query fails.
+    case "$args" in
+      *"get events"*)          echo 'Error from server: etcdserver: request timed out' >&2; exit 1 ;;
+      *initContainerStatuses*) exit 0 ;;
+      *containerStatuses*)     printf 'web\ttrue\t0\t\t2026-07-18T00:00:00Z\t\n'; exit 0 ;;
+      *conditions*)            exit 0 ;;
+      *custom-columns=PHASE*)  printf 'Running node-1 10.3.2.9 2026-07-18T00:00:00Z\n'; exit 0 ;;
+    esac ;;
+  degraded_state)
+    # summary succeeds; the container-states query fails; events still succeed.
+    case "$args" in
+      *"get events"*)          awk 'BEGIN{for(i=1;i<=2;i++)printf "2026-07-18T00:0%d:00Z Normal Pulled EVT%d image pulled\n",i,i}'; exit 0 ;;
+      *initContainerStatuses*) exit 0 ;;
+      *containerStatuses*)     echo 'Error from server: unable to return a response' >&2; exit 1 ;;
+      *conditions*)            exit 0 ;;
+      *custom-columns=PHASE*)  printf 'Pending node-1 <none> 2026-07-18T00:00:00Z\n'; exit 0 ;;
+    esac ;;
+  multiline)
+    # a multi-line terminated message must not spawn phantom container rows.
+    case "$args" in
+      *"get events"*)          exit 0 ;;
+      *initContainerStatuses*) exit 0 ;;
+      *containerStatuses*)     printf 'app\tfalse\t0\tError\t\tpanic: boom\ngoroutine 1 [running]:\nmain.main()\n'; exit 0 ;;
+      *conditions*)            exit 0 ;;
+      *custom-columns=PHASE*)  printf 'Running node-1 10.3.2.9 2026-07-18T00:00:00Z\n'; exit 0 ;;
+    esac ;;
+  *)
+    case "$args" in
+      *"get events"*)          awk 'BEGIN{for(i=1;i<=15;i++)printf "2026-07-18T00:%02d:00Z Warning BackOff EVT%02d back-off restarting failed container\n",i,i}'; exit 0 ;;
+      *initContainerStatuses*) printf 'setup\ttrue\t0\tCompleted\t\t\n'; exit 0 ;;
+      *containerStatuses*)     printf 'app\tfalse\t5\tCrashLoopBackOff\t\tback-off 5m0s restarting failed container=app\n'; exit 0 ;;
+      *conditions*)            printf 'Ready\tContainersNotReady\tcontainers with unready status: [app]\nContainersReady\tContainersNotReady\tcontainers with unready status: [app]\n'; exit 0 ;;
+      *custom-columns=PHASE*)  printf 'Running node-3 10.3.1.5 2026-07-18T00:00:00Z\n'; exit 0 ;;
+    esac ;;
+esac
+exit 0
+STUB
+chmod +x "$kstub/kubectl"
+calls="$kstub/calls"
+
+# --- bad usage (no cluster call needed) ---
+exits  "no args -> usage exit 2"        2 "$T/ktriage.sh"
+exits  "missing pod arg -> exit 2"      2 "$T/ktriage.sh" ot media
+exits  "too many args -> exit 2"        2 "$T/ktriage.sh" ot media crashpod extra
+assert "usage names ktriage"            grep -qi 'usage:.*ktriage' <<<"$("$T/ktriage.sh" 2>&1)"
+exits  "bad cluster -> kc.sh exit 2"    2 "$T/ktriage.sh" xx media crashpod
+
+# --- crashing / restarted container ---
+: >"$calls"
+cout="$(PATH="$kstub:$PATH" KT_FIXTURE=crash KUBECTL_CALLS="$calls" "$T/ktriage.sh" ot media crashpod 2>&1)"; cec=$?
+assert "crash -> exit 0"                test "$cec" = 0
+assert "crash -> summary phase"         grep -q 'PHASE=Running' <<<"$cout"
+assert "crash -> container state"       grep -q 'app .*restarts=5 .*CrashLoopBackOff' <<<"$cout"
+assert "crash -> init container state"  grep -q 'setup .*Completed' <<<"$cout"
+assert "crash -> non-True condition"    grep -q 'Ready .*ContainersNotReady' <<<"$cout"
+# events clamped to latest 10 despite 15 emitted
+assert "crash -> latest event kept"     grep -q 'EVT15' <<<"$cout"
+refute "crash -> 11th-from-end dropped" grep -q 'EVT05' <<<"$cout"
+assert "crash -> exactly 10 events"     test "$(grep -c 'EVT[0-9]' <<<"$cout")" = 10
+# current logs clamped to tail 20 despite 100 emitted
+assert "crash -> last log line kept"    grep -q 'LOGLINE-100' <<<"$cout"
+assert "crash -> 20th-from-end kept"    grep -q 'LOGLINE-81' <<<"$cout"
+refute "crash -> 21st-from-end dropped" grep -q 'LOGLINE-80' <<<"$cout"
+assert "crash -> exactly 20 cur logs"   test "$(grep -c 'LOGLINE-' <<<"$cout")" = 20
+# previous logs shown for restarted container, also clamped
+assert "crash -> previous logs shown"   grep -q 'PREVLOG-100' <<<"$cout"
+assert "crash -> exactly 20 prev logs"  test "$(grep -c 'PREVLOG-' <<<"$cout")" = 20
+assert "crash -> output <= 80 lines"    test "$(grep -c . <<<"$cout")" -le 80
+
+# --- read-only contract (recorded verbs) ---
+assert "calls include get pod"          grep -q 'get pod' "$calls"
+assert "calls include logs"             grep -q 'logs' "$calls"
+assert "calls use --request-timeout=10s" grep -q -- '--request-timeout=10s' "$calls"
+assert "restarted -> uses --previous"   grep -q -- '--previous' "$calls"
+refute "never dumps -o yaml"            grep -q -- '-o yaml' "$calls"
+refute "never dumps -o json"            grep -qE -- '-o json($| )' "$calls"
+refute "never touches secrets"          grep -qi 'secret' "$calls"
+for v in apply delete exec patch create replace edit scale drain cordon rollout annotate label cp attach port-forward set; do
+  refute "never runs verb: $v"          grep -qw "$v" "$calls"
+done
+
+# --- healthy / no-restart container ---
+: >"$calls"
+hout="$(PATH="$kstub:$PATH" KT_FIXTURE=ok KUBECTL_CALLS="$calls" "$T/ktriage.sh" ot media healthypod 2>&1)"; hec=$?
+assert "healthy -> exit 0"              test "$hec" = 0
+assert "healthy -> container shown"     grep -q 'web .*ready=true' <<<"$hout"
+refute "healthy -> no crashloop"        grep -q 'CrashLoopBackOff' <<<"$hout"
+refute "healthy -> no previous logs"    grep -q 'PREVLOG' <<<"$hout"
+refute "healthy -> no --previous call"  grep -q -- '--previous' "$calls"
+assert "healthy -> current logs clamped" test "$(grep -c 'LOGLINE-' <<<"$hout")" = 20
+assert "healthy -> compact (<=40 ln)"   test "$(grep -c . <<<"$hout")" -le 40
+
+# --- API failure -> nonzero, no misleading partial success ---
+: >"$calls"
+aout="$(PATH="$kstub:$PATH" KT_FIXTURE=apifail KUBECTL_CALLS="$calls" "$T/ktriage.sh" ot media ghost 2>&1)"; aec=$?
+assert "api failure -> nonzero exit"    test "$aec" != 0
+assert "api failure -> reports error"   grep -qiE 'error|not found|cannot read' <<<"$aout"
+refute "api failure -> no log section"  grep -q 'LOGLINE' <<<"$aout"
+refute "api failure -> no fake summary" grep -q 'PHASE=' <<<"$aout"
+
+# --- later-section failure -> nonzero + inline marker, never mislabeled ---
+# events query fails after the gate: must read "unavailable", not "(none)".
+: >"$calls"
+eout="$(PATH="$kstub:$PATH" KT_FIXTURE=degraded_events KUBECTL_CALLS="$calls" "$T/ktriage.sh" ot media evpod 2>&1)"; eec=$?
+assert "events-fail -> exit 4 (partial)"      test "$eec" = 4
+assert "events-fail -> summary still shown"   grep -q 'PHASE=Running' <<<"$eout"
+assert "events-fail -> container still shown" grep -q 'web .*ready=true' <<<"$eout"
+assert "events-fail -> unavailable marker"    grep -q 'events.*:' <<<"$eout"
+assert "events-fail -> section marked"        grep -q '(unavailable' <<<"$eout"
+refute "events-fail -> not mislabeled none"   grep -q '(none)' <<<"$eout"
+
+# container-states query fails: marker + degrade, but later sections still run.
+: >"$calls"
+sfout="$(PATH="$kstub:$PATH" KT_FIXTURE=degraded_state KUBECTL_CALLS="$calls" "$T/ktriage.sh" ot media stpod 2>&1)"; sfec=$?
+assert "state-fail -> exit 4 (partial)"       test "$sfec" = 4
+assert "state-fail -> summary still shown"    grep -q 'PHASE=Pending' <<<"$sfout"
+assert "state-fail -> states unavailable"     grep -q 'containers: (unavailable' <<<"$sfout"
+assert "state-fail -> events still emitted"   grep -q 'EVT1' <<<"$sfout"
+
+# --- multi-line container message must not spawn phantom rows / log fetches ---
+: >"$calls"
+mout="$(PATH="$kstub:$PATH" KT_FIXTURE=multiline KUBECTL_CALLS="$calls" "$T/ktriage.sh" ot media mlpod 2>&1)"; mec=$?
+assert "multiline -> exit 0"                  test "$mec" = 0
+assert "multiline -> real row kept"           grep -q 'app ready=false .*Error' <<<"$mout"
+assert "multiline -> exactly one state row"   test "$(grep -c 'ready=' <<<"$mout")" = 1
+refute "multiline -> no phantom row printed"  grep -q 'goroutine' <<<"$mout"
+assert "multiline -> logs fetched for app"    grep -q -- '-c app' "$calls"
+refute "multiline -> no phantom log fetch"    grep -q -- 'main.main' "$calls"
+rm -rf "$kstub"
+
 # ---------------------------------------------------------------- app.sh
 section "app.sh"
 list1="$("$T/app.sh" --list)"; list2="$("$T/app.sh" --list)"
@@ -69,7 +230,10 @@ assert "immich -> nonempty"        test -n "$refs"
 assert "output sorted+unique"      test "$refs" = "$(printf '%s\n' "$refs" | sort -u)"
 allfiles=1; while IFS= read -r p; do [ -f "$ROOT/$p" ] || allfiles=0; done <<<"$refs"
 assert "output lines are file paths" test "$allfiles" = 1
-exits  "no-match -> exit 1"         1 "$T/refs.sh" zzz-nonexistent-xyz
+# PID-suffixed at runtime so the query literal can't self-match this tracked
+# test file via refs.sh's content search (a static token would live here).
+nomatch="zzz-refs-nomatch-$$"
+exits  "no-match -> exit 1"         1 "$T/refs.sh" "$nomatch"
 exits  "no args -> exit 2"          2 "$T/refs.sh"
 
 # ---------------------------------------------------------------- orphans.sh


### PR DESCRIPTION
## Summary

- add `tools/ktriage.sh <cluster> <namespace> <pod>` for bounded, read-only pod diagnostics
- report pod summary, container/init states, non-ready conditions, 10 recent events, and 20-line current/previous log tails
- route all access through `kc.sh`, enforce local output caps, and use only `get`/`logs`
- add offline fixtures covering crashes, healthy pods, multiline messages, API failures, partial failures, output bounds, and forbidden verbs

## Why

The Claude session audit behind #2000 found that the largest remaining output-token sink was repeated full pod YAML/JSON retrieval: 227 full dumps, including one session with roughly 767k characters of tool output. `kc.sh` removed cluster-selection boilerplate, but did not bound diagnostic output.

This helper provides the status, events, and logs those sessions actually extracted without placing complete manifests into model context.

## Safety and behavior

- closed read-only command set: Kubernetes `get` and `logs` only
- no Secret access, decoding, full YAML, or full JSON
- `--request-timeout=10s` on every request
- local `tail`/`cut` caps even if a server or stub ignores requested limits
- initial pod read gates all output; later unavailable sections are marked and return exit 4

## Validation

- `tools/tests/run.sh` — **112 passed, 0 failed**
- `shellcheck tools/ktriage.sh tools/tests/run.sh` — passed
- `git diff --check` — passed
- scoped Ottawa/Robbinsdale render checks were attempted but exceeded the documented 300-second local timeout; no manifests are changed
