### PR TITLE
spurfire: allow Cilium kube-apiserver identity

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/alpha-cilium-policy.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-cilium-policy.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: spurfire-kube-apiserver
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: spurfire
+      app.kubernetes.io/name: spurfire-control
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP

--- a/kubernetes/apps/base/spurfire/spurfire/kustomization.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./httproute.yaml
   - ./alpha-state-pvc.yaml
   - ./alpha-public-config.yaml
+  - ./alpha-cilium-policy.yaml
   - ./alpha-broker-oauth.sops.yaml
   - ./alpha-vault-key.sops.yaml
   - ./alpha-broker-mac.sops.yaml


### PR DESCRIPTION
Hubble proves Cilium maps the Ottawa API endpoints to the reserved kube-apiserver identity after DNAT, so standard ipBlock egress remains denied. Add an Ottawa-specific policy selecting only Spurfire endpoints and allowing only kube-apiserver TCP/6443.