### PR TITLE
spurfire: initialize broker PVC ownership

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/alpha-broker-bootstrap.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-broker-bootstrap.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: spurfire-broker-bootstrap
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: initialize-owner
+          image: ghcr.io/rajsinghtech/spurfire-server@sha256:8a2d8178b796ebcc5b25d0dc73eaf2ffede4aabc1dc915ddd4560d40d15e2e27
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - chown 10001:10001 /var/lib/spurfire && chmod 0700 /var/lib/spurfire
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - FOWNER
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          volumeMounts:
+            - name: broker-state
+              mountPath: /var/lib/spurfire
+      volumes:
+        - name: broker-state
+          persistentVolumeClaim:
+            claimName: spurfire-broker

--- a/kubernetes/apps/base/spurfire/spurfire/kustomization.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./alpha-state-pvc.yaml
   - ./alpha-public-config.yaml
   - ./alpha-cilium-policy.yaml
+  - ./alpha-broker-bootstrap.yaml
   - ./alpha-broker-oauth.sops.yaml
   - ./alpha-vault-key.sops.yaml
   - ./alpha-broker-mac.sops.yaml


### PR DESCRIPTION
Run one credential-free, non-networked, one-shot Job to set the retained broker PVC root to the custody owner and mode required by the broker fail-closed checks. The Job mounts no OAuth, vault key, MAC, TLS, or receipt material.