### PR TITLE
spurfire: prepare fresh alpha run B

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
@@ -1,34 +1,34 @@
 apiVersion: v1
 data:
-    mac.key: ENC[AES256_GCM,data:jA2KZnOonId3FCenKD0K1n4O9+/caONscbkGWZ7K5Z5FH7vLYrhwnWaaWM4=,iv:2lJpLWqZnzE9whf7WvFKH0LWqpXpfx8oOrZMq77C/9o=,tag:ZUXP111UyNMb/YmZbZtUyw==,type:str]
+    mac.key: ENC[AES256_GCM,data:OWWtKaOuW9v7NqHIowI84yahCNzGN5kgrOFEDhmMs/IxigwCa1EtvICz9s0=,iv:omSAynyCKzLjIP/9sJtOi/4i0BagNo5vu48yYNltyq8=,tag:raSZam1ZKfobSVpGBZEyKw==,type:str]
 kind: Secret
 metadata:
     name: spurfire-alpha-broker-mac
     namespace: spurfire
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-22T09:39:51Z"
-    mac: ENC[AES256_GCM,data:28TXu0t5EgEd2ZKjwXa0FXkR4fm/O/GvW6GymJ0qpkDLjyw1HWbwL4DDszGIR9tt7oBSLrmVuTmpeSTueG28uMkt7p0erHACsw0gzRfB1WtKx/GIpnCMvRn2OpXe129922xaejg6wU1KvGR0YwmVRM4Wof2r6jIOoslUVT6xueQ=,iv:dhhtbmpVj3kgkVg7QksLyLmcEFgAF3hlsrDJubBjFEw=,tag:f9bDsbPdlBPs6CJiYLttgw==,type:str]
+    lastmodified: "2026-07-22T10:41:50Z"
+    mac: ENC[AES256_GCM,data:feSe8D5GFFogWaidTxPyWKBauTp+P6yOO8bupoDvwaNNlbmFs77M+5aXdBRP5i3aDu+RF6i8kP3XwMsRe9vKrSAMotrTd2rZtYyqGuU1lSh/7VT2bLKbsGWs1vrW2WkM9ayM9YekSKRotiwZDVW8rmYSB2b7tdBbkpatD5Vyrb8=,iv:32Fnh2sCkFiPrQpPM+oSnSTkm1Y2X7VRALQSuwv2CYA=,tag:6uxeD4Zqkaa+hR0l1FKO5w==,type:str]
     pgp:
-        - created_at: "2026-07-22T09:39:51Z"
+        - created_at: "2026-07-22T10:41:50Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0HSi2TJaWveARAAkt/5ARpVFXNIat5EUldxozPRw11K1NWavGMeGx6Sy4FV
-            CKPbGCPi4Rwx2YQUvXmQfG56NzXuCSiVJMiH/gLFh3Gusat6ricI0CwLgyrsIWme
-            FOUJQe650YMVcsS0257DZ0o8yMxLDn9KmTXAVVFFiIELG3qqYirrb/9KuX/PB3TY
-            ZmlACtkS+JsRdmj39TzweNuan2FxqTaF43cFLlnLLESegFmL4ldq+C28TSnxbClz
-            669pFjpd2iSrK+7U/NOoVv1jgvsIxDYialS1cF4Vd3uRbNlDRCxXhF5CZr9t2bLG
-            bp9+hQNgS3TCkdETTQNsZOPs8259ooFiRb1Dnr65RlJVGTrH2BRLTNcx7QCDseoY
-            lS/p5mjIw+YcEvzDj5va39+RvGrzkUya9aTHkjIvnaqKv/Hv26J7F9TYID1dMg4Y
-            XtEfskTou9bpmfBfELo0l1NZ0Ywh5FJBS2fzx53uTiWuDoF4nvpFzgQAooGVTzyU
-            trXR4xhHAMba9xdsNbzV1DxuUcbEPPPAJVIuRSA5ZIYZPTTBJ53jv7CmqqHKxAyp
-            ZZMlgL2F3tUlSlPKD9iPNrP8FBEhXH/cxw4MYfJNICj7RvXDpyDGGhTBabmOgvex
-            fF7QOP1KukisjiJS8ncvqfAwDiDBdf0mZXdwcz43fwlS/yqU6uRjxtDn5PT9JWfU
-            aAEJAhDK8BrEyFfiOx2/51fN2g3+INy6uQhYuBJYLSc9e7mUMexY2U1tbsQY/Yip
-            hPRyszTiq0cjKAkRT5D9DotoygCUT1XbmsxosrKkXBp//la+5hqFcqdiwyrG5doZ
-            9WSVewTMZ6Hb
-            =CfJB
+            hQIMA0HSi2TJaWveARAAlNdmtPppCgOeroWVmYaLQUNILF0IvRZWlmAUWZYCoeXa
+            klTclN9Ms0tb/5A7x1jrZLaw7JzPTPWkRSSfwuoj/rIr6D4DRuyokyWpAiyEbISm
+            G3Xz19gKvne0+Tf5cdmA4yx4HgWAby9Fqqp8xsdvmpOjgrg43R6AbqUIZ4y6mDA8
+            5ZxK57/wShbu9WUgd4eXwzqLvNbkpqU9FMuTimU3qxN2uisgxtyYY4r7ovw8h8Dz
+            a+CftlUw1Kl+QKPMj2BHMU7D0n2VTNUGyZivOUqH1uAZncsdLfHvEFoaXIELiA06
+            4EX5PYJz0ffFMCV33us9/3b7Jlp77vq/OFXNVIj/W5nKPRzhhQqV16RhL+8YlJFj
+            Dk+fJgOT+1fhNOzRXWNbEXNl2b1YZwFh1hGtaPO2bzzNgbV5zhQJ96Qb5NDbsFZr
+            nyouUABXnfOtWl6AdK2iwzIyL88294J7fU/R96PTLhLtsDl7R3ZKmlwlSRzR7UrU
+            tYkA6cEFrDj1M4FWOJjz/s6lL1QYhdaduFOipTkDzQNI0nSlQNMfR8iPxFssHZPp
+            2+JTr+3jIlUaMDridVgTvvWW49ovjDgWp0EnEiLKQXMZe3LjMWJQLkbq5r+3bQbR
+            Un7/k852n+PLp+bKMrzcVsfxuYmoCBRHe8v9yvPep2CRW8iR5mo9oo4PQXPCS2PU
+            aAEJAhADAmQTYNVerp+Rp1JmkYAGfAn05u0KzFX4pgKqfVvr3k2LJ6wm+IHEBhj5
+            UDCMAc70LKUnxcp8wFjWdwuOXgz9XNl5edglRJjLo4fove3jgxIxiLDe4iF4t3mt
+            FqHSJUJT5cuT
+            =Sii7
             -----END PGP MESSAGE-----
           fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
     version: 3.13.2

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spurfire-alpha-public
 data:
   broker.json: >-
-    {"run_id":"run-c7f0843cbb6982b93ddff5ab0072865a","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
+    {"run_id":"run-77fe791f97ee055a8e004e2a0201acd5","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
   artifact-set-sha256: 4bec34a1cd2b5a7509a76947cb225d1404018bc28ed1dde1818536598e3f36e7
   source-sha: 7e4034b147ad39366b87e4a712d8837eb8b1dbcc
   runtime-image-digest: sha256:8a2d8178b796ebcc5b25d0dc73eaf2ffede4aabc1dc915ddd4560d40d15e2e27

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: spurfire-alpha-state-20260722
+  name: spurfire-alpha-state-20260722-b
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:

--- a/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
@@ -18,10 +18,10 @@ spec:
     # One receipt-bound, two-rider protected Alpha. Ordinary real-mutation
     # switches remain closed; provider authority exists only in the broker.
     config:
-      dryRun: false
+      dryRun: true
       dryRunTtlSeconds: 300
-      maxPlayers: 2
-      provisioningMode: tailnet_per_lobby
+      maxPlayers: 16
+      provisioningMode: dry_run
       sharedTailnet: "-"
     tailscale:
       apiBase: https://api.tailscale.com/api/v2
@@ -30,17 +30,17 @@ spec:
       clientSecretKey: TS_CLIENT_SECRET
     persistence:
       enabled: true
-      existingClaim: spurfire-alpha-state-20260722
+      existingClaim: spurfire-alpha-state-20260722-b
       storageClass: ceph-block-replicated
       accessModes:
         - ReadWriteOnce
       size: 1Gi
       retain: true
     protectedAlpha:
-      prepare: false
-      enabled: true
-      installationId: ottawa-alpha-20260722-7a026dfb20591570
-      authorizedLobbyId: bf7a63ff-5769-4325-bf20-a3a31011a64f
+      prepare: true
+      enabled: false
+      installationId: ottawa-alpha-20260722-d12ef9466e1126cc3f590809
+      authorizedLobbyId: 13b7bc0e-0cd3-4eb5-b947-445130d50694
       publicOrigin: https://spurfire.rajsingh.info
       internalListener: spurfire-broker.spurfire.svc:9443
       sourceSha: 7e4034b147ad39366b87e4a712d8837eb8b1dbcc

--- a/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
@@ -21,7 +21,7 @@ spec:
             value: /v1/lobbies
         - path:
             type: PathPrefix
-            value: /v1/lobbies/bf7a63ff-5769-4325-bf20-a3a31011a64f
+            value: /v1/lobbies/13b7bc0e-0cd3-4eb5-b947-445130d50694
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
Return to credential-free preparation with a new retained state PVC, installation/lobby/run tuple, and per-run MAC after the first fail-closed startup persisted cleanup-only evidence. Provider mutations remain disabled.