### PR TITLE
spurfire: prepare corrected alpha run C

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
@@ -1,34 +1,34 @@
 apiVersion: v1
 data:
-    mac.key: ENC[AES256_GCM,data:OWWtKaOuW9v7NqHIowI84yahCNzGN5kgrOFEDhmMs/IxigwCa1EtvICz9s0=,iv:omSAynyCKzLjIP/9sJtOi/4i0BagNo5vu48yYNltyq8=,tag:raSZam1ZKfobSVpGBZEyKw==,type:str]
+    mac.key: ENC[AES256_GCM,data:DQJYE6USWfIzey6LLe2ETAQXzdDIfCg/nlbEf1yy1lpJnXt6VfI0dmR/nfA=,iv:hvapYA00vL8EIwM3phYYSQLcOJ7wwX9TFZePDw0DaXc=,tag:Gl+L1KWfIYM5ikQEPOo8cQ==,type:str]
 kind: Secret
 metadata:
     name: spurfire-alpha-broker-mac
     namespace: spurfire
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-22T10:41:50Z"
-    mac: ENC[AES256_GCM,data:feSe8D5GFFogWaidTxPyWKBauTp+P6yOO8bupoDvwaNNlbmFs77M+5aXdBRP5i3aDu+RF6i8kP3XwMsRe9vKrSAMotrTd2rZtYyqGuU1lSh/7VT2bLKbsGWs1vrW2WkM9ayM9YekSKRotiwZDVW8rmYSB2b7tdBbkpatD5Vyrb8=,iv:32Fnh2sCkFiPrQpPM+oSnSTkm1Y2X7VRALQSuwv2CYA=,tag:6uxeD4Zqkaa+hR0l1FKO5w==,type:str]
+    lastmodified: "2026-07-22T11:25:34Z"
+    mac: ENC[AES256_GCM,data:Sv5NrpaGa2kj5wzhBaySsUQQzdkGOe84i/IiDwJYDCfZRXrmc6QPWTDzPMpcJT0ynAmhcI3b4lVGPtkr0NTziH2KH22wWDJ6yN7XaujOwgH7fQWCO1sRRWuhsIfs83e0Jcx59wQyhaZ7xySSfeq3oF2PjLwDU23Hoo1ITRTZZQs=,iv:Pk547rQOe1bFORLVgPbhLkJ4PiiTVQ67y8F78umGYGQ=,tag:ITeUcZoogK704uemiX6ksw==,type:str]
     pgp:
-        - created_at: "2026-07-22T10:41:50Z"
+        - created_at: "2026-07-22T11:25:34Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0HSi2TJaWveARAAlNdmtPppCgOeroWVmYaLQUNILF0IvRZWlmAUWZYCoeXa
-            klTclN9Ms0tb/5A7x1jrZLaw7JzPTPWkRSSfwuoj/rIr6D4DRuyokyWpAiyEbISm
-            G3Xz19gKvne0+Tf5cdmA4yx4HgWAby9Fqqp8xsdvmpOjgrg43R6AbqUIZ4y6mDA8
-            5ZxK57/wShbu9WUgd4eXwzqLvNbkpqU9FMuTimU3qxN2uisgxtyYY4r7ovw8h8Dz
-            a+CftlUw1Kl+QKPMj2BHMU7D0n2VTNUGyZivOUqH1uAZncsdLfHvEFoaXIELiA06
-            4EX5PYJz0ffFMCV33us9/3b7Jlp77vq/OFXNVIj/W5nKPRzhhQqV16RhL+8YlJFj
-            Dk+fJgOT+1fhNOzRXWNbEXNl2b1YZwFh1hGtaPO2bzzNgbV5zhQJ96Qb5NDbsFZr
-            nyouUABXnfOtWl6AdK2iwzIyL88294J7fU/R96PTLhLtsDl7R3ZKmlwlSRzR7UrU
-            tYkA6cEFrDj1M4FWOJjz/s6lL1QYhdaduFOipTkDzQNI0nSlQNMfR8iPxFssHZPp
-            2+JTr+3jIlUaMDridVgTvvWW49ovjDgWp0EnEiLKQXMZe3LjMWJQLkbq5r+3bQbR
-            Un7/k852n+PLp+bKMrzcVsfxuYmoCBRHe8v9yvPep2CRW8iR5mo9oo4PQXPCS2PU
-            aAEJAhADAmQTYNVerp+Rp1JmkYAGfAn05u0KzFX4pgKqfVvr3k2LJ6wm+IHEBhj5
-            UDCMAc70LKUnxcp8wFjWdwuOXgz9XNl5edglRJjLo4fove3jgxIxiLDe4iF4t3mt
-            FqHSJUJT5cuT
-            =Sii7
+            hQIMA0HSi2TJaWveARAAnNTosHBPeAZt8+MDyD9C16UAt5Yzsehjdk6z1xCkyLo7
+            KC0AErXlssqT3wmiVfoTxlgeGTj4kKpBWpD1yaRAMX1npxoZ/44tyf7qVQiMCUIp
+            vQW6bQw+bISHgU0uB/ca6/O0jKm5B3MYllarPhVz0ela0ErRhuM2D1sCfoCoBym6
+            gXwx6Wen9T36JGLibiZp2gvIIOsvW5WOcJ4v8t0umAKfcufc73BSi6fNfHasdnwC
+            auDlS7p5nL9Fps+hBf+H9C/xQJRvThLfC9thgKhsJxWCbQTpR55eprrbvYbXJ/Nr
+            rZyQpP5oZlgzMyARCKcdif76f0tO/t8WOyk8OoCrsNHa8LCbC3gkxDQfmxfUeQLo
+            5o8twK8+O/yakxpBt7ZawCsUvaSThLX35lzfxQiQhHa2x+pMLXuzTPy2we5jNFzP
+            ZXCLRblcNdUAfRV2oirxDAddPVDDfUPE0TuDVfUHMGUE5EW1G8NIEKbuGrfRDVp2
+            nVlUP8rpobXw+5QU9yycRFnapbX1S5quFxMtyw9G9MyNOSjEC6c4OaCk/MBx2MnT
+            Dka+PRgichYw+n6ti0427ky8mHD+68XFHGs2uUwDUFSYJmgSNmohAvXrObZ95Pjb
+            d7V7jeTootZW3VPGYcRkPc9V72NFbgvtGerpXCWIpzIA8laY6XXYDTkbIN8+iQrU
+            aAEJAhD7M/3DCuvChzXk85hLO8lW5Gi5cKvryMjLXI7YCGeqCIVCIUwB6w8P6Uq2
+            crH2Dz9Y5BzX209Abh+7wcoEM1yyPaT2Bw9lVmHeO87FOksxyMyAQY9QKy/8CDbp
+            QERhzQFuRzpG
+            =1ymr
             -----END PGP MESSAGE-----
           fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
     version: 3.13.2

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
@@ -5,8 +5,8 @@ metadata:
   name: spurfire-alpha-public
 data:
   broker.json: >-
-    {"run_id":"run-77fe791f97ee055a8e004e2a0201acd5","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
-  artifact-set-sha256: 4bec34a1cd2b5a7509a76947cb225d1404018bc28ed1dde1818536598e3f36e7
-  source-sha: 7e4034b147ad39366b87e4a712d8837eb8b1dbcc
-  runtime-image-digest: sha256:8a2d8178b796ebcc5b25d0dc73eaf2ffede4aabc1dc915ddd4560d40d15e2e27
-  chart-digest: sha256:7cdf6a71001f63671dedc91fb571558289a86c83c881de46125a6bbb535b5c1d
+    {"run_id":"run-8f8649e17dde110c84189534ce308b27","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
+  artifact-set-sha256: 0ab424bf382c97b6083a34b88353a1ab83d526ac625407cf61851d17e8f0e955
+  source-sha: 60e6092048c7da8c19065d4703b93c6a6b655287
+  runtime-image-digest: sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43
+  chart-digest: sha256:932aa514dac3216b6cc50abf0a10485ae8fc5d316cfe42eb3cd6fdccf7c73e66

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: spurfire-alpha-state-20260722-b
+  name: spurfire-alpha-state-20260722-c
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:

--- a/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
@@ -12,16 +12,16 @@ spec:
     fullnameOverride: spurfire
     image:
       repository: ghcr.io/rajsinghtech/spurfire-server
-      tag: "sha-7e4034b147ad39366b87e4a712d8837eb8b1dbcc"
-      digest: "sha256:8a2d8178b796ebcc5b25d0dc73eaf2ffede4aabc1dc915ddd4560d40d15e2e27"
+      tag: "sha-60e6092048c7da8c19065d4703b93c6a6b655287"
+      digest: "sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43"
       pullPolicy: IfNotPresent
     # One receipt-bound, two-rider protected Alpha. Ordinary real-mutation
     # switches remain closed; provider authority exists only in the broker.
     config:
-      dryRun: false
+      dryRun: true
       dryRunTtlSeconds: 300
-      maxPlayers: 2
-      provisioningMode: tailnet_per_lobby
+      maxPlayers: 16
+      provisioningMode: dry_run
       sharedTailnet: "-"
     tailscale:
       apiBase: https://api.tailscale.com/api/v2
@@ -30,26 +30,26 @@ spec:
       clientSecretKey: TS_CLIENT_SECRET
     persistence:
       enabled: true
-      existingClaim: spurfire-alpha-state-20260722-b
+      existingClaim: spurfire-alpha-state-20260722-c
       storageClass: ceph-block-replicated
       accessModes:
         - ReadWriteOnce
       size: 1Gi
       retain: true
     protectedAlpha:
-      prepare: false
-      enabled: true
-      installationId: ottawa-alpha-20260722-d12ef9466e1126cc3f590809
-      authorizedLobbyId: 13b7bc0e-0cd3-4eb5-b947-445130d50694
+      prepare: true
+      enabled: false
+      installationId: ottawa-alpha-20260722-c7d544898d7a4f3e9637ecb9
+      authorizedLobbyId: dae4b494-ee79-4cca-b3c9-c9366fb7b6a1
       publicOrigin: https://spurfire.rajsingh.info
       internalListener: spurfire-broker.spurfire.svc:9443
-      sourceSha: 7e4034b147ad39366b87e4a712d8837eb8b1dbcc
-      provenanceSha256: 70b78b6b7d5f45505accbe5ec401245f67f7ef1aac2c3c5827b5c1d23f05a838
-      artifactSetSha256: 4bec34a1cd2b5a7509a76947cb225d1404018bc28ed1dde1818536598e3f36e7
+      sourceSha: 60e6092048c7da8c19065d4703b93c6a6b655287
+      provenanceSha256: 6f70d69dadd8f77b202aa4596c6a702c152ce2b96804758fe97b89919ae38b06
+      artifactSetSha256: 0ab424bf382c97b6083a34b88353a1ab83d526ac625407cf61851d17e8f0e955
       policyProfileSha256: a663104d4ea858a7d888da570d39824a40103da48d8e6e4d2acd698d83caf135
       leaseName: spurfire-protected-alpha
-      runtimeImageDigest: "sha256:8a2d8178b796ebcc5b25d0dc73eaf2ffede4aabc1dc915ddd4560d40d15e2e27"
-      brokerImageDigest: "sha256:8a2d8178b796ebcc5b25d0dc73eaf2ffede4aabc1dc915ddd4560d40d15e2e27"
+      runtimeImageDigest: "sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43"
+      brokerImageDigest: "sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43"
       receiptSopsSecret: spurfire-alpha-receipt
       brokerCredentialSopsSecret: spurfire-alpha-broker-oauth
       brokerVaultKeySopsSecret: spurfire-alpha-vault-key

--- a/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
@@ -21,7 +21,7 @@ spec:
             value: /v1/lobbies
         - path:
             type: PathPrefix
-            value: /v1/lobbies/13b7bc0e-0cd3-4eb5-b947-445130d50694
+            value: /v1/lobbies/dae4b494-ee79-4cca-b3c9-c9366fb7b6a1
       backendRefs:
         - group: ""
           kind: Service

--- a/kubernetes/apps/base/spurfire/spurfire/ocirepository.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/ocirepository.yaml
@@ -9,6 +9,6 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: "0.2.0-main.128.1.sha-7e4034b147ad"
-    digest: "sha256:7cdf6a71001f63671dedc91fb571558289a86c83c881de46125a6bbb535b5c1d"
+    tag: "0.2.0-main.130.1.sha-60e6092048c7"
+    digest: "sha256:932aa514dac3216b6cc50abf0a10485ae8fc5d316cfe42eb3cd6fdccf7c73e66"
   url: oci://ghcr.io/rajsinghtech/charts/spurfire-control


### PR DESCRIPTION
Pin the signed corrected Spurfire main image/chart and prepare a final fresh retained state, installation/lobby/run tuple, and per-run MAC. Provider mutations remain disabled during bootstrap.