### PR TITLE
feat(tailgate): bump to v0.0.12 + enable UI with Tailscale OAuth

### DIFF
--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: tailgate-operator
-      version: "0.0.11"
+      version: "0.0.12"
       sourceRef:
         kind: HelmRepository
         name: tailgate-operator
@@ -39,10 +39,18 @@ spec:
       # never blackhole through the tunnel.
       clusterCIDRs: "${CLUSTER_POD_CIDR},${CLUSTER_SERVICE_CIDR}"
       image:
-        tag: v0.0.11
+        tag: v0.0.12
     operator:
       image:
-        tag: v0.0.11
+        tag: v0.0.12
     gateway:
       image:
-        tag: v0.0.11
+        tag: v0.0.12
+    ui:
+      enabled: true
+      image:
+        tag: v0.0.12
+      oauthSecretName: tailgate-ui-oauth
+      oauthRedirectURL: "https://tailgate.keiretsu.top/callback"
+      adminEmails:
+        - "rajsingh@keiretsu.top"

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/httproute.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/httproute.yaml
@@ -1,0 +1,39 @@
+---
+# tailgate-ui web route — public + private gateways. The UI does its own
+# Tailscale OAuth (identity-only), so no tinyauth SecurityPolicy is needed.
+# The host tailgate.keiretsu.top is a wildcard-matched hostname (*.keiretsu.top
+# is covered by the wildcard cert on the public gateway).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tailgate-ui
+  namespace: tailgate-operator-system
+  annotations:
+    item.homer.rajsingh.info/name: "Tailgate"
+    item.homer.rajsingh.info/subtitle: "Egress Management"
+    item.homer.rajsingh.info/keywords: "tailscale, egress, kubernetes, tailgate"
+    service.homer.rajsingh.info/name: "Infrastructure"
+    service.homer.rajsingh.info/icon: "fas fa-network-wired"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+  hostnames:
+    - "tailgate.${COMMON_DOMAIN}"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: tailgate-operator-ui
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/kustomization.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/kustomization.yaml
@@ -3,4 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - secret.yaml
+  - ui-secret.yaml
   - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/ui-secret.yaml
+++ b/kubernetes/apps/base/tailgate-operator-system/tailgate-operator/app/ui-secret.yaml
@@ -1,0 +1,18 @@
+---
+# OAuth app credentials for tailgate-ui. This is a SEPARATE OAuth app from the
+# operator's client-credentials client — this one uses the authorization-code
+# flow (identity-only, no scopes) so users can log in with their Tailscale
+# identity. Create the OAuth app under Settings → OAuth apps in the Tailscale
+# admin console with redirect URI https://tailgate.keiretsu.top/callback.
+#
+# client_id / client_secret come from common-secrets (substituted by Flux).
+# session_key is a stable HMAC key for signing session cookies (32+ bytes hex).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailgate-ui-oauth
+type: Opaque
+stringData:
+  client_id: ${TAILGATE_UI_OAUTH_CLIENT_ID}
+  client_secret: ${TAILGATE_UI_OAUTH_CLIENT_SECRET}
+  session_key: ${TAILGATE_UI_SESSION_KEY}


### PR DESCRIPTION
Bump chart from v0.0.11 to v0.0.12 (auto-follow scheduling + management UI). Enable the UI with Tailscale OAuth identity, route at tailgate.keiretsu.top.