### PR TITLE
spurfire: prepare corrected alpha run D

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 data:
-    mac.key: ENC[AES256_GCM,data:DQJYE6USWfIzey6LLe2ETAQXzdDIfCg/nlbEf1yy1lpJnXt6VfI0dmR/nfA=,iv:hvapYA00vL8EIwM3phYYSQLcOJ7wwX9TFZePDw0DaXc=,tag:Gl+L1KWfIYM5ikQEPOo8cQ==,type:str]
+    mac.key: ENC[AES256_GCM,data:4/VQOzSpc9LfygFV/Dyuwo/tK9OkbUX8mGOlZigrOqdNpVF+9dC/p1k3De0=,iv:Pnv+d+picCNXnFsyw8lDyPz3gykkuam/fF6j5UJnEUA=,tag:3TNiQGeVJGcoBu+hj13d6Q==,type:str]
 kind: Secret
 metadata:
     name: spurfire-alpha-broker-mac
     namespace: spurfire
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-22T11:25:34Z"
-    mac: ENC[AES256_GCM,data:Sv5NrpaGa2kj5wzhBaySsUQQzdkGOe84i/IiDwJYDCfZRXrmc6QPWTDzPMpcJT0ynAmhcI3b4lVGPtkr0NTziH2KH22wWDJ6yN7XaujOwgH7fQWCO1sRRWuhsIfs83e0Jcx59wQyhaZ7xySSfeq3oF2PjLwDU23Hoo1ITRTZZQs=,iv:Pk547rQOe1bFORLVgPbhLkJ4PiiTVQ67y8F78umGYGQ=,tag:ITeUcZoogK704uemiX6ksw==,type:str]
+    lastmodified: "2026-07-22T11:35:48Z"
+    mac: ENC[AES256_GCM,data:8k4u8nQQVZFV5yCRXggDOZUTyp5eB4HiwkHvOUZ8rDFXJ/u1ZxHVrIpUEtw+wr6mia2DtshLrSLugUYmD1ZjotkkXlfCJkitPhn1xsh3ivuvdJxdfqPp7UXLfqfwyElcMP/aB9+mn9tvqIu8JIhi4hHCFTU7PDrA5vGk4PtOqEM=,iv:0nsrENjdbXYw7hpe+WYCee2VwHyyWhV3CEzKPR6qctk=,tag:zH86j8L4zx+5/GzCV3AL5Q==,type:str]
     pgp:
         - created_at: "2026-07-22T11:25:34Z"
           enc: |-

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spurfire-alpha-public
 data:
   broker.json: >-
-    {"run_id":"run-8f8649e17dde110c84189534ce308b27","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
+    {"run_id":"run-a6bdfc8e227f01544036d908c01e8abe","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
   artifact-set-sha256: 0ab424bf382c97b6083a34b88353a1ab83d526ac625407cf61851d17e8f0e955
   source-sha: 60e6092048c7da8c19065d4703b93c6a6b655287
   runtime-image-digest: sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: spurfire-alpha-state-20260722-c
+  name: spurfire-alpha-state-20260722-d
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:

--- a/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
@@ -15,13 +15,12 @@ spec:
       tag: "sha-60e6092048c7da8c19065d4703b93c6a6b655287"
       digest: "sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43"
       pullPolicy: IfNotPresent
-    # One receipt-bound, two-rider protected Alpha. Ordinary real-mutation
-    # switches remain closed; provider authority exists only in the broker.
+    # Prepare a fresh protected Alpha generation without provider authority.
     config:
-      dryRun: false
+      dryRun: true
       dryRunTtlSeconds: 300
-      maxPlayers: 2
-      provisioningMode: tailnet_per_lobby
+      maxPlayers: 16
+      provisioningMode: dry_run
       sharedTailnet: "-"
     tailscale:
       apiBase: https://api.tailscale.com/api/v2
@@ -30,17 +29,17 @@ spec:
       clientSecretKey: TS_CLIENT_SECRET
     persistence:
       enabled: true
-      existingClaim: spurfire-alpha-state-20260722-c
+      existingClaim: spurfire-alpha-state-20260722-d
       storageClass: ceph-block-replicated
       accessModes:
         - ReadWriteOnce
       size: 1Gi
       retain: true
     protectedAlpha:
-      prepare: false
-      enabled: true
-      installationId: ottawa-alpha-20260722-c7d544898d7a4f3e9637ecb9
-      authorizedLobbyId: dae4b494-ee79-4cca-b3c9-c9366fb7b6a1
+      prepare: true
+      enabled: false
+      installationId: ottawa-alpha-20260722-a8c0ad23a07dcd117f592a45
+      authorizedLobbyId: db5758b1-af31-4679-82c9-0a87d5e5a2b0
       publicOrigin: https://spurfire.rajsingh.info
       internalListener: spurfire-broker.spurfire.svc:9443
       sourceSha: 60e6092048c7da8c19065d4703b93c6a6b655287

--- a/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
@@ -21,7 +21,7 @@ spec:
             value: /v1/lobbies
         - path:
             type: PathPrefix
-            value: /v1/lobbies/dae4b494-ee79-4cca-b3c9-c9366fb7b6a1
+            value: /v1/lobbies/db5758b1-af31-4679-82c9-0a87d5e5a2b0
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
Rotates the protected Alpha run identity, state PVC, authorized lobby path, and broker MAC into a fresh dry-run/prepare generation before activation. Pins the previously verified exact source, image, chart, and artifact hashes.