### PR TITLE
spurfire: prepare clean alpha run E

### DIFF
--- a/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-broker-mac.sops.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 data:
-    mac.key: ENC[AES256_GCM,data:4/VQOzSpc9LfygFV/Dyuwo/tK9OkbUX8mGOlZigrOqdNpVF+9dC/p1k3De0=,iv:Pnv+d+picCNXnFsyw8lDyPz3gykkuam/fF6j5UJnEUA=,tag:3TNiQGeVJGcoBu+hj13d6Q==,type:str]
+    mac.key: ENC[AES256_GCM,data:u1dgsvX2Ajos8QKVRVgZYT+bQG+dJ42Yn7r7fK6M5xKv8OmG9qBKRjWBLdQ=,iv:cvlAYx8CmEdZozig6+mJWQvAOFSYEpJIi5tSog1+Y7k=,tag:3Lgtn7er2UupeH6EPGm6Pg==,type:str]
 kind: Secret
 metadata:
     name: spurfire-alpha-broker-mac
     namespace: spurfire
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-22T11:35:48Z"
-    mac: ENC[AES256_GCM,data:8k4u8nQQVZFV5yCRXggDOZUTyp5eB4HiwkHvOUZ8rDFXJ/u1ZxHVrIpUEtw+wr6mia2DtshLrSLugUYmD1ZjotkkXlfCJkitPhn1xsh3ivuvdJxdfqPp7UXLfqfwyElcMP/aB9+mn9tvqIu8JIhi4hHCFTU7PDrA5vGk4PtOqEM=,iv:0nsrENjdbXYw7hpe+WYCee2VwHyyWhV3CEzKPR6qctk=,tag:zH86j8L4zx+5/GzCV3AL5Q==,type:str]
+    lastmodified: "2026-07-22T12:08:25Z"
+    mac: ENC[AES256_GCM,data:qp5my2WT943BK6TjvAbD6E6cZWWrPpaDS7J+oo0aQgq6J38qPjciw7iwiEj5gb1yp56EcoOozK46uTeMEV4fMYNNQlYQdxJ+uMA6UeKtZVcw+k1JGSvBm3vS0sCBVqol5nRZ8nYBctYHzGFgXjr5CGbDwlDiN6yAiCY5dmn+blM=,iv:5GpGZ7hZYhejJW3N/zBRuCYBB6ogWsmUyc2rVJuIRzA=,tag:FyvOisDIX81kZd3MuMujkw==,type:str]
     pgp:
         - created_at: "2026-07-22T11:25:34Z"
           enc: |-

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-public-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spurfire-alpha-public
 data:
   broker.json: >-
-    {"run_id":"run-a6bdfc8e227f01544036d908c01e8abe","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
+    {"run_id":"run-d24763093134a3b64d7a4195d10ca2cd","namespace":"spurfire","lease_name":"spurfire-protected-alpha"}
   artifact-set-sha256: 0ab424bf382c97b6083a34b88353a1ab83d526ac625407cf61851d17e8f0e955
   source-sha: 60e6092048c7da8c19065d4703b93c6a6b655287
   runtime-image-digest: sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43

--- a/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/alpha-state-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: spurfire-alpha-state-20260722-d
+  name: spurfire-alpha-state-20260722-e
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:

--- a/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/helmrelease.yaml
@@ -8,47 +8,18 @@ spec:
     kind: OCIRepository
     name: spurfire
   interval: 1h
-  # The protected runtime must not consume its one-shot receipt until the
-  # private broker is accepting TLS connections.
   postRenderers:
     - kustomize:
         patches:
-          - target:
-              kind: Deployment
-              name: spurfire
-            patch: |
-              - op: add
-                path: /spec/template/spec/initContainers
-                value:
-                  - name: wait-for-provider-broker
-                    image: busybox:1.37.0
-                    imagePullPolicy: IfNotPresent
-                    command: ["/bin/sh", "-ec"]
-                    args:
-                      - until nc -z -w 2 spurfire-broker.spurfire.svc 9443; do sleep 1; done
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      readOnlyRootFilesystem: true
-                      runAsNonRoot: true
-                      runAsUser: 10001
-                      capabilities:
-                        drop: ["ALL"]
-                    resources:
-                      requests:
-                        cpu: 1m
-                        memory: 4Mi
-                      limits:
-                        cpu: 50m
-                        memory: 16Mi
-          # Run D uses a fresh retained vault because a force-removed run-C
-          # process on rei still owns the previous PVC's OS writer lock.
+          # Run E uses a fresh retained vault and never shares a writer lock
+          # with an earlier failed-closed generation.
           - target:
               kind: PersistentVolumeClaim
               name: spurfire-broker
             patch: |
               - op: replace
                 path: /metadata/name
-                value: spurfire-broker-run-d2
+                value: spurfire-broker-run-e
           - target:
               kind: Deployment
               name: spurfire-broker
@@ -66,7 +37,7 @@ spec:
                     volumes:
                       - name: broker-state
                         persistentVolumeClaim:
-                          claimName: spurfire-broker-run-d2
+                          claimName: spurfire-broker-run-e
   values:
     fullnameOverride: spurfire
     image:
@@ -74,13 +45,12 @@ spec:
       tag: "sha-60e6092048c7da8c19065d4703b93c6a6b655287"
       digest: "sha256:d30c0894ac869c6864866b2cd5ff24339ea3097ab5bac43e31549456174f5e43"
       pullPolicy: IfNotPresent
-    # One receipt-bound, two-rider protected Alpha. Ordinary real-mutation
-    # switches remain closed; provider authority exists only in the broker.
+    # Prepare a fresh protected Alpha generation without provider authority.
     config:
-      dryRun: false
+      dryRun: true
       dryRunTtlSeconds: 300
-      maxPlayers: 2
-      provisioningMode: tailnet_per_lobby
+      maxPlayers: 16
+      provisioningMode: dry_run
       sharedTailnet: "-"
     tailscale:
       apiBase: https://api.tailscale.com/api/v2
@@ -89,17 +59,17 @@ spec:
       clientSecretKey: TS_CLIENT_SECRET
     persistence:
       enabled: true
-      existingClaim: spurfire-alpha-state-20260722-d
+      existingClaim: spurfire-alpha-state-20260722-e
       storageClass: ceph-block-replicated
       accessModes:
         - ReadWriteOnce
       size: 1Gi
       retain: true
     protectedAlpha:
-      prepare: false
-      enabled: true
-      installationId: ottawa-alpha-20260722-a8c0ad23a07dcd117f592a45
-      authorizedLobbyId: db5758b1-af31-4679-82c9-0a87d5e5a2b0
+      prepare: true
+      enabled: false
+      installationId: ottawa-alpha-20260722-543017711aae5997838d04f2
+      authorizedLobbyId: a07cae87-44b1-432e-8f25-affc06c04023
       publicOrigin: https://spurfire.rajsingh.info
       internalListener: spurfire-broker.spurfire.svc:9443
       sourceSha: 60e6092048c7da8c19065d4703b93c6a6b655287

--- a/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
+++ b/kubernetes/apps/base/spurfire/spurfire/httproute.yaml
@@ -21,7 +21,7 @@ spec:
             value: /v1/lobbies
         - path:
             type: PathPrefix
-            value: /v1/lobbies/db5758b1-af31-4679-82c9-0a87d5e5a2b0
+            value: /v1/lobbies/a07cae87-44b1-432e-8f25-affc06c04023
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
Bootstraps a fresh dry-run state/Lease generation with the broker absent, rotates the public run/lobby identity and MAC, and reserves a fresh retained broker vault. This prevents any stale broker endpoint from consuming the one-shot runtime state before activation.