### PR TITLE
fix(k8s-gpu-dra-driver): move ottawa to the upstream ROCm chart

### DIFF
--- a/kubernetes/apps/base/k8s-gpu-dra-driver/k8s-gpu-dra-driver-ottawa/app/helmrelease.yaml
+++ b/kubernetes/apps/base/k8s-gpu-dra-driver/k8s-gpu-dra-driver-ottawa/app/helmrelease.yaml
@@ -1,32 +1,28 @@
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
+kind: HelmRepository
 metadata:
   name: k8s-gpu-dra-driver
 spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: v0.1.0
-  url: oci://ghcr.io/buroa/helm/k8s-gpu-dra-driver
+  interval: 1h
+  url: https://rocm.github.io/k8s-gpu-dra-driver
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: k8s-gpu-dra-driver
 spec:
-  chartRef:
-    kind: OCIRepository
-    name: k8s-gpu-dra-driver
+  chart:
+    spec:
+      chart: k8s-gpu-dra-driver
+      version: v1.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: k8s-gpu-dra-driver
   interval: 1h
   values:
     cdi:
       dynamicPath: /var/cdi/dynamic
-    image:
-      repository: ghcr.io/buroa/k8s-gpu-dra-driver
-      tag: v0.1.0@sha256:6aad2f4bfedf894981bdad2bcbf164b8696e1073ca87f7d06ce952feb38d9d89
     kubeletPlugin:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
`ghcr.io/buroa/helm/k8s-gpu-dra-driver` was deleted upstream, breaking the ottawa render gate:

```
✗ OCIRepository kube-system/k8s-gpu-dra-driver
✗ HelmRelease   kube-system/k8s-gpu-dra-driver
    resolve v0.1.0: 403 denied
```

The container image `ghcr.io/buroa/k8s-gpu-dra-driver:v0.1.0` is gone too. The DaemonSet only still runs because `imagePullPolicy: IfNotPresent` is serving cached images — any node losing that cache cannot start the plugin.

`buroa/k8s-gpu-dra-driver` is a fork of `ROCm/k8s-gpu-dra-driver` with `ahead_by: 0` — no commits of its own. It predates ROCm publishing an official chart (2026-07-21), so there is nothing fork-specific to preserve.

Moves to the official chart, kept ottawa-scoped inline as before.

| Check | Result |
|---|---|
| `docker.io/rocm/k8s-gpu-dra-driver:v1.0.1` | exists |
| chart `v1.0.1`, `kubeVersion >=1.32.0-0` | ottawa v1.36.2 OK |
| DeviceClass name | `gpu.amd.com`, unchanged |
| `cdi.dynamicPath: /var/cdi/dynamic` | honored |
| `extensions.talos.dev/amdgpu` affinity | honored |

DeviceClass name is identical, so the `frigate`, `jellyfin`, and `plex` ResourceClaimTemplates need no change.

Merging restarts the kubeletplugin DaemonSet — brief GPU gap for those three.