### PR TITLE
fix(woodpecker): persist gRPC secret across server restarts

### DIFF
--- a/kubernetes/apps/base/woodpecker/woodpecker/app/helmrelease.yaml
+++ b/kubernetes/apps/base/woodpecker/woodpecker/app/helmrelease.yaml
@@ -46,6 +46,17 @@ spec:
             secretKeyRef:
               name: woodpecker-postgres-app
               key: uri
+        # Persist the gRPC JWT signing secret across server restarts. When unset,
+        # the server mints a fresh random secret on every boot, invalidating every
+        # agent's cached JWT and forcing all agents to CrashLoop-reconnect (seen
+        # during the 3.17 upgrade outage). Reuse the chart-managed agent secret —
+        # it is already stable (createAgentSecret writes it once and keeps it), so
+        # no new secret material is introduced.
+        WOODPECKER_GRPC_SECRET:
+          valueFrom:
+            secretKeyRef:
+              name: woodpecker-default-agent-secret
+              key: WOODPECKER_AGENT_SECRET
       createAgentSecret: true
       service:
         type: ClusterIP


### PR DESCRIPTION
The Woodpecker server minted a fresh random WOODPECKER_GRPC_SECRET on every
boot ("generated a temporary random secret" warning), invalidating all
agents' cached JWTs and forcing a CrashLoop reconnect storm — seen during
the 3.17 upgrade outage.

Pin WOODPECKER_GRPC_SECRET from the chart-managed woodpecker-default-agent-secret
(createAgentSecret writes it once and keeps it stable across upgrades). No new
secret material. Only the server needs it; agents still auth with
WOODPECKER_AGENT_SECRET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)