### PR TITLE
fix(buzz): route device pairing through sidecar

### DIFF
--- a/kubernetes/apps/base/buzz/buzz/README.md
+++ b/kubernetes/apps/base/buzz/buzz/README.md
@@ -5,6 +5,12 @@ This stack uses Block's released Buzz chart `0.1.7` from
 Postgres and Dragonfly instances plus a dedicated single-replica MinIO object
 store backed by a replicated Ceph block volume. The relay is configured for two
 replicas at `wss://buzz.ottawa.keiretsu.top` behind the Ottawa public Gateway.
+A separate single-replica `buzz-pairing` Deployment handles the ephemeral
+NIP-AB device handshake at `wss://buzz.ottawa.keiretsu.top/pair`; keeping it
+single-replica ensures both pairing WebSockets share the same in-memory state.
+The Gateway sends only the exact `/pair` path to that unauthenticated,
+non-persistent service and sends every other path to the membership-gated main
+relay.
 
 The HelmRelease uses the operator's configured owner identity and the
 SOPS-encrypted `buzz-identity` Secret. A production Flux render must not use the

--- a/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
@@ -19,7 +19,9 @@ spec:
     fullnameOverride: buzz
     image:
       repository: ghcr.io/block/buzz
-      tag: main
+      # Match the image digest already running in Ottawa; do not combine this
+      # pairing rollout with whatever upstream currently publishes as `main`.
+      tag: sha-ac4fa13
       pullPolicy: Always
     relayUrl: wss://buzz.ottawa.keiretsu.top
     ownerPubkey: b0ea34e1aad99dd51ea38673f433e43e6d7a73e557b95a2145e3a45ff3d5f12e

--- a/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
@@ -25,6 +25,14 @@ spec:
     ownerPubkey: b0ea34e1aad99dd51ea38673f433e43e6d7a73e557b95a2145e3a45ff3d5f12e
     replicaCount: 2
 
+    # NIP-43 blocks an unpaired phone from reaching the main relay. Keep the
+    # ephemeral NIP-AB handshake on its dedicated, single-replica service so
+    # both WebSocket peers share the same in-memory pairing state.
+    pairingRelay:
+      enabled: true
+      url: wss://buzz.ottawa.keiretsu.top/pair
+      replicaCount: 1
+
     secrets:
       existingSecret: buzz-secrets
 
@@ -76,6 +84,21 @@ spec:
           sectionName: wildcard-location-keiretsu-top-https
       hostnames:
         - buzz.ottawa.keiretsu.top
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: /pair
+          backendRefs:
+            - name: buzz-pairing
+              port: 5000
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          backendRefs:
+            - name: buzz
+              port: 3000
 
     serviceMonitor:
       enabled: true

--- a/kubernetes/apps/base/buzz/buzz/app/networkpolicy.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/networkpolicy.yaml
@@ -103,3 +103,35 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: buzz-pairing-ingress
+spec:
+  description: Expose the ephemeral pairing relay only through the public Gateway and node health probes.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: buzz
+      app.kubernetes.io/instance: buzz
+      app.kubernetes.io/component: pairing-relay
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            app.kubernetes.io/name: envoy
+            app.kubernetes.io/component: proxy
+            gateway.envoyproxy.io/owning-gateway-name: public
+            gateway.envoyproxy.io/owning-gateway-namespace: home
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+  egress: []


### PR DESCRIPTION
## Summary

- enable the stateless Buzz NIP-AB pairing relay as one replica
- route only the exact /pair path to the pairing service
- restrict pairing ingress to the Ottawa public Gateway and node health probes
- pin both relay workloads to sha-ac4fa13, the exact image digest already running in Ottawa, so this rollout does not pull unrelated upstream main changes
- document why pairing must remain single-replica

## Verification

- reproduced the live failure: root WebSocket returns 101 while /pair returns 404
- rendered the pinned Buzz chart 0.1.7 with the proposed values
- confirmed the generated pairing Deployment, Service, environment, HTTPRoute, and immutable image tag
- verified sha-ac4fa13 resolves to the exact live digest sha256:510978bb0bc168cd69af55ea46a307bfc935268939f6df844623344999fde7ef
- validated both changed resources with read-only kubectl diff against Ottawa
- tools/check.sh talos-ottawa reports the same seven pre-existing dependency failures on an untouched origin/main worktree