### PR TITLE
feat(buzz): complete production integrations

### DIFF
--- a/kubernetes/apps/base/buzz/buzz/README.md
+++ b/kubernetes/apps/base/buzz/buzz/README.md
@@ -4,13 +4,25 @@ This stack uses Block's released Buzz chart `0.1.7` from
 `oci://ghcr.io/block/buzz/charts/buzz`. It provisions dedicated, operator-managed
 Postgres and Dragonfly instances plus a dedicated single-replica MinIO object
 store backed by a replicated Ceph block volume. The relay is configured for two
-replicas at `wss://buzz.ottawa.keiretsu.top` behind the Ottawa public Gateway.
+to six replicas (CPU HPA, with a two-replica floor) at
+`wss://buzz.ottawa.keiretsu.top` behind the Ottawa public Gateway.
 A separate single-replica `buzz-pairing` Deployment handles the ephemeral
 NIP-AB device handshake at `wss://buzz.ottawa.keiretsu.top/pair`; keeping it
 single-replica ensures both pairing WebSockets share the same in-memory state.
 The Gateway sends only the exact `/pair` path to that unauthenticated,
 non-persistent service and sends every other path to the membership-gated main
 relay.
+
+The bundled Git browser is available at
+`https://buzz.ottawa.keiretsu.top/repos`. The deployment-wide read-only
+moderation and feedback dashboard is available at
+`https://buzz-admin.killinit.cc` only through the Ottawa private and
+tailnet Gateways. Buzz does not authenticate individual dashboard operators,
+so that route must never be attached to the public Gateway.
+
+The relay explicitly uses Buzz's public APNs delivery endpoint. The external
+probe verifies DNS, TLS, and route reachability, but only a registered iPhone
+can exercise App Attest, obtain a push lease, and confirm an APNs delivery.
 
 The HelmRelease uses the operator's configured owner identity and the
 SOPS-encrypted `buzz-identity` Secret. A production Flux render must not use the
@@ -60,11 +72,26 @@ start against a replacement database.
 
 The `buzz` bucket in the dedicated MinIO StatefulSet is authoritative for relay
 media and object-backed Git state. Its `200Gi` `ceph-block-replicated` PVC is
-retained if the StatefulSet is removed. The old Garage `buzz` bucket and key are
-temporarily retained so Garage can continue generating the existing `buzz-s3`
-Secret without introducing another encrypted credential; Buzz network policy
-does not permit the relay to connect to Garage. Database and object data should
-be restored to a consistent recovery point when recovering the whole service.
+retained if the StatefulSet is removed. Every six hours,
+`CronJob/buzz-object-backup` synchronizes the current object set to the
+independent, federated Garage `buzz-backup` bucket and runs `rclone check`.
+Overwritten and deleted objects move to `versions/<UTC timestamp>/` and remain
+recoverable for 30 days. `Job/buzz-object-backup-bootstrap-v1` performs and
+verifies the first copy during the initial GitOps rollout instead of waiting
+for the next schedule.
+
+For latest-state recovery, stop relay writes through GitOps, reverse-sync
+`buzz-backup/current` into a clean MinIO `buzz` bucket with a reviewed one-shot
+GitOps Job, and run `rclone check` before restoring service. For an accidentally
+overwritten or deleted object, select its copy below `versions/` and copy it
+back explicitly. Restore PostgreSQL and objects to an application-consistent
+point when recovering the whole service.
+
+The old Garage `buzz` bucket and key remain temporarily so Garage can continue
+generating the existing `buzz-s3` Secret, which MinIO uses as its root
+credential. The relay's Cilium policy does not permit it to connect directly to
+Garage. The backup worker has a separate least-privilege Garage key and can
+reach only MinIO, the Garage S3 gateway, and DNS.
 
 The `buzz-postgres` bucket remains on Garage and is still the CNPG backup target.
 
@@ -73,6 +100,21 @@ Its operator-generated NetworkPolicy is disabled because this stack supplies a
 namespaced Cilium policy for relay, replication, operator, and metrics access.
 
 The public monitor performs a full external DNS/TLS/HTTPS request through the
-Ottawa Gateway. The repository blackbox-exporter configuration has no WebSocket
-upgrade module, so a protocol-level WebSocket handshake check is intentionally
-not claimed here.
+Ottawa Gateway. A second blackbox check negotiates TLS, sends an RFC 6455 Upgrade
+request to `/pair`, and passes only when the Gateway and pairing relay return
+`101 Switching Protocols`. Alerts also cover relay and pairing replicas, HPA
+health and saturation, MinIO readiness, scheduled backup freshness/failures,
+Dragonfly, metrics ingestion, and public push-gateway reachability.
+
+## Deliberately gated features
+
+- Huddle audio remains unavailable because the released chart supports it only
+  for a single relay replica until a production SFU path exists. This deployment
+  keeps relay HA and autoscaling instead.
+- Join terms, privacy notice, and age attestation remain disabled until the
+  operator supplies approved policy text and an age-gating decision. Do not
+  invent legal copy in manifests.
+- An always-on Buzz ACP agent needs its own Nostr identity, community membership,
+  agent runtime image, model choice, and provider credential. None of those are
+  interchangeable with the relay identity, so no agent is deployed by this
+  stack.

--- a/kubernetes/apps/base/buzz/buzz/app/admin-httproute.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/admin-httproute.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: buzz-admin
+spec:
+  # Buzz's deployment-wide moderation dashboard has no per-operator identity.
+  # Keep it on the private and tailnet gateways; never attach this route to the
+  # public Gateway.
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - buzz-admin.${CLUSTER_DOMAIN}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: buzz
+          port: 3000
+          weight: 1

--- a/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
@@ -27,6 +27,16 @@ spec:
     ownerPubkey: b0ea34e1aad99dd51ea38673f433e43e6d7a73e557b95a2145e3a45ff3d5f12e
     replicaCount: 2
 
+    # Metrics Server is available in Ottawa. Keep a two-replica HA floor and
+    # scale conservatively on CPU; WebSocket custom metrics require an adapter
+    # the cluster does not currently run.
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 6
+      targetCPUUtilizationPercentage: 65
+      websocketMetricEnabled: false
+
     # NIP-43 blocks an unpaired phone from reaching the main relay. Keep the
     # ephemeral NIP-AB handshake on its dedicated, single-replica service so
     # both WebSocket peers share the same in-memory pairing state.
@@ -50,6 +60,7 @@ spec:
     relay:
       corsOrigins:
         - https://buzz.ottawa.keiretsu.top
+        - https://buzz-admin.${CLUSTER_DOMAIN}
       resources:
         requests:
           cpu: 250m
@@ -75,6 +86,16 @@ spec:
           value: path
         - name: BUZZ_GIT_CONFORMANCE_PROBE
           value: "true"
+        # Pin the public Buzz APNs gateway explicitly instead of depending on
+        # the binary's compiled-in default.
+        - name: BUZZ_PUSH_GATEWAY_DELIVERY_URL
+          value: https://push.buzz.xyz/v1/deliveries/apns
+        - name: BUZZ_SERVE_GIT_WEB_GUI
+          value: "true"
+        - name: BUZZ_ADMIN_HOST
+          value: buzz-admin.${CLUSTER_DOMAIN}
+        - name: BUZZ_ADMIN_WEB_DIR
+          value: /srv/buzz/admin-web
 
     httproute:
       enabled: true

--- a/kubernetes/apps/base/buzz/buzz/app/kustomization.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: buzz
 resources:
   - ocirepository.yaml
   - helmrelease.yaml
+  - admin-httproute.yaml
   - buzz-identity.sops.yaml
   - secretstore-rbac.yaml
   - secretstore.yaml

--- a/kubernetes/apps/base/buzz/buzz/app/networkpolicy.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/networkpolicy.yaml
@@ -4,7 +4,7 @@ kind: CiliumNetworkPolicy
 metadata:
   name: buzz-relay-ingress
 spec:
-  description: Restrict relay ingress and egress to its gateways, monitoring, dependencies, DNS, and HTTPS.
+  description: Restrict relay ingress and egress to its public and private gateways, monitoring, dependencies, DNS, and HTTPS.
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: buzz
@@ -17,6 +17,18 @@ spec:
             app.kubernetes.io/name: envoy
             app.kubernetes.io/component: proxy
             gateway.envoyproxy.io/owning-gateway-name: public
+            gateway.envoyproxy.io/owning-gateway-namespace: home
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            app.kubernetes.io/name: envoy
+            app.kubernetes.io/component: proxy
+            gateway.envoyproxy.io/owning-gateway-name: private
+            gateway.envoyproxy.io/owning-gateway-namespace: home
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            app.kubernetes.io/name: envoy
+            app.kubernetes.io/component: proxy
+            gateway.envoyproxy.io/owning-gateway-name: ts
             gateway.envoyproxy.io/owning-gateway-namespace: home
       toPorts:
         - ports:

--- a/kubernetes/apps/base/buzz/buzz/app/probe.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/probe.yaml
@@ -16,3 +16,39 @@ spec:
         service: buzz
         target: public
         check: https
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-buzz-pairing-websocket
+spec:
+  jobName: blackbox
+  module: buzz_pairing_websocket
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - buzz.ottawa.keiretsu.top:443
+      labels:
+        service: buzz
+        target: pairing
+        check: websocket
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-buzz-push-gateway
+spec:
+  jobName: blackbox
+  module: http_buzz_push_gateway
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://push.buzz.xyz/v1/deliveries/apns
+      labels:
+        service: buzz
+        target: push-gateway
+        check: https

--- a/kubernetes/apps/base/buzz/buzz/app/prometheusrule.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/prometheusrule.yaml
@@ -37,6 +37,51 @@ spec:
           annotations:
             summary: Buzz public HTTPS endpoint is unavailable
             description: The external HTTPS probe to buzz.ottawa.keiretsu.top has failed for 3 minutes.
+        - alert: BuzzPairingRelayUnavailable
+          expr: kube_deployment_status_replicas_available{namespace="buzz",deployment="buzz-pairing"} < 1
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: Buzz pairing relay is unavailable
+            description: The dedicated single-replica pairing Deployment has had no available pod for 3 minutes.
+        - alert: BuzzPairingEndpointUnavailable
+          expr: |
+            probe_success{service="buzz",target="pairing",check="websocket"} == 0
+            and on() kube_deployment_spec_replicas{namespace="buzz",deployment="buzz-pairing"} > 0
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: Buzz pairing WebSocket upgrade is unavailable
+            description: The external TLS and HTTP Upgrade probe to the Ottawa /pair endpoint has not received status 101 for 3 minutes.
+        - alert: BuzzPushGatewayUnavailable
+          expr: probe_success{service="buzz",target="push-gateway",check="https"} == 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Buzz public push gateway is unreachable
+            description: The exact APNs delivery endpoint has failed its external DNS, TLS, or HTTP reachability check for 10 minutes. This check does not claim an end-to-end APNs delivery.
+        - alert: BuzzRelayAutoscalerInactive
+          expr: kube_horizontalpodautoscaler_status_condition{namespace="buzz",horizontalpodautoscaler="buzz",condition="ScalingActive",status="false"} == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Buzz relay autoscaler is inactive
+            description: The Buzz HPA has been unable to calculate its CPU replica recommendation for 10 minutes.
+        - alert: BuzzRelayAutoscalerAtMaximum
+          expr: |
+            kube_horizontalpodautoscaler_status_current_replicas{namespace="buzz",horizontalpodautoscaler="buzz"}
+              >= on(namespace, horizontalpodautoscaler)
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace="buzz",horizontalpodautoscaler="buzz"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Buzz relay autoscaler is at its maximum
+            description: The Buzz relay has remained at its six-replica HPA ceiling for 15 minutes.
         - alert: BuzzDragonflyReplicasUnavailable
           expr: kube_statefulset_status_replicas_ready{namespace="buzz",statefulset="dragonfly-buzz"} < 2
           for: 5m
@@ -55,3 +100,37 @@ spec:
           annotations:
             summary: Buzz Dragonfly metrics are absent
             description: Prometheus has not received metrics from the dedicated Buzz Dragonfly service for 10 minutes.
+        - alert: BuzzMinioUnavailable
+          expr: kube_statefulset_status_replicas_ready{namespace="buzz",statefulset="minio"} < 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Buzz authoritative object store is unavailable
+            description: The dedicated Buzz MinIO StatefulSet has had no ready replica for 5 minutes.
+        - alert: BuzzObjectBackupStale
+          expr: time() - kube_cronjob_status_last_successful_time{namespace="buzz",cronjob="buzz-object-backup"} > 28800
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: Buzz object backup is stale
+            description: The current MinIO object set has not been synced and verified against Garage for more than 8 hours.
+        - alert: BuzzObjectBackupNeverCompleted
+          expr: |
+            (time() - kube_cronjob_created{namespace="buzz",cronjob="buzz-object-backup"} > 28800)
+              unless on(namespace, cronjob)
+            kube_cronjob_status_last_successful_time{namespace="buzz",cronjob="buzz-object-backup"}
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: Buzz scheduled object backup has never completed
+            description: The backup CronJob has existed for more than 8 hours without a successful scheduled run.
+        - alert: BuzzObjectBackupJobFailed
+          expr: max_over_time(kube_job_status_failed{namespace="buzz",job_name=~"buzz-object-backup.*"}[15m]) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: A Buzz object backup job failed
+            description: A Buzz MinIO-to-Garage backup attempt reported a failed Job within the last 15 minutes.

--- a/kubernetes/apps/base/buzz/buzz/infra/kustomization.yaml
+++ b/kubernetes/apps/base/buzz/buzz/infra/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - redis.yaml
   - object-storage.yaml
   - minio.yaml
+  - object-backup.yaml
   - networkpolicy-dependencies.yaml
   - servicemonitor-dragonfly.yaml

--- a/kubernetes/apps/base/buzz/buzz/infra/networkpolicy-dependencies.yaml
+++ b/kubernetes/apps/base/buzz/buzz/infra/networkpolicy-dependencies.yaml
@@ -89,7 +89,7 @@ kind: CiliumNetworkPolicy
 metadata:
   name: buzz-minio-ingress
 spec:
-  description: Keep Buzz's authoritative object store private to the relay and bucket initializer.
+  description: Keep Buzz's authoritative object store private to the relay, bucket initializer, and backup worker.
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: minio
@@ -105,6 +105,10 @@ spec:
             app.kubernetes.io/name: minio
             app.kubernetes.io/instance: buzz
             app.kubernetes.io/component: bucket-init
+        - matchLabels:
+            app.kubernetes.io/name: buzz
+            app.kubernetes.io/instance: buzz
+            app.kubernetes.io/component: object-backup
       toPorts:
         - ports:
             - port: "9000"
@@ -143,6 +147,57 @@ spec:
       toPorts:
         - ports:
             - port: "9000"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: buzz-object-backup-egress
+spec:
+  description: Allow the object backup worker to reach only Buzz MinIO, Garage's S3 gateway, and cluster DNS.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: buzz
+      app.kubernetes.io/instance: buzz
+      app.kubernetes.io/component: object-backup
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: buzz
+            app.kubernetes.io/name: minio
+            app.kubernetes.io/instance: buzz
+            app.kubernetes.io/component: object-storage
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: garage
+            app.kubernetes.io/name: garage
+            app.kubernetes.io/instance: garage
+            garage.rajsingh.info/tier: gateway
+      toPorts:
+        - ports:
+            - port: "3900"
               protocol: TCP
     - toEndpoints:
         - matchLabels:

--- a/kubernetes/apps/base/buzz/buzz/infra/object-backup.yaml
+++ b/kubernetes/apps/base/buzz/buzz/infra/object-backup.yaml
@@ -1,0 +1,264 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: buzz-object-backup-script
+data:
+  # Flux post-build substitution is single-pass: $$ becomes the literal $
+  # consumed by the shell in-cluster.
+  backup.sh: |
+    #!/bin/sh
+    set -eu
+
+    : "$${RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID:?}"
+    : "$${RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY:?}"
+    : "$${RCLONE_CONFIG_BACKUP_ACCESS_KEY_ID:?}"
+    : "$${RCLONE_CONFIG_BACKUP_SECRET_ACCESS_KEY:?}"
+
+    backup_stamp="$$(date -u +%Y%m%dT%H%M%SZ)"
+    echo "Syncing authoritative MinIO objects to Garage at $${backup_stamp}"
+    rclone sync source:buzz backup:buzz-backup/current \
+      --backup-dir "backup:buzz-backup/versions/$${backup_stamp}" \
+      --metadata \
+      --fast-list \
+      --checkers 16 \
+      --transfers 8 \
+      --log-level INFO
+
+    echo "Verifying the current Garage copy"
+    rclone check source:buzz backup:buzz-backup/current \
+      --one-way \
+      --fast-list \
+      --checkers 16 \
+      --log-level INFO
+
+    echo "Pruning retained object versions older than 30 days"
+    rclone delete backup:buzz-backup/versions \
+      --min-age 30d \
+      --fast-list \
+      --log-level INFO
+    rclone rmdirs backup:buzz-backup/versions --leave-root
+    echo "Buzz object backup completed at $$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: buzz-object-backup
+spec:
+  schedule: "17 */6 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: buzz
+            app.kubernetes.io/instance: buzz
+            app.kubernetes.io/component: object-backup
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          terminationGracePeriodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: backup
+              image: docker.io/rclone/rclone:1.75.0@sha256:b06aed988cf5967de7c25be5925240983981c757f4ed1ac9d2fa659d51d60548
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - /scripts/backup.sh
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: RCLONE_CONFIG
+                  value: /tmp/rclone.conf
+                - name: RCLONE_CONFIG_SOURCE_TYPE
+                  value: s3
+                - name: RCLONE_CONFIG_SOURCE_PROVIDER
+                  value: Minio
+                - name: RCLONE_CONFIG_SOURCE_ENDPOINT
+                  value: http://minio.buzz.svc.cluster.local:9000
+                - name: RCLONE_CONFIG_SOURCE_REGION
+                  value: us-east-1
+                - name: RCLONE_CONFIG_SOURCE_FORCE_PATH_STYLE
+                  value: "true"
+                - name: RCLONE_CONFIG_SOURCE_NO_CHECK_BUCKET
+                  value: "true"
+                - name: RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: buzz-s3
+                      key: BUZZ_S3_ACCESS_KEY
+                - name: RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: buzz-s3
+                      key: BUZZ_S3_SECRET_KEY
+                - name: RCLONE_CONFIG_BACKUP_TYPE
+                  value: s3
+                - name: RCLONE_CONFIG_BACKUP_PROVIDER
+                  value: Other
+                - name: RCLONE_CONFIG_BACKUP_ENDPOINT
+                  value: http://${COMMON_S3_ENDPOINT}
+                - name: RCLONE_CONFIG_BACKUP_REGION
+                  value: garage
+                - name: RCLONE_CONFIG_BACKUP_FORCE_PATH_STYLE
+                  value: "true"
+                - name: RCLONE_CONFIG_BACKUP_NO_CHECK_BUCKET
+                  value: "true"
+                - name: RCLONE_CONFIG_BACKUP_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: buzz-backup-s3
+                      key: AWS_ACCESS_KEY_ID
+                - name: RCLONE_CONFIG_BACKUP_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: buzz-backup-s3
+                      key: AWS_SECRET_ACCESS_KEY
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: script
+              configMap:
+                name: buzz-object-backup-script
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}
+---
+# Run once on the initial rollout so recovery does not wait for the next six-hour
+# window. The operation is idempotent and remains as an auditable Completed Job.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: buzz-object-backup-bootstrap-v1
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  activeDeadlineSeconds: 3600
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: buzz
+        app.kubernetes.io/instance: buzz
+        app.kubernetes.io/component: object-backup
+    spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: backup
+          image: docker.io/rclone/rclone:1.75.0@sha256:b06aed988cf5967de7c25be5925240983981c757f4ed1ac9d2fa659d51d60548
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - /scripts/backup.sh
+          env:
+            - name: HOME
+              value: /tmp
+            - name: RCLONE_CONFIG
+              value: /tmp/rclone.conf
+            - name: RCLONE_CONFIG_SOURCE_TYPE
+              value: s3
+            - name: RCLONE_CONFIG_SOURCE_PROVIDER
+              value: Minio
+            - name: RCLONE_CONFIG_SOURCE_ENDPOINT
+              value: http://minio.buzz.svc.cluster.local:9000
+            - name: RCLONE_CONFIG_SOURCE_REGION
+              value: us-east-1
+            - name: RCLONE_CONFIG_SOURCE_FORCE_PATH_STYLE
+              value: "true"
+            - name: RCLONE_CONFIG_SOURCE_NO_CHECK_BUCKET
+              value: "true"
+            - name: RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: buzz-s3
+                  key: BUZZ_S3_ACCESS_KEY
+            - name: RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: buzz-s3
+                  key: BUZZ_S3_SECRET_KEY
+            - name: RCLONE_CONFIG_BACKUP_TYPE
+              value: s3
+            - name: RCLONE_CONFIG_BACKUP_PROVIDER
+              value: Other
+            - name: RCLONE_CONFIG_BACKUP_ENDPOINT
+              value: http://${COMMON_S3_ENDPOINT}
+            - name: RCLONE_CONFIG_BACKUP_REGION
+              value: garage
+            - name: RCLONE_CONFIG_BACKUP_FORCE_PATH_STYLE
+              value: "true"
+            - name: RCLONE_CONFIG_BACKUP_NO_CHECK_BUCKET
+              value: "true"
+            - name: RCLONE_CONFIG_BACKUP_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: buzz-backup-s3
+                  key: AWS_ACCESS_KEY_ID
+            - name: RCLONE_CONFIG_BACKUP_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: buzz-backup-s3
+                  key: AWS_SECRET_ACCESS_KEY
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: script
+          configMap:
+            name: buzz-object-backup-script
+            defaultMode: 0555
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/apps/base/buzz/buzz/infra/object-storage.yaml
+++ b/kubernetes/apps/base/buzz/buzz/infra/object-storage.yaml
@@ -76,3 +76,42 @@ spec:
       read: true
       write: true
       owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: buzz-backup
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: buzz-backup
+  quotas:
+    maxSize: 400Gi
+    maxObjects: 20000000
+  keyPermissions:
+    - keyRef:
+        name: buzz-backup-key
+      read: true
+      write: true
+      owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: buzz-backup-key
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: Buzz Object Backup Key
+  secretTemplate:
+    name: buzz-backup-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: buzz-backup
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/monitoring/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter/app/helmrelease.yaml
@@ -43,6 +43,27 @@ spec:
             preferred_ip_protocol: ip4
             tls_config:
               insecure_skip_verify: true
+        http_buzz_push_gateway:
+          prober: http
+          timeout: 5s
+          http:
+            # An unauthenticated request is intentionally rejected. Any of
+            # these client-error responses proves DNS, TLS, and the exact push
+            # delivery route are reachable; redirects and 5xx do not.
+            valid_status_codes: [400, 401, 403, 405]
+            follow_redirects: false
+            preferred_ip_protocol: ip4
+        buzz_pairing_websocket:
+          prober: tcp
+          timeout: 5s
+          tcp:
+            preferred_ip_protocol: ip4
+            tls: true
+            tls_config:
+              server_name: buzz.ottawa.keiretsu.top
+            query_response:
+              - send: "GET /pair HTTP/1.1\r\nHost: buzz.ottawa.keiretsu.top\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"
+              - expect: "^HTTP/1\\.1 101"
         icmp:
           prober: icmp
           timeout: 5s


### PR DESCRIPTION
## Summary

- add protocol-level pairing and push-gateway probes plus alerts
- add an independent six-hour MinIO-to-Garage backup with 30-day changed/deleted-object retention and an initial verified seed job
- enable CPU autoscaling, the bundled Git browser, explicit APNs delivery, and a private/tailnet-only admin dashboard
- document recovery ownership and the features that still require operator policy or credentials

## Verification

- `tools/check-versions.sh`
- Flux-substituted app and infrastructure renders validated with kubeconform
- Buzz chart 0.1.7 and blackbox chart 11.16.0 rendered directly
- blackbox exporter v0.28.0 accepted the rendered config; live `/pair` probe returned success on a TLS WebSocket 101 handshake
- all 14 Buzz Prometheus rules passed `promtool check rules`
- the backup script passed a disposable two-S3-store integration test, including overwrite and deletion retention
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh talos-ottawa` reproduces the same seven unrelated render failures on clean `origin/main` (missing chart dependencies plus existing Garage/Homer render failures)
