### PR TITLE
test(tailscale): preserve member self SSH access

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -336,6 +336,13 @@
 			],
 		},
 	],
+	"sshTests": [
+		{
+			"src":    "rajsinghtech@github",
+			"dst":    ["rajsinghtech@github"],
+			"accept": ["root", "workspace", "rajsingh"],
+		},
+	],
 	"tests": [
 		{
 			"src":    "group:superuser",


### PR DESCRIPTION
Adds an SSH policy regression test for the existing autogroup:member → autogroup:self rule. It verifies root, workspace, and an arbitrary non-root username remain accepted for a member accessing their own nodes.

Local validation:
- HuJSON conversion passed
- JSON assertions passed
- git diff --check passed
- repository render checks attempted; current main has unrelated missing chart-source/secret and stale Kustomize-path failures