### PR TITLE
revert(buzz): restore relay HA

### DIFF
--- a/kubernetes/apps/base/buzz/buzz/README.md
+++ b/kubernetes/apps/base/buzz/buzz/README.md
@@ -3,11 +3,9 @@
 This stack uses Block's released Buzz chart `0.1.7` from
 `oci://ghcr.io/block/buzz/charts/buzz`. It provisions dedicated, operator-managed
 Postgres and Dragonfly instances plus a dedicated single-replica MinIO object
-store backed by a replicated Ceph block volume. The relay temporarily runs as
-one replica at `wss://buzz.ottawa.keiretsu.top` behind the Ottawa public Gateway
-so chart `0.1.7` can serve its process-local huddle audio rooms. The HPA,
-topology spread, and relay PDB settings remain commented beside the active
-values for restoration when cross-pod mesh audio has production chart support.
+store backed by a replicated Ceph block volume. The relay is configured for two
+to six replicas (CPU HPA, with a two-replica floor) at
+`wss://buzz.ottawa.keiretsu.top` behind the Ottawa public Gateway.
 A separate single-replica `buzz-pairing` Deployment handles the ephemeral
 NIP-AB device handshake at `wss://buzz.ottawa.keiretsu.top/pair`; keeping it
 single-replica ensures both pairing WebSockets share the same in-memory state.
@@ -104,27 +102,15 @@ namespaced Cilium policy for relay, replication, operator, and metrics access.
 The public monitor performs a full external DNS/TLS/HTTPS request through the
 Ottawa Gateway. A second blackbox check negotiates TLS, sends an RFC 6455 Upgrade
 request to `/pair`, and passes only when the Gateway and pairing relay return
-`101 Switching Protocols`. Alerts also cover relay and pairing availability,
-MinIO readiness, scheduled backup freshness/failures, Dragonfly, metrics
-ingestion, and public push-gateway reachability.
-
-## Temporary single-pod huddle audio mode
-
-`relay.huddleAudioAvailable` is explicitly enabled. The released chart keeps
-huddle rooms in the relay process, so the Deployment must remain at exactly one
-replica and must not use an HPA while this mode is active. This trades relay
-failover for working desktop-to-desktop huddle audio; Postgres, Dragonfly,
-MinIO, and their backups retain their existing redundancy and durability.
-
-Do not raise the relay replica count without first disabling huddle audio or
-shipping and validating the cross-pod mesh path. The current mobile client can
-display huddle lifecycle events but does not yet implement the microphone/audio
-WebSocket path, so this server mode does not claim phone voice support.
+`101 Switching Protocols`. Alerts also cover relay and pairing replicas, HPA
+health and saturation, MinIO readiness, scheduled backup freshness/failures,
+Dragonfly, metrics ingestion, and public push-gateway reachability.
 
 ## Deliberately gated features
 
-- Cross-pod huddle audio and relay HA remain gated until the mesh path has
-  production chart support and an Ottawa rollout test.
+- Huddle audio remains unavailable because the released chart supports it only
+  for a single relay replica until a production SFU path exists. This deployment
+  keeps relay HA and autoscaling instead.
 - Join terms, privacy notice, and age attestation remain disabled until the
   operator supplies approved policy text and an age-gating decision. Do not
   invent legal copy in manifests.

--- a/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
@@ -25,18 +25,17 @@ spec:
       pullPolicy: Always
     relayUrl: wss://buzz.ottawa.keiretsu.top
     ownerPubkey: b0ea34e1aad99dd51ea38673f433e43e6d7a73e557b95a2145e3a45ff3d5f12e
-    # Huddle audio rooms are process-local in chart 0.1.7, so keep exactly one
-    # relay pod until the cross-pod mesh audio path has production chart support.
-    replicaCount: 1
+    replicaCount: 2
 
-    # Restore this HA profile when cross-pod huddle audio is ready:
-    # replicaCount: 2
-    # autoscaling:
-    #   enabled: true
-    #   minReplicas: 2
-    #   maxReplicas: 6
-    #   targetCPUUtilizationPercentage: 65
-    #   websocketMetricEnabled: false
+    # Metrics Server is available in Ottawa. Keep a two-replica HA floor and
+    # scale conservatively on CPU; WebSocket custom metrics require an adapter
+    # the cluster does not currently run.
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 6
+      targetCPUUtilizationPercentage: 65
+      websocketMetricEnabled: false
 
     # NIP-43 blocks an unpaired phone from reaching the main relay. Keep the
     # ephemeral NIP-AB handshake on its dedicated, single-replica service so
@@ -59,7 +58,6 @@ spec:
         size: 20Gi
 
     relay:
-      huddleAudioAvailable: true
       corsOrigins:
         - https://buzz.ottawa.keiretsu.top
         - https://buzz-admin.${CLUSTER_DOMAIN}
@@ -70,16 +68,15 @@ spec:
         limits:
           cpu: "2"
           memory: 2Gi
-      # Restore with the HA profile above:
-      # topologySpreadConstraints:
-      #   - maxSkew: 1
-      #     topologyKey: kubernetes.io/hostname
-      #     whenUnsatisfiable: ScheduleAnyway
-      #     labelSelector:
-      #       matchLabels:
-      #         app.kubernetes.io/name: buzz
-      #         app.kubernetes.io/instance: buzz
-      #         app.kubernetes.io/component: relay
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: buzz
+              app.kubernetes.io/instance: buzz
+              app.kubernetes.io/component: relay
       extraEnv:
         - name: RUST_LOG
           value: buzz_relay=info,buzz_db=info,buzz_auth=info,buzz_pubsub=info,tower_http=info
@@ -132,6 +129,5 @@ spec:
       scrapeTimeout: 10s
 
     podDisruptionBudget:
-      # A one-pod relay has no replica to protect during voluntary disruption.
-      # Re-enable minAvailable: 1 together with the HA profile above.
-      enabled: false
+      enabled: true
+      minAvailable: 1

--- a/kubernetes/apps/base/buzz/buzz/app/prometheusrule.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/prometheusrule.yaml
@@ -10,13 +10,13 @@ spec:
     - name: buzz.rules
       rules:
         - alert: BuzzRelayReplicasUnavailable
-          expr: kube_deployment_status_replicas_available{namespace="buzz",deployment="buzz"} < 1
-          for: 3m
+          expr: kube_deployment_status_replicas_available{namespace="buzz",deployment="buzz"} < 2
+          for: 5m
           labels:
-            severity: critical
+            severity: warning
           annotations:
-            summary: Buzz relay is unavailable
-            description: The temporary single-replica Ottawa Buzz relay has had no available pod for 3 minutes.
+            summary: Buzz relay has fewer than two available replicas
+            description: The Ottawa Buzz relay has been below its two-replica target for 5 minutes.
         - alert: BuzzRelayMetricsAbsent
           expr: |
             absent(up{namespace="buzz",job="buzz"} == 1)
@@ -63,6 +63,25 @@ spec:
           annotations:
             summary: Buzz public push gateway is unreachable
             description: The exact APNs delivery endpoint has failed its external DNS, TLS, or HTTP reachability check for 10 minutes. This check does not claim an end-to-end APNs delivery.
+        - alert: BuzzRelayAutoscalerInactive
+          expr: kube_horizontalpodautoscaler_status_condition{namespace="buzz",horizontalpodautoscaler="buzz",condition="ScalingActive",status="false"} == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Buzz relay autoscaler is inactive
+            description: The Buzz HPA has been unable to calculate its CPU replica recommendation for 10 minutes.
+        - alert: BuzzRelayAutoscalerAtMaximum
+          expr: |
+            kube_horizontalpodautoscaler_status_current_replicas{namespace="buzz",horizontalpodautoscaler="buzz"}
+              >= on(namespace, horizontalpodautoscaler)
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace="buzz",horizontalpodautoscaler="buzz"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Buzz relay autoscaler is at its maximum
+            description: The Buzz relay has remained at its six-replica HPA ceiling for 15 minutes.
         - alert: BuzzDragonflyReplicasUnavailable
           expr: kube_statefulset_status_replicas_ready{namespace="buzz",statefulset="dragonfly-buzz"} < 2
           for: 5m


### PR DESCRIPTION
## Summary

- revert the temporary single-pod huddle-audio configuration from #2184
- restore the two-replica floor, CPU HPA (2-6), topology spread, and relay PDB
- restore the HA/HPA alerting and mark huddle audio unavailable again

## Verification

- all three changed files exactly match commit 719196123^
- focused pinned-chart render: BUZZ_HUDDLE_AUDIO_AVAILABLE=false
- focused pinned-chart render: HPA min=2, max=6; relay PDB minAvailable=1
- git diff --check passes
- local repository-wide Flate reached its known partial baseline and then hit the 300-second watchdog; authoritative PR CI is required before merge

This reverts commit 719196123584566a63295becbf7d6928e030148f.