### PR TITLE
[SRE] fix(external-secrets): tailnet FQDN for ottawa+robbinsdale ClusterSecretStore

### DIFF
--- a/kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-stores.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-stores.yaml
@@ -11,7 +11,11 @@ spec:
     kubernetes:
       remoteNamespace: external-secrets
       server:
-        url: https://ottawa-k8s-operator.tailscale.svc.cluster.local
+        # Must be the tailnet FQDN: the Tailscale operator's API-server proxy
+        # only serves TLS for its MagicDNS name and rejects any other SNI
+        # ("invalid domain ... must be one of [...keiretsu.ts.net]"), which
+        # surfaced as "tls: internal error" validation failures.
+        url: https://ottawa-k8s-operator.keiretsu.ts.net
       auth:
         token:
           bearerToken:
@@ -29,7 +33,10 @@ spec:
     kubernetes:
       remoteNamespace: external-secrets
       server:
-        url: https://robbinsdale-k8s-operator.tailscale.svc.cluster.local
+        # Must be the tailnet FQDN: the Tailscale operator's API-server proxy
+        # only serves TLS for its MagicDNS name and rejects any other SNI
+        # ("invalid domain ... must be one of [...keiretsu.ts.net]").
+        url: https://robbinsdale-k8s-operator.keiretsu.ts.net
       auth:
         token:
           bearerToken:


### PR DESCRIPTION
## What
Fix the `kubernetes-ottawa` and `kubernetes-robbinsdale` ClusterSecretStore URLs in `kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-stores.yaml` from `tailscale.svc.cluster.local` to the tailnet MagicDNS FQDN (`*.keiretsu.ts.net`).

## Why
The Tailscale operator's API-server proxy only serves TLS for its MagicDNS hostname and rejects any other SNI, so the `tailscale.svc.cluster.local` URLs fail TLS validation (`tls: internal error`), surfacing as `ClusterSecretStore` "could not determine validation status" errors in external-secrets on ottawa and robbinsdale.

StPetersburg already carries the correct fix (with explanatory comment); this applies the same pattern to the other two clusters.

## Changes
- `kubernetes/apps/base/external-secrets/external-secrets/config/cluster-secret-stores.yaml`
  - `kubernetes-ottawa` url → `https://ottawa-k8s-operator.keiretsu.ts.net`
  - `kubernetes-robbinsdale` url → `https://robbinsdale-k8s-operator.keiretsu.ts.net`

## Verification
`tools/check.sh talos-ottawa` renders 235 objects OK. The single check failure is a pre-existing offline/SOPS `cluster-secrets` substitution limitation, identical on clean `main` (not caused by this change).

Closes #2187
