### PR TITLE
fix(monitoring): use resolvable .robbinsdale.internal blackbox probe targets

### DIFF
--- a/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-cluster-infra.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-cluster-infra.yaml
@@ -11,7 +11,7 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://k8s.robbinsdale.local:6443/readyz
+        - https://k8s.robbinsdale.internal:6443/readyz
       labels:
         service: kubernetes-api
         target: cluster-vip

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-nodes.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-nodes.yaml
@@ -11,30 +11,18 @@ spec:
   targets:
     staticConfig:
       static:
-        - tank.local:6443
-        - titan.local:6443
-        - stone.local:6443
+        - tank.robbinsdale.internal:6443
+        - titan.robbinsdale.internal:6443
+        - stone.robbinsdale.internal:6443
       labels:
         service: nodes
         target: kubelet-port
 ---
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: app-nas-https
-spec:
-  jobName: blackbox
-  module: http_2xx_insecure
-  prober:
-    url: blackbox-exporter.monitoring.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-        - https://nas.local
-      labels:
-        service: nodes
-        target: nas
----
+# NAS (SMB / HTTPS) is monitored natively by Gatus (https://nas.local);
+# there is no DNS record reachable from the blackbox probe pod on the
+# cluster network, so the blackbox NAS probes were removed (they only
+# produced false ProbeFailed alerts). See gatus-robbinsdale.
+# ICMP reachability for nodes.
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
@@ -47,10 +35,9 @@ spec:
   targets:
     staticConfig:
       static:
-        - tank.local
-        - titan.local
-        - stone.local
-        - nas.local
+        - tank.robbinsdale.internal
+        - titan.robbinsdale.internal
+        - stone.robbinsdale.internal
       labels:
         service: nodes
         target: ping


### PR DESCRIPTION
## Summary
The robbinsdale blackbox node + cluster-VIP probes targeted `.local` mDNS names (`tank/titan/stone/nas.local`, `k8s.robbinsdale.local`) that **do not resolve from the blackbox probe pod on the cluster network**, producing ~9 persistent false `ProbeFailed` alerts even though all nodes are demonstrably healthy (Ready, kubelet up, no pressure conditions).

## Change
Point the robbinsdale blackbox probe targets at the existing ExternalDNS `*.robbinsdale.internal` records (defined in `kubernetes/apps/base/home/home/dnsrecords/robbinsdale-internal.yaml`), mirroring the proven-working ottawa `*.killinit.internal` probe pattern:

- `probes-nodes.yaml`:
  - `app-nodes-tcp`: `tank/titan/stone.local:6443` → `*.robbinsdale.internal:6443`
  - `app-nodes-icmp`: `tank/titan/stone.local` → `*.robbinsdale.internal` (drop `nas.local` — no cluster-reachable NAS record; NAS health is already covered by Gatus `https://nas.local`)
  - remove `app-nas-https` (`https://nas.local`) — same reason; Gatus covers NAS
- `probes-cluster-infra.yaml`:
  - `app-k8s-api-local`: `https://k8s.robbinsdale.local:6443/readyz` → `https://k8s.robbinsdale.internal:6443/readyz`

Reference evidence: ottawa runs **identical** probe definitions on `*.killinit.internal` and reports `probe_success=1` for all (ICMP + kubelet-port + NAS), confirming the blackbox ICMP module works and the defect is purely the `.local` DNS resolution.

## Verification
`tools/check.sh talos-robbinsdale`: all modified `monitoring/blackbox-exporter` objects render OK. The only failing object is `kube-system/csi-driver-smb` — a **pre-existing, unrelated** Helm chart digest mismatch (index digest `6dee97…` vs downloaded `0319a2…`), present on clean main independent of this change.

Closes the probe-noise portion of #2193.