### PR TITLE
fix(descheduler): grant persistentvolumeclaims list RBAC to descheduler-sa

### DIFF
--- a/kubernetes/apps/base/kube-system/cilium-ottawa/app/descheduler-cronjob.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/app/descheduler-cronjob.yaml
@@ -50,6 +50,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
   - scheduling.k8s.io
   resources:
   - priorityclasses

--- a/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/descheduler-cronjob.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/descheduler-cronjob.yaml
@@ -50,6 +50,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
   - scheduling.k8s.io
   resources:
   - priorityclasses


### PR DESCRIPTION
## Summary
The descheduler CronJob on robbinsdale fails every run. Logs (VictoriaLogs, `talos-robbinsdale`/`kube-system`) show:

```
failed to list *v1.PersistentVolumeClaim: persistentvolumeclaims is forbidden:
User "system:serviceaccount:kube-system:descheduler-sa" cannot list resource
"persistentvolumeclaims" in API group "" at the cluster scope
```

descheduler v0.36's informer factory lists PVClaims at startup regardless of enabled plugins, but the vendored (`release-1.32`) ClusterRole never granted it. robbinsdale shows `kube_job_status_failed=1` (e.g. `descheduler-cronjob-29710115`); it's one of the components of #2193.

## Change
Add the missing `persistentvolumeclaims` `get`/`watch`/`list` rule to the `descheduler-cluster-role` in the robbinsdale **and** ottawa descheduler manifests. Both were vendored from the same source with the same RBAC gap. The stpetersburg copy already carries this rule — this brings robbinsdale/ottawa in line with it (identical definition).

## Verification
`tools/check.sh talos-robbinsdale`: the modified ClusterRole renders cleanly; the only failing object is the **pre-existing, unrelated** `kube-system/csi-driver-smb` chart digest mismatch (present on clean main). All three clusters' metrics.k8s.io + PVC perms are unaffected otherwise.

Part of #2193 (descheduler failure component). Once merged and reconciled by Flux, the descheduler CronJob should stop failing (robbinsdale) and be prevented from failing the same way (ottawa).