### PR TITLE
fix(monitoring): raise node-exporter web.max-requests to prevent 503 wedge (spark-0/spark-1)

### DIFF
--- a/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
@@ -215,6 +215,13 @@ spec:
 
     prometheus-node-exporter:
       priorityClassName: "infra-high"
+      # DGX/RDMA nodes (stpetersburg spark-0/spark-1) intermittently wedge
+      # node_exporter: a slow collector lets scrapes pile up and trip the
+      # default --web.max-requests=40 cap, making the exporter 503 every scrape
+      # and dropping up=0 (issue #2189). Raise the parallel-scrape cap for
+      # headroom so transient slowness can't knock the target down.
+      extraArgs:
+        - --web.max-requests=200
       updateStrategy:
         rollingUpdate:
           maxUnavailable: "100%"


### PR DESCRIPTION
## Summary

Fixes #2189 — node-exporter on stpetersburg `spark-0` (192.168.73.206) and `spark-1` (192.168.73.209) intermittently wedges: scrapes pile up and trip node_exporter's default `--web.max-requests=40` cap, after which the exporter 503s every scrape and Prometheus marks the target down (`up=0`).

## Root cause (verified live)

I probed the failing `:9100` endpoints directly from a host with stpetersburg cross-LAN reach:
- `spark-0` / `spark-1` `:9100` → `HTTP 503 "Limit of concurrent requests reached (40)"` on every scrape (0.14s each)
- `orin-0` `:9100` → `HTTP 200` with real metrics

All 3 node-exporter pods were Running/Ready/0 restarts with clean logs; the DS binds `0.0.0.0:9100` (hostNetwork) and there is no NetPol in `monitoring`. So this is **not** a host firewall or bind-to-interface problem (as originally guessed) — it's the exporter concurrency-saturated by slow/hung collectors on the DGX/RDMA (ConnectX-7) nodes. Restarting the two spark node-exporter pods recovered `:9100` to `200` immediately.

## Change

Raise `prometheus-node-exporter.extraArgs` to set `--web.max-requests=200` (default is 40). This gives the exporter headroom so transiently-slow collector scrapes can't saturate the parallel-request cap and knock the target down. Applies to the shared `monitoring-common` base; harmless on all clusters (the threads are not on the affected nodes, and the tuning only raises a concurrency cap — no metrics are dropped).

```yaml
prometheus-node-exporter:
  priorityClassName: "infra-high"
  extraArgs:
    - --web.max-requests=200
```

This matches the verified root cause and the repo's GitOps-first rule (change ships via Flux; the live restart was only immediate incident mitigation).

## Verification

- Immediate remediation already done live: both spark node-exporter pods restarted, `:9100` now returns `200` on `spark-0`/`spark-1`/`orin-0`.
- Chart schema validated: `prometheus-node-exporter.extraArgs` is the chart's documented "additional container arguments" key; `--web.max-requests` is a valid node_exporter flag (default 40).

> Originating conversation: Buzz channel `kubernetes-manifests` (thread `4a13d42246258e9964a1ce2b8be1ee53647fce2ddf7ec5b5ace7eb525af0f882`)