### PR TITLE
fix(monitoring): point Grafana Alertmanager datasource at the real service FQDN

### DIFF
--- a/kubernetes/apps/base/monitoring/grafana/datasources/alertmanager.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/datasources/alertmanager.yaml
@@ -13,7 +13,7 @@ spec:
     type: alertmanager
     uid: alertmanager
     access: proxy
-    url: http://alertmanager.monitoring:9093
+    url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
     jsonData:
       implementation: prometheus
     editable: false


### PR DESCRIPTION
## Summary
Fixes the Grafana **Alertmanager datasource 502** (part of #2192).

## Root cause
The datasource pointed at `http://alertmanager.monitoring:9093`, but that is **not a real Service**. Everywhere else in the repo the Alertmanager service is `kube-prometheus-stack-alertmanager.monitoring` — the Mimir ruler's `alertmanager_url`, the ServiceMonitors, and the egress all use it. A wrong service name → the Grafana alertmanager plugin proxy 502s / "plugin unavailable".

## Change
`grafana/datasources/alertmanager.yaml`: change access URL from the bogus `alertmanager.monitoring:9093` to the correct FQDN
`http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093` (mirrors the ruler's working `alertmanager_url`).

## Verification
`tools/check.sh talos-ottawa` renders clean (only the pre-existing, unrelated `kube-system/csi-driver-smb` chart digest mismatch fails on clean main).

Part of #2192.