### PR TITLE
fix(monitoring): drop robbinsdale blackbox node/VIP probes unreachable from the probe pod

### DIFF
--- a/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-cluster-infra.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-cluster-infra.yaml
@@ -1,20 +1,7 @@
----
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: app-k8s-api-local
-spec:
-  jobName: blackbox
-  module: http_401
-  prober:
-    url: blackbox-exporter.monitoring.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-        - https://k8s.robbinsdale.internal:6443/readyz
-      labels:
-        service: kubernetes-api
-        target: cluster-vip
+# app-k8s-api-local (https://k8s.robbinsdale.internal:6443/readyz, the cluster-VIP)
+# removed: the blackbox probe pod has no route to the robbinsdale LAN 192.168.50.0/24,
+# so it could never connect (HTTP status 0 -> permanent false ProbeFailed). API
+# liveness is covered by the in-cluster kubernetes.default.svc probe below/Gatus.
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Probe

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-nodes.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-robbinsdale/app/probes-nodes.yaml
@@ -1,43 +1,17 @@
----
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: app-nodes-tcp
-spec:
-  jobName: blackbox
-  module: tcp_connect
-  prober:
-    url: blackbox-exporter.monitoring.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-        - tank.robbinsdale.internal:6443
-        - titan.robbinsdale.internal:6443
-        - stone.robbinsdale.internal:6443
-      labels:
-        service: nodes
-        target: kubelet-port
----
-# NAS (SMB / HTTPS) is monitored natively by Gatus (https://nas.local);
-# there is no DNS record reachable from the blackbox probe pod on the
-# cluster network, so the blackbox NAS probes were removed (they only
-# produced false ProbeFailed alerts). See gatus-robbinsdale.
-# ICMP reachability for nodes.
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: app-nodes-icmp
-spec:
-  jobName: blackbox
-  module: icmp
-  prober:
-    url: blackbox-exporter.monitoring.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-        - tank.robbinsdale.internal
-        - titan.robbinsdale.internal
-        - stone.robbinsdale.internal
-      labels:
-        service: nodes
-        target: ping
+# Node / cluster-VIP reachability probes removed.
+#
+# These targeted the robbinsdale bare-metal LAN (192.168.50.x via
+# *.robbinsdale.internal): DNS resolves (probe_dns_lookup_time_seconds > 0),
+# but the blackbox probe pod on the cluster network has NO route to that LAN,
+# so every ICMP / kubelet-port(6443) / VIP-readyz probe failed (probe_success=0,
+# HTTP status 0) = permanent false ProbeFailed alerts.
+#
+# Node + API liveness is already covered by, and better served by:
+#   - kubelet `up` (job="kubelet")  by node
+#   - kube_node_status_condition{condition="Ready"}
+#   - Gatus robbinsdale health checks (runs host-network, CAN reach the LAN:
+#     tank/titan/stone.local:6443 and k8s.robbinsdale.local:6443/readyz)
+#   - kube-state-metrics node metrics
+#
+# Do NOT re-add LAN-based blackbox probes unless the blackbox pod gets a
+# network path (e.g. hostNetwork) to 192.168.50.0/24.


### PR DESCRIPTION
## Summary
Removes the robbinsdale blackbox **node + cluster-VIP** probes that can never succeed from the blackbox probe pod, eliminating the remaining false `ProbeFailed` alerts (part of #2193).

## Why
After #2201 fixed DNS (`.local` → `.robbinsdale.internal`), the probes now **resolve** (`probe_dns_lookup_time_seconds > 0`) but still fail on connection:
- `tank/titan/stone.robbinsdale.internal` (ICMP ping) + `:6443` (kubelet-port) → `probe_success=0`
- `k8s.robbinsdale.internal:6443/readyz` (cluster-VIP) → `probe_http_status_code=0` (no connection), vs in-cluster `kubernetes.default.svc` probe returning 401 (working)

Cause: the blackbox probe pod on the cluster network has **no route to the robbinsdale LAN `192.168.50.0/24`**. These probes are structurally unreachable from that pod, regardless of the hostname.

## Change
- `probes-nodes.yaml`: remove `app-nodes-tcp` (kubelet-port) + `app-nodes-icmp` (ping); leave a comment.
- `probes-cluster-infra.yaml`: remove `app-k8s-api-local` (cluster-VIP readyz); keep the working in-cluster probes.

Node/API liveness is still covered by: kubelet `up`, `kube_node_status_condition{Ready}`, kube-state-metrics, and **Gatus** robbinsdale (host-network, which CAN reach the LAN).

## Verification
`tools/check.sh talos-robbinsdale` → `✓ HelmRelease monitoring/blackbox-exporter` renders OK; only the pre-existing, unrelated `kube-system/csi-driver-smb` digest mismatch fails (present on clean main).

Part of #2193.