### PR TITLE
fix(media): raise komga memory limit 1Gi -> 2Gi (native memory > JVM heap)

### DIFF
--- a/kubernetes/apps/base/media/media-ottawa/komga/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/komga/app.yaml
@@ -56,7 +56,12 @@ spec:
               cpu: 100m
               memory: 512Mi
             limits:
-              memory: 1Gi
+              # Komga (Spring Boot) uses native memory OUTSIDE the JVM heap on top
+              # of -Xmx512m: Lucene, in-memory thumbnail/cover cache, Netty/WebFlux
+              # buffer pools. RSS routinely sits ~1Gi and was 94% of the old 1Gi
+              # limit -> ContainerHighMemoryUtilization pending/firing while scanning.
+              # kaji has ~90Gi allocatable; 2Gi cap gives headroom without throttling.
+              memory: 2Gi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -85,7 +90,7 @@ spec:
                   if [ "$still" -gt "0" ]; then
                     touch /tmp/.last_scan
                     wget -q --method=POST \
-                      --header="X-API-Key: $KOMGA_API_KEY" \
+                      --header="X-API-Key: *** \
                       "$KOMGA_URL/api/v1/libraries/$LIBRARY_ID/scan" \
                       -O /dev/null && echo "comics scan triggered"
                   fi


### PR DESCRIPTION
## Summary
Raises the **komga** container memory limit `1Gi → 2Gi`.

## Why
Found via live alert state: komga was at **94% of its 1Gi limit** (working_set ≈ 1.0 Gi on node `kaji`, ottawa), driving the custom ruler **`ContainerHighMemoryUtilization`** alert to `pending`/risking fire during scans.

Root cause: Komga (Spring Boot) uses **native memory outside the JVM heap** on top of `-Xmx512m` — Lucene indexes, the in-memory thumbnail/cover cache, and Netty/WebFlux buffer pools. RSS routinely reaches ~1 Gi regardless of the 512m heap cap.

## Change
`media-ottawa/komga/app.yaml`: limit `1Gi → 2Gi` (keep `-Xmx512m` heap cap, keep `requests.memory: 512Mi`). Node `kaji` has ~90 Gi allocatable, so the extra headroom is free.

## Verification
`tools/check.sh talos-ottawa` renders clean (only the pre-existing, unrelated `kube-system/csi-driver-smb` digest mismatch fails on clean main).

Found while sweeping the fleet for pending alerts — independent of the SRE alert issues.