### PR TITLE
feat(garage): stage node-local pool prerequisites

### DIFF
--- a/docs/garage-node-local-v0.7.1-migration.md
+++ b/docs/garage-node-local-v0.7.1-migration.md
@@ -22,6 +22,13 @@ never mounted by a pool pod.
 - Kubernetes is v1.36.3, the validating/conversion webhooks are enabled, and
   the operator is installed cluster-wide.
 
+Final preflight also found six persistent block-resync error hashes replicated
+across their expected nodes. Their reported object references all belong to a
+Garage bucket that no longer exists, which suggests orphaned metadata rather
+than reachable S3 data, but that is not permission to discard it. Do not begin
+pool enrollment until the references receive a separate destructive-action
+review and `garage stats --all-nodes` reports zero block errors everywhere.
+
 The source LocalPath identities are:
 
 | Site | GarageNode | Node ID | Capacity |

--- a/docs/garage-node-local-v0.7.1-migration.md
+++ b/docs/garage-node-local-v0.7.1-migration.md
@@ -23,11 +23,12 @@ never mounted by a pool pod.
   the operator is installed cluster-wide.
 
 Final preflight also found six persistent block-resync error hashes replicated
-across their expected nodes. Their reported object references all belong to a
-Garage bucket that no longer exists, which suggests orphaned metadata rather
-than reachable S3 data, but that is not permission to discard it. Do not begin
-pool enrollment until the references receive a separate destructive-action
-review and `garage stats --all-nodes` reports zero block errors everywhere.
+across their expected nodes. Every reported object reference belonged only to
+the already-deleted Garage bucket `99aa1da58dc06129`. With explicit approval,
+the orphaned references were purged and each node retried its own failed block
+work on 2026-08-08. `garage stats --all-nodes` then reported zero block errors
+on all 18 processes. The cleanup temporarily populated resync queues, so do not
+begin pool enrollment until those queues have also returned to zero.
 
 The source LocalPath identities are:
 

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/hostpath-prep.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/hostpath-prep.yaml
@@ -1,0 +1,140 @@
+---
+# These one-shot Jobs create only the fresh node-local-pool directories and
+# filesystem markers. They never mount an existing LocalPath PVC or node_key.
+# Completed Job pods have no running process and mount nothing while the pool
+# rollout waits for a later GitOps change.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-asuka
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: asuka }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-700/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-700/data, type: DirectoryOrCreate }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-kaji
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: kaji }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-700/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-700/data, type: DirectoryOrCreate }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-rei
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: rei }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-700/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-700/data, type: DirectoryOrCreate }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-shiro
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: shiro }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-200/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/ottawa-200/data, type: DirectoryOrCreate }

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ottawa-garage-localpath-kaji.yaml
   - ottawa-garage-localpath-asuka.yaml
   - ottawa-garage-localpath-rei.yaml
+  - hostpath-prep.yaml
   - service-ts-storage.yaml

--- a/kubernetes/apps/base/garage/garage-nodes-ottawa/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-ottawa/service-ts-storage.yaml
@@ -100,3 +100,94 @@ spec:
     statefulset.kubernetes.io/pod-name: ottawa-garage-smb-0
   type: LoadBalancer
   loadBalancerClass: tailscale
+---
+# Pre-stage one identity-specific endpoint per future node-local-pool member.
+# These selectors do not match the current StatefulSets, so the existing
+# endpoints above remain untouched until a later GitOps change adds the pool.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-pool-asuka
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-asuka-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-700
+    garage.rajsingh.info/kubernetes-node: asuka
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-pool-kaji
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-kaji-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-700
+    garage.rajsingh.info/kubernetes-node: kaji
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-pool-rei
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-rei-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-700
+    garage.rajsingh.info/kubernetes-node: rei
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: ottawa-garage-pool-shiro
+    tailscale.com/tags: "tag:k8s,tag:ottawa"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-shiro-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-200
+    garage.rajsingh.info/kubernetes-node: shiro
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/hostpath-prep.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/hostpath-prep.yaml
@@ -1,0 +1,104 @@
+---
+# Fresh, empty HostPaths only. These Jobs never mount an existing LocalPath PVC
+# or Garage node_key; their completed pods have no running mounts.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-stone
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: stone }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/robbinsdale-700/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/robbinsdale-700/data, type: DirectoryOrCreate }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-tank
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: tank }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/robbinsdale-700/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/robbinsdale-700/data, type: DirectoryOrCreate }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-titan
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: titan }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/robbinsdale-700/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/robbinsdale-700/data, type: DirectoryOrCreate }

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - robbinsdale-garage-localpath-tank.yaml
   - robbinsdale-garage-localpath-titan.yaml
   - robbinsdale-garage-localpath-stone.yaml
+  - hostpath-prep.yaml
   - service-ts-storage.yaml

--- a/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-robbinsdale/nodes/service-ts-storage.yaml
@@ -80,3 +80,72 @@ spec:
     statefulset.kubernetes.io/pod-name: robbinsdale-garage-smb-0
   type: LoadBalancer
   loadBalancerClass: tailscale
+---
+# Pre-stage one identity-specific endpoint per future node-local-pool member.
+# These selectors do not match the current StatefulSets, so the existing
+# endpoints above remain untouched until a later GitOps change adds the pool.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: robbinsdale-garage-pool-stone
+    tailscale.com/tags: "tag:k8s,tag:robbinsdale"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-stone-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-700
+    garage.rajsingh.info/kubernetes-node: stone
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: robbinsdale-garage-pool-tank
+    tailscale.com/tags: "tag:k8s,tag:robbinsdale"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-tank-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-700
+    garage.rajsingh.info/kubernetes-node: tank
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: robbinsdale-garage-pool-titan
+    tailscale.com/tags: "tag:k8s,tag:robbinsdale"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-titan-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-700
+    garage.rajsingh.info/kubernetes-node: titan
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/hostpath-prep.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/hostpath-prep.yaml
@@ -1,0 +1,108 @@
+---
+# Fresh, empty HostPaths only. These Jobs never mount an existing LocalPath PVC
+# or Garage node_key; their completed pods have no running mounts.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-spark-0
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: spark-0 }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/stpetersburg-2ti/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/stpetersburg-2ti/data, type: DirectoryOrCreate }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-spark-1
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: spark-1 }
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/stpetersburg-2ti/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/stpetersburg-2ti/data, type: DirectoryOrCreate }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-hostpath-prep-orin-0
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { kubernetes.io/hostname: orin-0 }
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: prepare
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command: ["/bin/sh", "-ec"]
+          args: ["touch /metadata/.garage-volume-id /data/.garage-volume-id && sync && test -f /metadata/.garage-volume-id && test -f /data/.garage-volume-id"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: metadata, mountPath: /metadata }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: metadata
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/stpetersburg-200/metadata, type: DirectoryOrCreate }
+        - name: data
+          hostPath: { path: /var/local-path-provisioner/garage-node-local/stpetersburg-200/data, type: DirectoryOrCreate }

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - stpetersburg-garage-localpath-spark-0.yaml
   - stpetersburg-garage-localpath-spark-1.yaml
   - stpetersburg-garage-localpath-orin-0.yaml
+  - hostpath-prep.yaml
   - service-ts-storage.yaml

--- a/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/service-ts-storage.yaml
+++ b/kubernetes/apps/base/garage/garage-nodes-stpetersburg/nodes/service-ts-storage.yaml
@@ -70,3 +70,72 @@ spec:
     statefulset.kubernetes.io/pod-name: stpetersburg-garage-localpath-orin-0-0
   type: LoadBalancer
   loadBalancerClass: tailscale
+---
+# Pre-stage one identity-specific endpoint per future node-local-pool member.
+# These selectors do not match the current StatefulSets, so the existing
+# endpoints above remain untouched until a later GitOps change adds the pool.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: stpetersburg-garage-pool-spark-0
+    tailscale.com/tags: "tag:k8s,tag:stpetersburg"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-spark-0-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-2ti
+    garage.rajsingh.info/kubernetes-node: spark-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: stpetersburg-garage-pool-spark-1
+    tailscale.com/tags: "tag:k8s,tag:stpetersburg"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-spark-1-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-2ti
+    garage.rajsingh.info/kubernetes-node: spark-1
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/hostname: stpetersburg-garage-pool-orin-0
+    tailscale.com/tags: "tag:k8s,tag:stpetersburg"
+    tailscale.com/proxy-group: "common-ingress"
+  name: garage-pool-orin-0-ts
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+      targetPort: rpc
+  selector:
+    app.kubernetes.io/instance: garage
+    garage.rajsingh.info/node-local-pool: local-200
+    garage.rajsingh.info/kubernetes-node: orin-0
+  type: LoadBalancer
+  loadBalancerClass: tailscale

--- a/kubernetes/apps/base/garage/garage/garagecluster.yaml
+++ b/kubernetes/apps/base/garage/garage/garagecluster.yaml
@@ -26,7 +26,7 @@ spec:
     # consumer; the rest are content-addressed (OCI/zot, Kopia/velero) or
     # append-only (logs, barman/CNPG backups), which tolerate eventual-consistent
     # reads (a stale/absent read is a transient retry, not corruption).
-    consistencyMode: "degraded"
+    consistencyMode: "${GARAGE_CONSISTENCY_MODE:=degraded}"
 
   s3Api:
     rootDomain: ".s3.${COMMON_DOMAIN}"
@@ -86,6 +86,11 @@ spec:
     # autoApply lets the operator apply legitimate same-zone tombstone cleanup on
     # gateway scale-down/replacement instead of leaving it pending.
     autoApply: true
+    # Positive-capacity retirement is enabled only after every federated site
+    # has completed its rollout to literal consistent mode. Keep the fail-closed
+    # default until that separately observed migration phase.
+    drain:
+      unverifiedPeersPolicy: "${GARAGE_DRAIN_PEER_POLICY:=Block}"
 
   blocks:
     ramBufferMax: 128Mi
@@ -109,6 +114,9 @@ spec:
     # tier stays operator-managed. Auto->Manual is one-way (operator ejects its
     # storage nodes; Manual->Auto is rejected by the webhook).
     layoutPolicy: "${GARAGE_STORAGE_LAYOUT_POLICY:=Auto}"
+    # Site-specific pool definitions are introduced one physical site at a
+    # time. The empty default makes this preparatory change topology-neutral.
+    nodeLocalPools: ${GARAGE_NODE_LOCAL_POOLS:=[]}
     metadata:
       size: 10Gi
       storageClassName: "${STORAGECLASS_METADATA}"

--- a/kubernetes/apps/ottawa/garage/namespace.yaml
+++ b/kubernetes/apps/ottawa/garage/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: garage
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # Node-local Garage pools mount explicitly prepared HostPaths.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/robbinsdale/garage/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/garage/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: garage
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # Node-local Garage pools mount explicitly prepared HostPaths.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/stpetersburg/garage/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/garage/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: garage
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # Node-local Garage pools mount explicitly prepared HostPaths.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest


### PR DESCRIPTION
## Summary

- create one short-lived marker Job on each of the ten target Kubernetes Nodes to prepare fresh node-local metadata/data HostPaths;
- pre-stage one identity-specific Tailscale RPC Service for each future pool member;
- add Pod Security labels required for the explicitly prepared HostPaths; and
- add no-op Flux substitution points for later per-site pool, consistency-mode, and drain-policy PRs.

This PR does not add a node-local pool, change Garage capacity, retire a node, or mutate the shared layout. `GARAGE_NODE_LOCAL_POOLS` defaults to `[]`; the other substitutions preserve the current settings.

## Safety

- Marker Jobs mount only new `/var/local-path-provisioner/garage-node-local/...` paths. They never mount an existing LocalPath PVC or Garage `node_key`.
- Each Job is pinned to one exact Node, writes only `.garage-volume-id` marker files, verifies them, and exits.
- New Services select the future pool/node label pair, so they do not match current StatefulSets.
- Existing PVCs, PVs, StatefulSets, SMB members, gateways, and Tailscale Services remain unchanged.

## Preflight

- garage-operator v0.7.1 is Ready in Ottawa, Robbinsdale, and St. Petersburg with ready webhook endpoints;
- all GarageClusters and GarageNodes converged at their observed generations after the upgrade;
- Garage remains healthy with 18/18 connected members, 12/12 healthy storage members, 256/256 healthy partitions, and layout version 173 fully acknowledged; and
- the six orphaned block references belonged only to the deleted bucket, were purged, and all nodes subsequently reported zero block errors.

## Validation

- `git diff --check` passes.
- The local Flate gate repeatedly hit its documented CPU-spin timeout; no direct render bypass was used. This PR's repository CI remains the render authority.

After merge, require all ten Jobs to complete, all marker files to remain present, all ten Tailscale Services to become Ready, and Garage health/layout to remain unchanged before any site-specific pool PR.
