### PR TITLE
feat(garage): add Ottawa node-local pools

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -46,5 +46,68 @@ data:
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.
   GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
 
+  # Operator-managed replacements for the four LocalPath GarageNodes. Each
+  # selected Node already has marker-backed metadata/data directories, and the
+  # identity-specific Tailscale Services use the same pool/node labels.
+  GARAGE_NODE_LOCAL_POOLS: >-
+    [
+      {
+        "name": "local-700",
+        "capacity": "700Gi",
+        "selector": {
+          "matchExpressions": [
+            {
+              "key": "kubernetes.io/hostname",
+              "operator": "In",
+              "values": ["asuka", "kaji", "rei"]
+            }
+          ]
+        },
+        "metadata": {
+          "hostPath": "/var/local-path-provisioner/garage-node-local/ottawa-700/metadata",
+          "hostPathType": "Directory"
+        },
+        "data": {
+          "hostPath": "/var/local-path-provisioner/garage-node-local/ottawa-700/data",
+          "hostPathType": "Directory"
+        },
+        "network": {
+          "rpcPublicAddrTemplate": "ottawa-garage-pool-{nodeName}.keiretsu.ts.net:3901"
+        },
+        "podTemplate": {
+          "priorityClassName": "infra-critical",
+          "resources": {
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+            "limits": {"cpu": "3000m", "memory": "3Gi"}
+          }
+        }
+      },
+      {
+        "name": "local-200",
+        "capacity": "200Gi",
+        "selector": {
+          "matchLabels": {"kubernetes.io/hostname": "shiro"}
+        },
+        "metadata": {
+          "hostPath": "/var/local-path-provisioner/garage-node-local/ottawa-200/metadata",
+          "hostPathType": "Directory"
+        },
+        "data": {
+          "hostPath": "/var/local-path-provisioner/garage-node-local/ottawa-200/data",
+          "hostPathType": "Directory"
+        },
+        "network": {
+          "rpcPublicAddrTemplate": "ottawa-garage-pool-{nodeName}.keiretsu.ts.net:3901"
+        },
+        "podTemplate": {
+          "priorityClassName": "infra-critical",
+          "resources": {
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+            "limits": {"cpu": "3000m", "memory": "3Gi"}
+          }
+        }
+      }
+    ]
+
   # Garage: exclude asuka from gateway scheduling (SIGILL on that node)
   GARAGE_GATEWAY_AFFINITY: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"NotIn","values":["asuka"]}]}]}}}'


### PR DESCRIPTION
## Summary

- add the local-700 pool on asuka, kaji, and rei
- add the local-200 pool on shiro
- use the marker-backed HostPaths and pre-staged identity-specific Tailscale RPC endpoints
- keep every existing GarageNode and volume in place for an additive overlap

The pool list is stored as JSON because ConfigMap data values are strings and Flux substitutes text. JSON is valid YAML, so the single value expands safely into spec.storage.nodeLocalPools without multiline indentation ambiguity.

## Live preflight

- all four target Kubernetes Nodes are Ready with exact hostname selectors and no taints
- all four HostPath marker Jobs completed with zero failures
- all four future pool Services have exact pool/node selectors, zero endpoints, and the expected IngressSvcNoBackendsConfigured fail-closed state
- Garage is healthy at 18/18 connected processes, 12/12 storage nodes, 256/256 healthy partitions, and layout current/minAck 173/173
- the structured all-node worker response covered 18/18 processes with zero RPC failures, zero non-idle block-resync workers, and zero persistent block errors

The diagnostic resync queue includes future delayed checks and Garage block garbage collection. The released operator intentionally does not require it to be empty for an additive layout change; worker state and persistent errors are the authoritative safety signals.

## Rollout gate

After merge, wait for all four Ottawa pool identities, Services, and the shared layout to converge before starting another site. Keep every old GarageNode and volume during this additive phase.

## Validation

- pool substitution parses as valid JSON with exactly the two intended pools
- git diff --check
- all seven CI checks pass, including every cluster render and test gate