### PR TITLE
fix(garage): route node-local RPC across sites

### DIFF
--- a/docs/garage-node-local-v0.7.1-migration.md
+++ b/docs/garage-node-local-v0.7.1-migration.md
@@ -115,6 +115,9 @@ In one non-topology PR:
 - label each `garage` namespace for HostPath admission;
 - create per-node marker Jobs that mount only the new empty HostPaths;
 - create the new identity-specific Tailscale Services;
+- add every new pool RPC name to the shared Tailscale storage-egress catalog so
+  Garage pods at the other two sites resolve it through their local
+  `common-egress` proxy group; and
 - add no-op Flux substitution points for per-site pools, consistency mode, and
   drain peer policy.
 
@@ -123,7 +126,9 @@ future pool/node selector. Before a pool pod exists,
 `TailscaleIngressSvcConfigured=False` with reason
 `IngressSvcNoBackendsConfigured` is the expected fail-closed state; no
 LoadBalancer address should be published yet. Completed Jobs mount nothing and
-may remain until the pool is healthy.
+may remain until the pool is healthy. An ingress Service at the source site is
+not sufficient by itself: before pool activation, confirm the corresponding
+ExternalName egress Service exists in all three clusters.
 
 ### 3. Add replacement pool members one site at a time
 
@@ -139,6 +144,9 @@ For each site, require:
 - every pool Service reports `TailscaleIngressSvcConfigured=True`, publishes
   its expected identity-specific `.keiretsu.ts.net` hostname, and reaches the
   matching pod on RPC port 3901;
+- Garage status from each of the other two sites reports every new identity
+  connected; a healthy source-site view alone does not prove cross-site RPC
+  reachability;
 - every generated GarageNode has a new 64-hex identity, is Connected and
   InLayout, and has the intended zone/capacity/RPC address;
 - `NodeLocalPoolsReady=True` and `StorageRolloutReady=True` at the current

--- a/kubernetes/apps/base/garage/garage/egress-storage-rpc.yaml
+++ b/kubernetes/apps/base/garage/garage/egress-storage-rpc.yaml
@@ -19,6 +19,170 @@ spec:
     - name: rpc
       port: 3901
       protocol: TCP
+
+# Node-local replacement identities use new RPC names while the source
+# StatefulSet identities remain online. Publish every planned pool endpoint in
+# each cluster before another site joins the shared Garage layout.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ottawa-garage-pool-asuka
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-garage-pool-asuka.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ottawa-garage-pool-kaji
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-garage-pool-kaji.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ottawa-garage-pool-rei
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-garage-pool-rei.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ottawa-garage-pool-shiro
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: ottawa-garage-pool-shiro.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-garage-pool-stone
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-garage-pool-stone.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-garage-pool-tank
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-garage-pool-tank.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-garage-pool-titan
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: robbinsdale-garage-pool-titan.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-garage-pool-spark-0
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-garage-pool-spark-0.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-garage-pool-spark-1
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-garage-pool-spark-1.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-garage-pool-orin-0
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-fqdn: stpetersburg-garage-pool-orin-0.keiretsu.ts.net
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

- add Tailscale common-egress Services for all ten planned node-local pool RPC identities
- keep the old storage identity routes in place during add-before-remove migration
- document that source ingress readiness does not prove cross-site RPC reachability

## Live finding

Ottawa reached 22/22 connected Garage nodes after its four pool identities joined, but Robbinsdale saw only 18/22 connected and 12/16 storage nodes up. All four new Ottawa identities were present in layout and reported as never seen from Robbinsdale. An authenticated RPC attempt from a Robbinsdale Garage pod to the new Ottawa Tailscale address timed out.

The source ingress Services were healthy. The missing piece was the shared storage egress catalog: it still contained only the old identity FQDNs, so remote Garage pods had no local common-egress proxy route for the new pool names.

## Change

The base Garage app now declares ExternalName egress Services for:

- Ottawa: asuka, kaji, rei, shiro
- Robbinsdale: stone, tank, titan
- St. Petersburg: spark-0, spark-1, orin-0

Each points the Tailscale operator at the identity-specific pool FQDN on RPC port 3901 through the existing common-egress ProxyGroup.

## Safety

This is a non-topology change. It does not alter GarageCluster membership, capacities, layout, workloads, or old Services. Future endpoints may remain unresolved until their source pool exists; existing traffic is unchanged.

## Verification

- all 22 YAML documents parse
- every Service name is unique
- all entries use ExternalName, common-egress, and TCP 3901
- local cluster renders reached the Garage resources; the only failures were pre-existing missing chart-source dependencies that CI supplies