### PR TITLE
feat(garage): add Robbinsdale node-local pool

### DIFF
--- a/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
@@ -46,4 +46,42 @@ data:
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.
   GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
 
+  # Operator-managed replacements for the three LocalPath GarageNodes. Each
+  # selected Node already has marker-backed metadata/data directories, and the
+  # identity-specific Tailscale Services use the same pool/node labels.
+  GARAGE_NODE_LOCAL_POOLS: >-
+    [
+      {
+        "name": "local-700",
+        "capacity": "700Gi",
+        "selector": {
+          "matchExpressions": [
+            {
+              "key": "kubernetes.io/hostname",
+              "operator": "In",
+              "values": ["stone", "tank", "titan"]
+            }
+          ]
+        },
+        "metadata": {
+          "hostPath": "/var/local-path-provisioner/garage-node-local/robbinsdale-700/metadata",
+          "hostPathType": "Directory"
+        },
+        "data": {
+          "hostPath": "/var/local-path-provisioner/garage-node-local/robbinsdale-700/data",
+          "hostPathType": "Directory"
+        },
+        "network": {
+          "rpcPublicAddrTemplate": "robbinsdale-garage-pool-{nodeName}.keiretsu.ts.net:3901"
+        },
+        "podTemplate": {
+          "priorityClassName": "infra-critical",
+          "resources": {
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+            "limits": {"cpu": "3000m", "memory": "3Gi"}
+          }
+        }
+      }
+    ]
+
   GARAGE_GATEWAY_AFFINITY: '{}'


### PR DESCRIPTION
Add the Robbinsdale node-local pool for `stone`, `tank`, and `titan` as the next site in the Garage storage migration.

The operator will create one durable Garage identity per selected Kubernetes Node using the pre-created, marker-backed HostPaths. Each identity advertises its existing fail-closed Tailscale RPC Service name. The existing LocalPath GarageNodes and their PVC/PVs remain untouched; this PR only enrolls the replacement members.

Preflight immediately before this PR:

- operator v0.7.2 is Ready in all three clusters, with webhooks serving;
- all sites report 22/22 connected nodes, 16/16 storage nodes up, and 256/256 healthy partitions;
- layout version 177 is current and fully acknowledged;
- all 88 enabled block-resync workers are idle with zero persistent or consecutive errors;
- `stone`, `tank`, and `titan` are Ready and have their completed HostPath marker jobs;
- the three RPC Services are selector-correct and remain fail-closed until their pool Pods exist.

The local Robbinsdale render produced 212 successful resources; its only failures are the three known unrelated missing OCI chart sources. Repository CI remains the merge gate.
