### PR TITLE
fix(garage): pin Robbinsdale pool RPC to IPv4

### DIFF
--- a/kubernetes/apps/base/garage/garage/egress-storage-rpc.yaml
+++ b/kubernetes/apps/base/garage/garage/egress-storage-rpc.yaml
@@ -136,6 +136,57 @@ spec:
       port: 3901
       protocol: TCP
 ---
+# The Tailscale Services above advertise both address families, but their
+# Kubernetes backends are IPv4-only. These aliases pin egress to the working
+# service VIP so Garage never selects the unroutable service IPv6 address.
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-garage-pool-stone-v4
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-ip: "100.74.83.242"
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-garage-pool-tank-v4
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-ip: "100.68.131.183"
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: robbinsdale-garage-pool-titan-v4
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-ip: "100.69.254.237"
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Add IPv4-pinned egress aliases for the three new Robbinsdale Garage identities before changing their advertised RPC addresses.

The Tailscale ingress Services are healthy and endpoint-exact, but their automatically-issued IPv6 service VIPs refuse connections because the Kubernetes backends are IPv4-only. The v1.98.9 egress proxy selected those IPv6 records when targeting the MagicDNS names. Direct checks proved all three IPv4 service VIPs reach the correct Garage listeners.

This PR is deliberately non-disruptive: it only creates parallel egress Services targeting the stable IPv4 VIPs. After Flux configures them in all three clusters, authenticated Garage handshakes from Ottawa and St. Petersburg will prove the path before a follow-up changes the node-local pool's RPC address template.

The local YAML and diff checks pass. The aggregate Flate run entered its known silent spin and was terminated by the repository's 120-second guard; repository CI remains the merge gate.
