### PR TITLE
fix(garage): advertise proven Robbinsdale RPC paths

### DIFF
--- a/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
@@ -72,7 +72,7 @@ data:
           "hostPathType": "Directory"
         },
         "network": {
-          "rpcPublicAddrTemplate": "robbinsdale-garage-pool-{nodeName}.keiretsu.ts.net:3901"
+          "rpcPublicAddrTemplate": "robbinsdale-garage-pool-{nodeName}-v4.garage.svc.cluster.local:3901"
         },
         "podTemplate": {
           "priorityClassName": "infra-critical",


### PR DESCRIPTION
Make the proven IPv4-pinned egress aliases the durable advertised RPC addresses for Robbinsdale's three node-local identities.

The preceding routing PR created the aliases without touching Garage. All nine alias Services became ready, and authenticated `ConnectClusterNodes` calls from Ottawa and St. Petersburg succeeded for stone, tank, and titan. The cluster is currently healthy from every site at 25/25 connected nodes, 19/19 storage nodes up, and 256/256 healthy partitions.

This one-line template change lets periodic federation reconciliation use the same proven addresses after any future disconnect. Durable node metadata and HostPaths preserve all three identities if the operator performs a serialized Pod rollout.

The Robbinsdale render produced 212 successful resources; its only failures are the three known unrelated missing OCI chart sources. Repository CI remains the merge gate.
