### PR TITLE
fix(garage): pin St. Petersburg pool RPC to IPv4

### DIFF
--- a/kubernetes/apps/base/garage/garage/egress-storage-rpc.yaml
+++ b/kubernetes/apps/base/garage/garage/egress-storage-rpc.yaml
@@ -235,6 +235,56 @@ spec:
       port: 3901
       protocol: TCP
 ---
+# St. Petersburg's advertised pool addresses point at these aliases so egress
+# always uses the working IPv4 side of each IPv4-backed Tailscale Service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-garage-pool-spark-0-v4
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-ip: "100.102.240.70"
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-garage-pool-spark-1-v4
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-ip: "100.123.167.105"
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stpetersburg-garage-pool-orin-0-v4
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+    tailscale.com/tailnet-ip: "100.69.141.19"
+    tailscale.com/proxy-group: common-egress
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - name: rpc
+      port: 3901
+      protocol: TCP
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Why

The St. Petersburg node-local pools are healthy, but remote Tailscale egress proxies choose IPv6 when resolving the original pool FQDNs. Those IPv6 connections are refused because the backing Tailscale Services currently expose working IPv4 VIPs.

## What changed

Add one IPv4-pinned egress alias for each St. Petersburg pool node:

- spark-0 → 100.102.240.70
- spark-1 → 100.123.167.105
- orin-0 → 100.69.141.19

The pool nodes already advertise these alias names, so applying this change restores remote RPC connectivity without restarting Garage pods or changing durable node identities.

## Validation

- YAML parses and git diff checks pass
- all three local pool pods are Ready with zero restarts
- St. Petersburg reports 28/28 nodes connected, 22/22 storage nodes up, and 256/256 partitions healthy
- the repository-wide local render timed out after 120 seconds with 193 checks passing; PR CI remains the merge gate