### PR TITLE
feat(garage): enable consistent mode in Ottawa

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -41,6 +41,10 @@ data:
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
   VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
+  # First site in the drain-safety rollout. Advance the other sites only after
+  # this site's Garage processes restart and the global cluster remains healthy.
+  GARAGE_CONSISTENCY_MODE: "consistent"
+
   # Garage: storage layout hand-managed per-node in clusters/talos-ottawa/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.


### PR DESCRIPTION
## Why

All three node-local pool rollouts have converged. The next migration phase is to move every Garage process into drain-safe consistent mode, one site at a time.

## What changed

Set Ottawa's Garage consistency mode to literal consistent. No membership, layout, storage, or drain-policy change is included.

## Rollout safety

This PR stays draft until the current block repair and resync work is settled. After merge, Ottawa must finish its serialized workload rollout and the global Garage cluster must remain healthy before Robbinsdale is changed.

## Validation

- YAML parses and git diff checks pass
- current global health is 28/28 nodes connected, 22/22 storage nodes up, and 256/256 partitions healthy
- layout version 186 is current and fully acknowledged
- the scoped local render reached the repository's documented Flate timeout (exit 124); PR CI is the render gate