### PR TITLE
feat(garage): enable consistent mode in Robbinsdale

### DIFF
--- a/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
@@ -41,6 +41,10 @@ data:
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
   VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
+  # Second site in the drain-safety rollout. Merge only after Ottawa is fully
+  # rolled out in consistent mode and the global Garage cluster is healthy.
+  GARAGE_CONSISTENCY_MODE: "consistent"
+
   # Garage: storage layout hand-managed per-node in clusters/talos-robbinsdale/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.


### PR DESCRIPTION
## Why

All three node-local pool rollouts have converged. The drain-safe consistency migration must advance one site at a time.

## What changed

Set Robbinsdale's Garage consistency mode to literal consistent. No membership, layout, storage, or drain-policy change is included.

## Rollout safety

This PR remains draft until Ottawa is fully rolled out in consistent mode and global Garage health has been re-proven. After merge, Robbinsdale must finish its serialized workload rollout before St. Petersburg is changed.

## Validation

- YAML parses and git diff checks pass
- the scoped local render passed 212 checks and hit only the three known missing OCI chart-source fixtures
- deployment remains blocked by draft status and the earlier-site health gates