### PR TITLE
feat(garage): enable consistent mode in St. Petersburg

### DIFF
--- a/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
@@ -41,6 +41,10 @@ data:
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
   VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
+  # Final site in the drain-safety rollout. Merge only after Ottawa and
+  # Robbinsdale are fully rolled out and global Garage health is confirmed.
+  GARAGE_CONSISTENCY_MODE: "consistent"
+
   # Garage: STORAGE layout is hand-managed per Spark node via GarageNode CRs in
   # clusters/talos-stpetersburg/apps/garage (decoupled from clusters/common so
   # each Spark can carry its own heterogeneous storage array). Per-tier Manual


### PR DESCRIPTION
## Why

All three node-local pool rollouts have converged. The drain-safe consistency migration must advance one site at a time.

## What changed

Set St. Petersburg's Garage consistency mode to literal consistent. No membership, layout, storage, or drain-policy change is included.

## Rollout safety

This PR remains draft until both Ottawa and Robbinsdale are fully rolled out in consistent mode and global Garage health has been re-proven after each site. St. Petersburg is the final consistency-mode rollout.

## Validation

- YAML parses and git diff checks pass
- the scoped local render reached the repository's documented Flate timeout after 182 checks passed; PR CI is the render gate
- deployment remains blocked by draft status and both earlier-site health gates