### PR TITLE
feat(garage): enable Ottawa drain peer policy

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -45,6 +45,10 @@ data:
   # this site's Garage processes restart and the global cluster remains healthy.
   GARAGE_CONSISTENCY_MODE: "consistent"
 
+  # All three sites now run literal consistent mode. Enable positive-capacity
+  # drain verification in Ottawa first; no GarageNode is retired by this change.
+  GARAGE_DRAIN_PEER_POLICY: "AssumeConsistent"
+
   # Garage: storage layout hand-managed per-node in clusters/talos-ottawa/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.


### PR DESCRIPTION
## Summary

- Set Ottawa's Garage drain peer policy to AssumeConsistent.
- Leave Robbinsdale and St. Petersburg on the fail-closed Block default.
- Do not remove any GarageNode or change any PVC, PV, or Garage membership.

## Why

All three federated sites now run literal consistent mode and have completed their serialized workload rollouts. This is the first site in the separate drain-policy phase required before retiring old positive-capacity identities.

## Pre-merge gate

- All three sites report 28/28 connected nodes and 22/22 storage nodes.
- All 256 partitions are healthy and have write quorum.
- Layout history is settled at currentVersion 186 and minAck 186.
- All 112 enabled block-resync workers are idle with zero errors.
- Every St. Petersburg GarageNode is Ready, Connected, and InLayout after the final consistency rollout.