### PR TITLE
feat(garage): enable Robbinsdale drain peer policy

### DIFF
--- a/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
@@ -45,6 +45,10 @@ data:
   # rolled out in consistent mode and the global Garage cluster is healthy.
   GARAGE_CONSISTENCY_MODE: "consistent"
 
+  # Second site in the positive-capacity drain rollout. Merge only after
+  # Ottawa accepts this policy and the global Garage cluster remains healthy.
+  GARAGE_DRAIN_PEER_POLICY: "AssumeConsistent"
+
   # Garage: storage layout hand-managed per-node in clusters/talos-robbinsdale/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.


### PR DESCRIPTION
## Summary

- Set Robbinsdale's Garage drain peer policy to AssumeConsistent.
- Leave St. Petersburg on the fail-closed Block default.
- Do not remove any GarageNode or change any PVC, PV, or Garage membership.

## Merge order

Keep this draft until Ottawa has applied the same policy and the global Garage health, layout, and worker gates have passed. This is the second site in the separate drain-policy phase before old identity retirement.

## Current baseline

- All three sites run literal consistent mode.
- Global Garage health is 28/28 connected nodes, 22/22 storage nodes, and 256/256 healthy partitions.
- Layout history is settled at currentVersion 186 and minAck 186.
- All 112 enabled block-resync workers are idle with zero errors.