### PR TITLE
feat(garage): enable St. Petersburg drain peer policy

### DIFF
--- a/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
@@ -45,6 +45,10 @@ data:
   # Robbinsdale are fully rolled out and global Garage health is confirmed.
   GARAGE_CONSISTENCY_MODE: "consistent"
 
+  # Final site in the positive-capacity drain rollout. Merge only after Ottawa
+  # and Robbinsdale accept this policy and global Garage health is confirmed.
+  GARAGE_DRAIN_PEER_POLICY: "AssumeConsistent"
+
   # Garage: STORAGE layout is hand-managed per Spark node via GarageNode CRs in
   # clusters/talos-stpetersburg/apps/garage (decoupled from clusters/common so
   # each Spark can carry its own heterogeneous storage array). Per-tier Manual


### PR DESCRIPTION
## What this changes

Sets the St. Petersburg Garage drain peer policy to `AssumeConsistent`. This prepares the site for the later, explicit retirement of its old positive-capacity identities.

## Rollout guard

This PR is intentionally a draft. Merge it only after Ottawa and Robbinsdale have accepted the same live policy and the global Garage health, layout, node, and repair-worker gates are healthy.

This changes only the policy setting. It does not drain or remove a GarageNode, change cluster membership, or delete any PVC or PV.