### PR TITLE
chore(db): set immich + buzz postgres S3 backup retention to 7d

### DIFF
--- a/kubernetes/apps/base/buzz/buzz/infra/postgres.yaml
+++ b/kubernetes/apps/base/buzz/buzz/infra/postgres.yaml
@@ -26,7 +26,7 @@ spec:
         barmanObjectName: buzz-postgres-s3-store
         serverName: buzz-postgres
   backup:
-    retentionPolicy: "30d"
+    retentionPolicy: "7d"
   externalClusters:
     - name: buzz-postgres-backup
       plugin:
@@ -56,7 +56,7 @@ spec:
     env:
       - name: AWS_DEFAULT_REGION
         value: garage
-  retentionPolicy: "30d"
+  retentionPolicy: "7d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup

--- a/kubernetes/apps/base/immich/immich/app/pg.yaml
+++ b/kubernetes/apps/base/immich/immich/app/pg.yaml
@@ -33,7 +33,7 @@ spec:
         serverName: immich-postgres
 
   backup:
-    retentionPolicy: "30d"
+    retentionPolicy: "7d"
   externalClusters:
     - name: keiretsu
       plugin:

--- a/kubernetes/apps/base/immich/immich/app/s3-backup.yaml
+++ b/kubernetes/apps/base/immich/immich/app/s3-backup.yaml
@@ -19,4 +19,4 @@ spec:
     env:
       - name: AWS_DEFAULT_REGION
         value: garage
-  retentionPolicy: "30d"
+  retentionPolicy: "7d"


### PR DESCRIPTION
## Summary
Set **immich postgres** and **buzz postgres** Barman-cloud S3 backup retention from `30d` → `7d` (backups to garage/S3 retained 7 days).

## Changes (3 files)
- `immich/app/s3-backup.yaml`: ObjectStore `immich-s3-store` retentionPolicy `30d → 7d`.
- `immich/app/pg.yaml`: Cluster `immich-postgres` `backup.retentionPolicy` `30d → 7d`.
- `buzz/infra/postgres.yaml`: Cluster `buzz-postgres` `backup.retentionPolicy` + ObjectStore `buzz-postgres-s3-store` retentionPolicy `30d → 7d`.

## Verification
- `kustomize build` renders both apps without errors.
- Rendered output shows all `retentionPolicy: 7d` (immich ObjectStore + Cluster, buzz ObjectStore + Cluster); no `30d` remains in the edited manifests.

Left to human review (not merged).