### PR TITLE
fix(ci): allow encrypted secrets in flate renders

### DIFF
--- a/tools/flate.sh
+++ b/tools/flate.sh
@@ -20,6 +20,26 @@ if [ -z "$pins" ] || [ "$(printf '%s\n' "$pins" | wc -l | tr -d ' ')" != 1 ]; th
 fi
 version="$pins"
 
+# SOPS-encrypted Secret values are intentionally unavailable in offline renders.
+# Without this flag, GitRepository reconciliation can fail before Flate reaches
+# the manifests being compared (and diff can fail identically on both trees).
+# Keep every test/diff caller safe, including CI invocations outside Make.
+flate_args=("$@")
+case "${flate_args[0]:-}" in
+  test|diff)
+    allow_missing_secrets=false
+    for arg in "${flate_args[@]}"; do
+      if [ "$arg" = "--allow-missing-secrets" ]; then
+        allow_missing_secrets=true
+        break
+      fi
+    done
+    if [ "$allow_missing_secrets" = false ]; then
+      flate_args+=(--allow-missing-secrets)
+    fi
+    ;;
+esac
+
 flate_version() {
   "$1" --version 2>/dev/null | sed -n 's/^flate version //p' | head -1
 }
@@ -30,13 +50,13 @@ if [ -n "${KMAN_FLATE_BIN:-}" ]; then
     echo "error: KMAN_FLATE_BIN is Flate ${actual:-unknown}; CI requires $version" >&2
     exit 2
   fi
-  exec "$KMAN_FLATE_BIN" "$@"
+  exec "$KMAN_FLATE_BIN" "${flate_args[@]}"
 fi
 
 if command -v flate >/dev/null 2>&1; then
   system_flate="$(command -v flate)"
   if [ "$(flate_version "$system_flate" || true)" = "$version" ]; then
-    exec "$system_flate" "$@"
+    exec "$system_flate" "${flate_args[@]}"
   fi
 fi
 
@@ -64,7 +84,7 @@ fi
 install_dir="$cache_root/kubernetes-manifests/flate/$version/$platform"
 cached_flate="$install_dir/flate"
 if [ -x "$cached_flate" ] && [ "$(flate_version "$cached_flate" || true)" = "$version" ]; then
-  exec "$cached_flate" "$@"
+  exec "$cached_flate" "${flate_args[@]}"
 fi
 
 mkdir -p "$install_dir"
@@ -114,4 +134,4 @@ fi
 mv -f -- "$stage/flate" "$cached_flate"
 cleanup
 trap - EXIT INT TERM
-exec "$cached_flate" "$@"
+exec "$cached_flate" "${flate_args[@]}"

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -308,7 +308,14 @@ chmod +x "$fstub/flate"
 
 : >"$flate_calls"
 KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" "$T/flate.sh" test all --no-progress
-assert "pinned override -> args passthrough" grep -q '^test all --no-progress$' "$flate_calls"
+assert "pinned override -> missing-secret safety" \
+  grep -q '^test all --no-progress --allow-missing-secrets$' "$flate_calls"
+
+: >"$flate_calls"
+KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" \
+  "$T/flate.sh" diff all --allow-missing-secrets
+assert "explicit missing-secret flag -> no duplicate" \
+  grep -q '^diff all --allow-missing-secrets$' "$flate_calls"
 assert "CI action pin matches wrapper fixture" grep -q 'home-operations/flate/action@v0.4.12' "$ROOT/.github/workflows/flate.yaml"
 
 cat >"$fstub/old-flate" <<'EOF'

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -299,7 +299,7 @@ flate_calls="$fstub/calls"
 cat >"$fstub/flate" <<'EOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "--version" ]; then
-  echo "flate version 0.4.12"
+  echo "flate version 0.5.0"
   exit 0
 fi
 printf '%s\n' "$*" >>"$FLATE_CALLS"
@@ -316,7 +316,7 @@ KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" \
   "$T/flate.sh" diff all --allow-missing-secrets
 assert "explicit missing-secret flag -> no duplicate" \
   grep -q '^diff all --allow-missing-secrets$' "$flate_calls"
-assert "CI action pin matches wrapper fixture" grep -q 'home-operations/flate/action@v0.4.12' "$ROOT/.github/workflows/flate.yaml"
+assert "CI action pin matches wrapper fixture" grep -q 'home-operations/flate/action@v0.5.0' "$ROOT/.github/workflows/flate.yaml"
 
 cat >"$fstub/old-flate" <<'EOF'
 #!/usr/bin/env bash
@@ -325,7 +325,7 @@ EOF
 chmod +x "$fstub/old-flate"
 oldout="$(KMAN_FLATE_BIN="$fstub/old-flate" "$T/flate.sh" test all 2>&1)"; oldec=$?
 assert "mismatched override -> exit 2" test "$oldec" = 2
-assert "mismatch names required version" grep -q 'CI requires 0.4.12' <<<"$oldout"
+assert "mismatch names required version" grep -q 'CI requires 0.5.0' <<<"$oldout"
 
 : >"$flate_calls"
 KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" make -s -C "$ROOT" test


### PR DESCRIPTION
## Summary

Make `tools/flate.sh` add `--allow-missing-secrets` to every `test` and `diff` invocation unless the caller already supplied it.

This fixes the Ottawa PR diff failure where both snapshots stopped at `GitRepository/flux-system/bhaiya` because the SOPS-encrypted `forgejo-bhaiya` credentials are intentionally unavailable during offline reconciliation. Centralizing the flag in the wrapper also keeps direct CI and local calls aligned with the Make targets.

## Verification

- Added an offline wrapper test proving an unflagged render receives `--allow-missing-secrets`.
- Added an offline wrapper test proving an explicitly supplied flag is not duplicated.
- Confirmed both edited shell scripts retain executable mode.
- Commit attribution verified as `Raj Singh <rajsinghcpre@gmail.com>`.

Originating Buzz channel: `d768c147-8d68-4d14-a543-06b95b68de40`.