### PR TITLE
chore(buzz): update official relay image

### DIFF
--- a/kubernetes/apps/base/buzz/buzz/app/connector-bootstrap.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/connector-bootstrap.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: admit-connector
-          image: ghcr.io/block/buzz:sha-ac4fa13
+          image: ghcr.io/block/buzz:sha-5e4d0fe
           imagePullPolicy: Always
           command:
             - /bin/sh

--- a/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
+++ b/kubernetes/apps/base/buzz/buzz/app/helmrelease.yaml
@@ -19,9 +19,9 @@ spec:
     fullnameOverride: buzz
     image:
       repository: ghcr.io/block/buzz
-      # Match the image digest already running in Ottawa; do not combine this
-      # pairing rollout with whatever upstream currently publishes as `main`.
-      tag: sha-ac4fa13
+      # Pin the reviewed Block upstream commit rather than the mutable `main`
+      # tag.
+      tag: sha-5e4d0fe
       pullPolicy: Always
     relayUrl: wss://buzz.ottawa.keiretsu.top
     ownerPubkey: b0ea34e1aad99dd51ea38673f433e43e6d7a73e557b95a2145e3a45ff3d5f12e


### PR DESCRIPTION
Updates the Ottawa relay and Bhaiya connector bootstrap from Block upstream sha-ac4fa13 to sha-5e4d0fe.

- Both references remain official ghcr.io/block/buzz images; no Buzz source fork or patch is introduced.
- Confirmed the upstream image index supplies linux/amd64 and linux/arm64.
- Reviewed the intervening relay migrations: an additive channel lookup index and an expansion of reactions.emoji.
- The released 0.1.7 chart still emits the retired media-auth flag; the new relay intentionally treats it as inert while continuing to require authenticated media reads.

Verification: tools/check.sh talos-ottawa