### PR TITLE
fix(ai): persist DSV4 runtime JIT caches

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -309,6 +309,13 @@ spec:
           - { name: HF_HOME, value: "/models/huggingface" }
           - { name: VLLM_COMPILE_CACHE_DIR, value: "/models/compile-cache" }
           - { name: VLLM_CACHE_ROOT, value: "/models/vllm-cache" }
+          # Keep runtime JIT artifacts on the node-local model PVC. Recreating a
+          # rank must not trigger mid-serve Triton/TileLang compilation.
+          - { name: TRITON_CACHE_DIR, value: "/models/triton-cache" }
+          - { name: TILELANG_CACHE_DIR, value: "/models/tilelang-cache" }
+          # Allow long model execution/JIT work to finish before EngineCore is
+          # declared failed; NCCL watchdogs still remain the hard failure bound.
+          - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
           securityContext:
             privileged: true
             capabilities:
@@ -535,6 +542,13 @@ spec:
           - { name: HF_HOME, value: "/models/huggingface" }
           - { name: VLLM_COMPILE_CACHE_DIR, value: "/models/compile-cache" }
           - { name: VLLM_CACHE_ROOT, value: "/models/vllm-cache" }
+          # Keep runtime JIT artifacts on the node-local model PVC. Recreating a
+          # rank must not trigger mid-serve Triton/TileLang compilation.
+          - { name: TRITON_CACHE_DIR, value: "/models/triton-cache" }
+          - { name: TILELANG_CACHE_DIR, value: "/models/tilelang-cache" }
+          # Allow long model execution/JIT work to finish before EngineCore is
+          # declared failed; NCCL watchdogs still remain the hard failure bound.
+          - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
           securityContext:
             privileged: true
             capabilities:


### PR DESCRIPTION
## Summary

- Persist Triton and TileLang runtime JIT caches on the existing node-local model PVC.
- Extend vLLM model execution timeout to 1800 seconds while preserving NCCL watchdog behavior.
- Applies symmetrically to leader and worker ranks.

## Verification

- `git diff --check` passed.
- PyYAML parsed all 6 manifest documents successfully.
- `tools/check.sh sp` was attempted but the local environment lacks `tar`; CI flate gate should provide the pinned tool.

Upstream basis: MiaAI-Lab `288e5f0` / current `f104c39a8c6fa68d4ea0b342ad6eed172bc0e635`.