### PR TITLE
fix(garage): scope tsflow reference grant to ottawa

### DIFF
--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/reference-grants.yaml
@@ -30,3 +30,16 @@ spec:
       name: buzz-postgres
     - kind: GarageBucket
       name: buzz-backup
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-sheep-adder-tsflow-key
+  namespace: tailscale-up
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: sheep-adder-tsflow-key

--- a/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
@@ -67,16 +67,3 @@ spec:
   to:
     - kind: GarageKey
       name: tailscale-recorder-key
----
-apiVersion: garage.rajsingh.info/v1beta1
-kind: GarageReferenceGrant
-metadata:
-  name: garage-bucket-to-sheep-adder-tsflow-key
-  namespace: tailscale-up
-spec:
-  from:
-    - kind: GarageBucket
-      namespace: garage
-  to:
-    - kind: GarageKey
-      name: sheep-adder-tsflow-key


### PR DESCRIPTION
Flux is failing garage-reference-grants on Robbinsdale and St. Petersburg because the shared base renders a GarageReferenceGrant in namespace tailscale-up, but that namespace and tsflow workload are deployed only by Ottawa.

Move the tsflow GarageReferenceGrant from the shared base into the existing Ottawa-only garage reference-grants overlay. This keeps the grant with the only cluster that has the target GarageKey.

Observed live failure:
- Robbinsdale: namespaces "tailscale-up" not found
- St. Petersburg: namespaces "tailscale-up" not found

Verification:
- git diff --check: passed
- kustomize build shared reference-grants: 5 grants
- kustomize build Ottawa reference-grants: 3 grants
- tools/orphans.sh: passed
- tools/check.sh rb/sp: blocked by pre-existing missing PyYAML in this checkout

Commit: 589a0beeba573610f99d2f6bd25c11f43461f4ab