### PR TITLE
feat(firefly): deploy app and read-only MCP

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -28,10 +28,10 @@ diagram in the [README](../../README.md#architecture).
 
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
-| `ottawa` | 4 | 60 | 124 |
+| `ottawa` | 4 | 61 | 126 |
 | `robbinsdale` | 3 | 43 | 87 |
 | `stpetersburg` | 3 | 39 | 79 |
-| **total** | **10** | **142** | **290** |
+| **total** | **10** | **143** | **292** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -117,6 +117,7 @@ diagram in the [README](../../README.md#architecture).
 | Application workloads | `buzz` | `buzz`, `buzz-infra` |
 | Application workloads | `cliproxy` | `cliproxy` |
 | Application workloads | `firecrawl` | `firecrawl` |
+| Application workloads | `firefly` | `firefly`, `firefly-mcp` |
 | Application workloads | `forgejo` | `forgejo` |
 | Application workloads | `hermes` | `hermes` |
 | Application workloads | `homer-operator` | `homer-operator-install` |

--- a/kubernetes/apps/base/firefly/firefly/app/cronjob.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/cronjob.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: firefly-cron
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: cron
+              image: curlimages/curl:8.16.0
+              env:
+                - name: STATIC_CRON_TOKEN
+                  valueFrom:
+                    secretKeyRef: {name: firefly-secret, key: STATIC_CRON_TOKEN}
+              command: [curl, --fail, --silent, --show-error, --retry, "3", "http://firefly:8080/api/v1/cron/$${STATIC_CRON_TOKEN}"]

--- a/kubernetes/apps/base/firefly/firefly/app/deployment.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/deployment.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firefly
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app.kubernetes.io/name: firefly}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: firefly}
+    spec:
+      containers:
+        - name: firefly
+          image: fireflyiii/core:version-6.6.6@sha256:ae69fdd95cdef9039c87a460a5aec731f14813973e4f096511d5a4ea9ff0e972
+          ports: [{name: http, containerPort: 8080}]
+          env:
+            - {name: APP_ENV, value: production}
+            - {name: APP_DEBUG, value: "false"}
+            - {name: APP_URL, value: "https://firefly.${CLUSTER_DOMAIN}"}
+            - {name: TRUSTED_PROXIES, value: "**"}
+            - {name: TZ, value: "${TIMEZONE}"}
+            - {name: DEFAULT_LANGUAGE, value: en_US}
+            - {name: DEFAULT_LOCALE, value: equal}
+            - {name: DB_CONNECTION, value: pgsql}
+            - {name: DB_HOST, value: firefly-postgres-rw}
+            - {name: DB_PORT, value: "5432"}
+            - {name: DB_DATABASE, value: firefly}
+            - name: DB_USERNAME
+              valueFrom: {secretKeyRef: {name: firefly-postgres-app, key: username}}
+            - name: DB_PASSWORD
+              valueFrom: {secretKeyRef: {name: firefly-postgres-app, key: password}}
+            - name: APP_KEY
+              valueFrom: {secretKeyRef: {name: firefly-secret, key: APP_KEY}}
+            - name: SITE_OWNER
+              valueFrom: {secretKeyRef: {name: firefly-secret, key: SITE_OWNER}}
+            - name: STATIC_CRON_TOKEN
+              valueFrom: {secretKeyRef: {name: firefly-secret, key: STATIC_CRON_TOKEN}}
+            - {name: CACHE_DRIVER, value: file}
+            - {name: SESSION_DRIVER, value: file}
+            - {name: LOG_CHANNEL, value: stderr}
+          volumeMounts: [{name: uploads, mountPath: /var/www/html/storage/upload}]
+          readinessProbe: {httpGet: {path: /api/v1/about, port: http}, initialDelaySeconds: 30, periodSeconds: 10}
+          livenessProbe: {httpGet: {path: /api/v1/about, port: http}, initialDelaySeconds: 60, periodSeconds: 20}
+      volumes:
+        - name: uploads
+          persistentVolumeClaim: {claimName: firefly-upload}

--- a/kubernetes/apps/base/firefly/firefly/app/httproute.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/httproute.yaml
@@ -14,14 +14,11 @@ spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: private
+      name: public
       namespace: home
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: ts
-      namespace: home
+      sectionName: wildcard-keiretsu-top-https
   hostnames:
-    - "firefly.${CLUSTER_DOMAIN}"
+    - "firefly.${COMMON_DOMAIN}"
   rules:
     - matches:
         - path:
@@ -30,6 +27,12 @@ spec:
       backendRefs:
         - name: firefly
           port: 8080
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-Proto
+                value: https
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
@@ -79,3 +82,27 @@ spec:
             - name: Remote-Email
               values:
                 - kartikbharath@gmail.com
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyExtensionPolicy
+metadata:
+  name: firefly-tinyauth-redirect
+  namespace: firefly
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: firefly
+  lua:
+    - inline: |
+        function envoy_on_response(response_handle)
+          local headers = response_handle:headers()
+          if headers:get(":status") == "401" then
+            local location = headers:get("x-tinyauth-location")
+            if location then
+              headers:replace(":status", "302")
+              headers:add("Location", location)
+              headers:remove("x-tinyauth-location")
+            end
+          end
+        end

--- a/kubernetes/apps/base/firefly/firefly/app/httproute.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/httproute.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: firefly
+  annotations:
+    item.homer.rajsingh.info/name: "Firefly III"
+    item.homer.rajsingh.info/subtitle: "Personal Finance Manager"
+    item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/svg/firefly-iii.svg"
+    item.homer.rajsingh.info/keywords: "finance, budgeting, accounting"
+    service.homer.rajsingh.info/name: "Personal"
+    service.homer.rajsingh.info/icon: "fas fa-wallet"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: private
+      namespace: home
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ts
+      namespace: home
+  hostnames:
+    - "firefly.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: firefly
+          port: 8080
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: firefly-tinyauth
+  namespace: firefly
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: firefly
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - cookie
+      - x-forwarded-proto
+      - x-forwarded-for
+      - user-agent
+    http:
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: tinyauth
+          namespace: tinyauth
+          port: 3000
+          weight: 1
+      headersToBackend:
+        - remote-user
+        - remote-email
+        - remote-name
+        - remote-groups
+      path: /api/auth/envoy?path=
+  authorization:
+    defaultAction: Deny
+    rules:
+      - action: Allow
+        name: allow-raj
+        principal:
+          headers:
+            - name: Remote-Email
+              values:
+                - rajsinghcpre@gmail.com
+      - action: Allow
+        name: allow-kartik
+        principal:
+          headers:
+            - name: Remote-Email
+              values:
+                - kartikbharath@gmail.com

--- a/kubernetes/apps/base/firefly/firefly/app/kustomization.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: firefly
+resources:
+  - postgres.yaml
+  - pvc.yaml
+  - secret.sops.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - cronjob.yaml

--- a/kubernetes/apps/base/firefly/firefly/app/postgres.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/postgres.yaml
@@ -23,18 +23,11 @@ spec:
         serverName: firefly-postgres
   backup:
     retentionPolicy: "30d"
-  externalClusters:
-    - name: keiretsu
-      plugin:
-        name: barman-cloud.cloudnative-pg.io
-        parameters:
-          barmanObjectName: firefly-s3-store
-          serverName: firefly-postgres
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: firefly-postgres-s3
+  name: firefly-postgres-scheduled
 spec:
   schedule: "0 0 1 * * *"
   immediate: true

--- a/kubernetes/apps/base/firefly/firefly/app/postgres.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/postgres.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: firefly-postgres
+spec:
+  instances: 2
+  bootstrap:
+    initdb:
+      database: firefly
+      owner: firefly
+      dataChecksums: true
+  storage:
+    size: 10Gi
+    storageClass: ceph-block-replicated
+  monitoring:
+    enablePodMonitor: true
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: firefly-s3-store
+        serverName: firefly-postgres
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: keiretsu
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: firefly-s3-store
+          serverName: firefly-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: firefly-postgres-s3
+spec:
+  schedule: "0 0 1 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: firefly-postgres
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: firefly-s3-store
+spec:
+  configuration:
+    destinationPath: s3://firefly-postgres/${LOCATION}/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: firefly-postgres-s3
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: firefly-postgres-s3
+        key: AWS_SECRET_ACCESS_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: firefly-postgres-key
+  namespace: firefly
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: Firefly PostgreSQL Backup Key
+  secretTemplate:
+    name: firefly-postgres-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: firefly-postgres
+        namespace: garage
+      read: true
+      write: true
+      owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: firefly-postgres
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: firefly-postgres
+  quotas:
+    maxSize: 200Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: firefly-postgres-key
+        namespace: firefly
+      read: true
+      write: true
+      owner: true
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-firefly-key
+  namespace: firefly
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: firefly-postgres-key

--- a/kubernetes/apps/base/firefly/firefly/app/pvc.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: firefly-upload
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: ceph-block-replicated
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/apps/base/firefly/firefly/app/secret.sops.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/secret.sops.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: firefly-secret
+    namespace: firefly
+type: Opaque
+stringData:
+    APP_KEY: ENC[AES256_GCM,data:qSDdeJCdAsJHc+q/CD+BbY5XEzB9jPNMfBtOWaj9SII=,iv:lL59vJr+6RGkATY/jQ74TZlrygOSW2alHjijHSyWebY=,tag:3HXiTGTJLI+6Noq10wzdPw==,type:str]
+
+    STATIC_CRON_TOKEN: ENC[AES256_GCM,data:OLRG/wIQwA/2Jm6AxhIF1fpN32v2eQnPAMReC+bh8oc=,iv:2uFQbuwuKLBa/VC7vo+SRYEWu/HB1I6/lrkketgUH1s=,tag:+4TeavtplNzJ7GXIJm1ZYQ==,type:str]
+    SITE_OWNER: ENC[AES256_GCM,data:PquC1+I6R1Tr67zvR4oIEnlxDw==,iv:F53f0u9wF0ePivq8ZWlAaGe7T2NOpLP06B+3RM7rq1E=,tag:pRzngbb1fvhiMAjNN+EMqQ==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-24T01:19:31Z"
+    mac: ENC[AES256_GCM,data:Ovvds0m1/y0ORezSGOVH4ZA2vSf9c7kYijZ+nP6aIp/vOxd96U1YuBhBH0ihktOoaIj2nK48Hpto2OeGFpRJ0o5VuOAF17gkEzm0oY4JtQ8AK4n0OGEX8oSOfWX227ZiVY2OqtwyA/eVvOyhhkt5htFS5xcCkS1btNnss5QbMW4=,iv:yyrTc4PB7dIqZzF/1L/1rrBVbNz9JhJlclenfdgm094=,tag:4lLL57TBywa+jN85m+oS7A==,type:str]
+    pgp:
+        - created_at: "2026-08-24T01:19:31Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveAQ/+Kp4DhkTC5QXDKaVV7J4ruzVaaNQBA65wSCHZz0r6Z96g
+            ww1sfKw/HDkEyYJK94UpwkKXKahegB5rbM29m1QLCQ6KrZXeYQ7KdxKiVijrg5qD
+            pIDX2e8A6z8PqgjvJ/MuZrMUVBGC4o95eUcI4r+49c1oqp1nnmXslSmYf2s7jTGR
+            NqMGeEWpto5Ii66h8QHeSmFW+oY3JcUecrJj0nDV84rpWA4baLb6yhKsQMJLR0JX
+            ra2+Shp6Xf7giGaNQUuTVFYHqg78y4FuzOGLLe3hneuuk7iCnXNurT6jAhUteOZd
+            3YZoKZC27pigTDcCizZDj3RJAEfMfgcAJ2d7ETA2/DT62Rjsor7bL2gpgPRbmMmH
+            JRGSF+xAhzJ2V7wqt7AUE1lLekEPv5nYWcRB9XdngYR20SQQmGlrPN39m+XZOtbX
+            TJfnfJe8+9t1HTOp0vMse4hyYTsFHE0CGqKW2THJfBnTarwkEXLGwQPsQww00Blv
+            6jJZ6PXHF9yO+jGLSfUwBBKdnsYdfm0ybgXLSmZrRYalBYyb57bZci/WZlnRcUaa
+            bH5yZohJRnoozOlhVqhmGNwtjysbW/8piW7CvP7aUgd+OQuVKKyik8UtBZgkxs0a
+            Y+PnuCdgMu6tUEn3dOKHoUVAoF3dTO2uDhikM14HN3j4N8i8FhZTh/PAr4+kfRvS
+            XgG4Bu7cEP0x9olF12PjbBa6JhUPWpy6ly70v41z4nt1DOcTsvPkTgMCeUnLP2gr
+            7jQnoX38pFHz/cajPUjTmD9hdgDdIUOg3HTfK+eWMmF/ud35B3LvvSYrRZMBRNI=
+            =XrA2
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.3

--- a/kubernetes/apps/base/firefly/firefly/app/service.yaml
+++ b/kubernetes/apps/base/firefly/firefly/app/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: firefly
+spec:
+  selector:
+    app.kubernetes.io/name: firefly
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/kubernetes/apps/base/firefly/firefly/mcp/deployment.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/deployment.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firefly-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: firefly-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: firefly-mcp
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: firefly-mcp
+          image: ghcr.io/daften/fireflyiii-mcp:0.4.2@sha256:2e756227c8b4298196c33a1090a96b4952405e9dbe83cd4255efb1407c103f1e
+          imagePullPolicy: IfNotPresent
+          args:
+            - --transport
+            - http
+            - --host
+            - 0.0.0.0
+            - --port
+            - "3000"
+            - --read-only
+          env:
+            - name: FIREFLY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: firefly-mcp
+                  key: FIREFLY_III_URL
+            - name: FIREFLY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: firefly-mcp
+                  key: FIREFLY_III_TOKEN
+            - name: MCP_READ_ONLY
+              value: "true"
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi

--- a/kubernetes/apps/base/firefly/firefly/mcp/deployment.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/deployment.yaml
@@ -39,11 +39,6 @@ spec:
                 secretKeyRef:
                   name: firefly-mcp
                   key: FIREFLY_III_URL
-            - name: FIREFLY_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: firefly-mcp
-                  key: FIREFLY_III_TOKEN
             - name: MCP_READ_ONLY
               value: "true"
           ports:

--- a/kubernetes/apps/base/firefly/firefly/mcp/externalsecret.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: firefly-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kubernetes-local
+    kind: ClusterSecretStore
+  target:
+    name: firefly-mcp
+    creationPolicy: Owner
+  data:
+    - secretKey: FIREFLY_III_URL
+      remoteRef:
+        key: firefly-iii
+        property: FIREFLY_III_URL
+    - secretKey: FIREFLY_III_TOKEN
+      remoteRef:
+        key: firefly-iii
+        property: FIREFLY_III_TOKEN

--- a/kubernetes/apps/base/firefly/firefly/mcp/externalsecret.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/externalsecret.yaml
@@ -16,7 +16,3 @@ spec:
       remoteRef:
         key: firefly-iii
         property: FIREFLY_III_URL
-    - secretKey: FIREFLY_III_TOKEN
-      remoteRef:
-        key: firefly-iii
-        property: FIREFLY_III_TOKEN

--- a/kubernetes/apps/base/firefly/firefly/mcp/integration-contract.md
+++ b/kubernetes/apps/base/firefly/firefly/mcp/integration-contract.md
@@ -1,0 +1,64 @@
+# Firefly III MCP integration contract
+
+## Upstream pin
+
+- Repository: <https://github.com/daften/fireflyiii-mcp>
+- Release: `v0.4.2`
+- Source commit: `e7894fa46243dff3a43a0651105a294faeedb7da`
+- Image: `ghcr.io/daften/fireflyiii-mcp:0.4.2`
+- Image index digest: `sha256:2e756227c8b4298196c33a1090a96b4952405e9dbe83cd4255efb1407c103f1e`
+- License: MIT
+
+The upstream image serves Streamable HTTP MCP on port `3000`; `GET /health`
+returns `{"status":"ok"}`. Requests without a bearer token return HTTP 401.
+The deployment starts the upstream server with `--read-only`, so mutation tools
+are not registered.
+
+## Secret and environment contract
+
+External Secrets materializes `firefly/firefly-mcp` from the local
+ClusterSecretStore key `firefly-iii`, properties:
+
+- `FIREFLY_III_URL`: Firefly III origin, without an `/api/v1` suffix.
+- `FIREFLY_III_TOKEN`: Firefly III Personal Access Token.
+
+The Deployment maps these to the upstream-required variables:
+
+- `FIREFLY_URL` <- `FIREFLY_III_URL`
+- `FIREFLY_TOKEN` <- `FIREFLY_III_TOKEN`
+
+No plaintext or SOPS token value is added by this change.
+
+## Network and client contract
+
+- Service: `firefly-mcp.firefly.svc.cluster.local:3000`
+- Only Bhaiya may access the MCP listener; host/remote-node access is limited to
+  `GET /health` for probes.
+- Bhaiya sends `Authorization: Bearer <Firefly III PAT>` to the Streamable HTTP
+  endpoint. The upstream resolves the bearer token per request and uses it for
+  Firefly III API calls.
+- No public HTTPRoute is created; Bhaiya remains the user-facing auth/UI boundary.
+
+## Verification
+
+The upstream checkout at the source commit passed `npm run check`: Biome,
+TypeScript, and 438 passing tests. Thirteen live integration tests were skipped
+because no Firefly III credentials were available in the build workspace.
+A real local upstream HTTP smoke test also verified `/health`, 401 without a
+bearer token, and MCP `initialize` returning server `firefly-iii-mcp` version
+`0.4.2` over SSE.
+
+The Kubernetes manifest files pass YAML parsing and `git diff --check`.
+The repository's canonical `./tools/check.sh ot` could not complete in this
+workspace because its Flate bootstrap requires `tar`, which is absent; this is
+a host-tooling blocker, not a manifest diagnostic.
+
+The ExternalSecret prerequisite is an existing backend record named `firefly-iii`
+with the two properties above. It must be provisioned separately by the cluster
+secret operator.
+
+## Existing Firefly III app
+
+The repository already deploys Firefly III itself in the Ottawa `firefly`
+namespace. This MCP service is intentionally colocated in the `firefly`
+namespace, but remains a separate Flux child and NetworkPolicy boundary.

--- a/kubernetes/apps/base/firefly/firefly/mcp/integration-contract.md
+++ b/kubernetes/apps/base/firefly/firefly/mcp/integration-contract.md
@@ -22,10 +22,12 @@ ClusterSecretStore key `firefly-iii`, properties:
 - `FIREFLY_III_URL`: Firefly III origin, without an `/api/v1` suffix.
 - `FIREFLY_III_TOKEN`: Firefly III Personal Access Token.
 
-The Deployment maps these to the upstream-required variables:
+The Deployment maps the URL to the upstream-required variable:
 
 - `FIREFLY_URL` <- `FIREFLY_III_URL`
-- `FIREFLY_TOKEN` <- `FIREFLY_III_TOKEN`
+
+`FIREFLY_TOKEN` is intentionally not set: upstream v0.4.2 ignores it in HTTP
+mode. Bhaiya injects the PAT as `Authorization: Bearer <token>` on each request.
 
 No plaintext or SOPS token value is added by this change.
 

--- a/kubernetes/apps/base/firefly/firefly/mcp/kustomization.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: firefly
+resources:
+  - ./externalsecret.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./networkpolicy.yaml

--- a/kubernetes/apps/base/firefly/firefly/mcp/networkpolicy.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: firefly-mcp-ingress
+spec:
+  description: Only Bhaiya may use the Firefly III MCP listener; host and remote-node receive health checks.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: firefly-mcp
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: bhaiya
+            app.kubernetes.io/name: bhaiya
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: /health$
+  egress:
+    - toEntities:
+        - cluster
+    - toFQDNs:
+        - matchPattern: "*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/base/firefly/firefly/mcp/service.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: firefly-mcp
+  labels:
+    app.kubernetes.io/name: firefly-mcp
+spec:
+  selector:
+    app.kubernetes.io/name: firefly-mcp
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/apps/base/garage/garage-bucket-ottawa/firefly-postgres.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket-ottawa/firefly-postgres.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: firefly-postgres
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: firefly-postgres
+  quotas:
+    maxSize: 200Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: firefly-postgres-key
+        namespace: firefly
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-bucket-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket-ottawa/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: garage
 resources:
   - ../garage-bucket
   - bucket.yaml
+  - firefly-postgres.yaml

--- a/kubernetes/apps/base/garage/garage-keys-ottawa/firefly-postgres-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys-ottawa/firefly-postgres-key.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: firefly-postgres-key
+  namespace: firefly
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: Firefly PostgreSQL Backup Key
+  secretTemplate:
+    name: firefly-postgres-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: firefly-postgres
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-keys-ottawa/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ../garage-keys
   - bhaiya-postgres-key.yaml
+  - firefly-postgres-key.yaml

--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/firefly-reference-grant.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/firefly-reference-grant.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-firefly-key
+  namespace: firefly
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: firefly-postgres-key

--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - reference-grants.yaml
+  - firefly-reference-grant.yaml

--- a/kubernetes/apps/base/k8gb/k8gb-common/config/cnames.yaml
+++ b/kubernetes/apps/base/k8gb/k8gb-common/config/cnames.yaml
@@ -71,6 +71,13 @@ spec:
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"
+    - dnsName: "firefly.${COMMON_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "ottawa.${COMMON_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
     - dnsName: "hubble.${COMMON_DOMAIN}"
       recordType: CNAME
       targets:

--- a/kubernetes/apps/ottawa/firefly/firefly-mcp.yaml
+++ b/kubernetes/apps/ottawa/firefly/firefly-mcp.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: firefly-mcp
+  namespace: flux-system
+spec:
+  targetNamespace: firefly
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: firefly-mcp
+  path: ./kubernetes/apps/base/firefly/firefly/mcp
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ottawa/firefly/firefly.yaml
+++ b/kubernetes/apps/ottawa/firefly/firefly.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firefly
+  namespace: flux-system
+spec:
+  targetNamespace: firefly
+  commonMetadata:
+    labels: {app.kubernetes.io/name: *app}
+  dependsOn:
+    - {name: cnpg-system}
+    - {name: rook-ceph-cluster-config}
+  path: ./kubernetes/apps/base/firefly/firefly/app
+  prune: true
+  sourceRef: {kind: GitRepository, name: kubernetes-manifests}
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/ottawa/firefly/firefly.yaml
+++ b/kubernetes/apps/ottawa/firefly/firefly.yaml
@@ -11,6 +11,9 @@ spec:
   dependsOn:
     - {name: cnpg-system}
     - {name: rook-ceph-cluster-config}
+    - {name: garage}
+    - {name: garage-bucket}
+    - {name: garage-keys}
   path: ./kubernetes/apps/base/firefly/firefly/app
   prune: true
   sourceRef: {kind: GitRepository, name: kubernetes-manifests}

--- a/kubernetes/apps/ottawa/firefly/kustomization.yaml
+++ b/kubernetes/apps/ottawa/firefly/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - firefly.yaml
+  - firefly-mcp.yaml

--- a/kubernetes/apps/ottawa/firefly/namespace.yaml
+++ b/kubernetes/apps/ottawa/firefly/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: firefly
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -63,3 +63,4 @@ resources:
   - ./victoria-logs
   - ./victoria-logs/victoria-logs.yaml
   - ./woodpecker
+  - ./firefly


### PR DESCRIPTION
Deploy Firefly III in Ottawa and colocate its read-only Firefly MCP in the firefly namespace. The MCP is reachable only from Bhaiya (health probes are GET /health only), its PAT is sourced from External Secrets ClusterSecretStore key firefly-iii, and no public MCP route is created. The Bhaiya integration uses http://firefly-mcp.firefly.svc.cluster.local:3000/mcp and remains admin-only.

Do not merge this pull request until the canonical render gate passes.