### PR TITLE
fix(garage): distribute tailscale-up namespace

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -29,9 +29,9 @@ diagram in the [README](../../README.md#architecture).
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
 | `ottawa` | 4 | 60 | 124 |
-| `robbinsdale` | 3 | 43 | 87 |
-| `stpetersburg` | 3 | 39 | 79 |
-| **total** | **10** | **142** | **290** |
+| `robbinsdale` | 3 | 44 | 87 |
+| `stpetersburg` | 3 | 40 | 79 |
+| **total** | **10** | **144** | **290** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -197,6 +197,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Networking, ingress and identity | `tailscale` | `tailscale-csi-provider`, `tailscale-operator`, `tailscale-operator-resources` |
 | Networking, ingress and identity | `tailscale-examples` | `tailscale-examples-sandbox` |
 | Networking, ingress and identity | `tailscale-system` | `tailscale-system-app` |
+| Networking, ingress and identity | `tailscale-up` | — |
 | Networking, ingress and identity | `tinyauth-egress` | `tinyauth-egress` → ns `tinyauth` |
 | Storage and data services | `cnpg-system` | `cnpg-system` |
 | Storage and data services | `csi-addons` | `csi-addons`, `csi-addons-config` |
@@ -284,6 +285,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Networking, ingress and identity | `k8gb` | `k8gb-app`, `k8gb-config` |
 | Networking, ingress and identity | `tailscale` | `tailscale-csi-provider`, `tailscale-operator`, `tailscale-operator-resources` |
 | Networking, ingress and identity | `tailscale-system` | `tailscale-system-app` |
+| Networking, ingress and identity | `tailscale-up` | — |
 | Networking, ingress and identity | `tinyauth-egress` | `tinyauth-egress` → ns `tinyauth` |
 | Storage and data services | `cnpg-system` | `cnpg-system` |
 | Storage and data services | `garage` | `garage`, `garage-bucket`, `garage-keys`, `garage-nodes-stpetersburg`, `garage-reference-grants`, `garage-velero-bucket`, `garage-webui` |

--- a/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
@@ -67,3 +67,16 @@ spec:
   to:
     - kind: GarageKey
       name: tailscale-recorder-key
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-sheep-adder-tsflow-key
+  namespace: tailscale-up
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: sheep-adder-tsflow-key

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -34,6 +34,7 @@ resources:
   - ./node-feature-discovery
   - ./tailscale-examples
   - ./tailscale-system
+  - ./tailscale-up
   - ./tailscale
   - ./local-path-storage
   - ./csi-addons

--- a/kubernetes/apps/robbinsdale/tailscale-up/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-up/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+

--- a/kubernetes/apps/robbinsdale/tailscale-up/namespace.yaml
+++ b/kubernetes/apps/robbinsdale/tailscale-up/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-up
+  labels:
+    app.kubernetes.io/name: tailscale-up
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - ./k8gb
   - ./node-feature-discovery
   - ./tailscale-system
+  - ./tailscale-up
   - ./tailscale
   - ./local-path-storage
   - ./tuppr

--- a/kubernetes/apps/stpetersburg/tailscale-up/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-up/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+

--- a/kubernetes/apps/stpetersburg/tailscale-up/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/tailscale-up/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale-up
+  labels:
+    app.kubernetes.io/name: tailscale-up
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Restore the shared GarageReferenceGrant for sheep-adder-tsflow and add the missing tailscale-up namespace to Robbinsdale and St. Petersburg.

The namespace is intentionally distributed without deploying the Ottawa-only tsflow/lobby workloads. This preserves the shared grant layout while satisfying the namespaced GarageReferenceGrant target on every cluster.

Changes:
- Restore the tsflow GarageReferenceGrant in the shared garage-reference-grants base.
- Add tailscale-up Namespace Kustomizations to Robbinsdale and St. Petersburg.
- Include the new per-cluster pointers in both cluster aggregates.

Verification:
- git diff --check: passed
- Robbinsdale tailscale-up Kustomization render: passed
- St. Petersburg tailscale-up Kustomization render: passed
- Shared Garage grants render: passed (6 grants)
- tools/orphans.sh: passed
- tools/check.sh --quick: blocked by a pre-existing repository issue: base/agent-sandbox/agent-sandbox lacks a kustomization file

Live before this change: both clusters had no tailscale-up namespace; garage-reference-grants and garage-bucket are now Ready after the prior fix.

Commit: 546884bfd8d4bccc8d8c7c3ab89989f47d4bfcdf