### PR TITLE
fix(firefly): retain MCP PAT in ExternalSecret

### DIFF
--- a/kubernetes/apps/base/firefly/firefly/mcp/deployment.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/deployment.yaml
@@ -26,12 +26,6 @@ spec:
           image: ghcr.io/daften/fireflyiii-mcp:0.4.2@sha256:2e756227c8b4298196c33a1090a96b4952405e9dbe83cd4255efb1407c103f1e
           imagePullPolicy: IfNotPresent
           args:
-            - --transport
-            - http
-            - --host
-            - 0.0.0.0
-            - --port
-            - "3000"
             - --read-only
           env:
             - name: FIREFLY_URL
@@ -39,6 +33,11 @@ spec:
                 secretKeyRef:
                   name: firefly-mcp
                   key: FIREFLY_III_URL
+            - name: FIREFLY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: firefly-mcp
+                  key: FIREFLY_III_TOKEN
             - name: MCP_READ_ONLY
               value: "true"
           ports:

--- a/kubernetes/apps/base/firefly/firefly/mcp/externalsecret.yaml
+++ b/kubernetes/apps/base/firefly/firefly/mcp/externalsecret.yaml
@@ -16,3 +16,7 @@ spec:
       remoteRef:
         key: firefly-iii
         property: FIREFLY_III_URL
+    - secretKey: FIREFLY_III_TOKEN
+      remoteRef:
+        key: firefly-iii
+        property: FIREFLY_III_TOKEN


### PR DESCRIPTION
The synchronized ExternalSecret was missing FIREFLY_III_TOKEN after the prior follow-up merge. Restore the token mapping required by the read-only MCP deployment and Bhaiya static Bearer bridge.