### PR TITLE
feat(ai): trial abliterated DSV4 checkpoint

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -7,7 +7,7 @@
 #                 NVFP4 sparse-MLA KV cache, LeaderWorkerSet gang scheduling.
 # Image         : ghcr.io/rajsinghtechbot/dsv4-nvfp4@sha256:67a0f4443851b3d674dd4d0369fcfb779367cf65d16ccf750d64e5c899d10250
 #                 (custom arm64 vLLM 0.21+B12X runtime with NVFP4 patches)
-# Model         : deepseek-ai/DeepSeek-V4-Flash-0731@9e165c30 (48 shards, FP8 weights)
+# Model         : drowzeys/keys-DeepSeekV4-Flash-GA-0731-Dspark-Abliterated-Anchored-Tensors (48 shards, FP8 weights; MTP/DSpark tensors stock)
 #
 # Tech2Wild-derived Stage-C NVFP4/B12X profile (upstream recipe commit 2d4820f):
 # - --max-num-seqs 6, --max-model-len 1048576 (full model context qualification)
@@ -36,10 +36,12 @@ data:
     #!/bin/bash
     set -euo pipefail
     MODEL_DIR="$${MODEL_DIR:-/models/dsv4}"
-    HF_REPO="$${HF_REPO:-deepseek-ai/DeepSeek-V4-Flash-0731}"
-    HF_REVISION="$${HF_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}"
+    HF_REPO="$${HF_REPO:-drowzeys/keys-DeepSeekV4-Flash-GA-0731-Dspark-Abliterated-Anchored-Tensors}"
+    # This gated abliterated repo tracks the pinned official 0731 base revision;
+    # the repo itself is the selected artifact, so no separate revision is needed.
+    HF_REVISION="$${HF_REVISION:-}"
     MODEL_MARKER="$${MODEL_DIR}/.model-revision"
-    EXPECTED_MARKER="$${HF_REPO}@$${HF_REVISION}"
+    EXPECTED_MARKER="$${HF_REPO}$${HF_REVISION:+@$${HF_REVISION}}"
     EXPECTED=48
 
     mkdir -p "$${MODEL_DIR}"
@@ -65,8 +67,12 @@ data:
     echo "[download] Cleaning stale lock files…"
     rm -rf "$${MODEL_DIR}"/.cache/huggingface/download/*.lock 2>/dev/null || true
 
-    echo "[download] Starting model download with hf CLI ($${HF_REPO}@$${HF_REVISION})…"
-    hf download "$${HF_REPO}" --revision "$${HF_REVISION}" --local-dir "$${MODEL_DIR}" 2>&1
+    echo "[download] Starting model download with hf CLI ($${EXPECTED_MARKER})…"
+    if [ -n "$${HF_REVISION}" ]; then
+      hf download "$${HF_REPO}" --revision "$${HF_REVISION}" --local-dir "$${MODEL_DIR}" 2>&1
+    else
+      hf download "$${HF_REPO}" --local-dir "$${MODEL_DIR}" 2>&1
+    fi
 
     echo "[validate] Checking for $${EXPECTED} shards…"
     COUNT="$$(find . -maxdepth 1 -name '*.safetensors' | wc -l)"
@@ -75,7 +81,11 @@ data:
     if [ "$${COUNT}" -lt "$${EXPECTED}" ]; then
       echo "[ERROR] Expected $${EXPECTED} shards, got $${COUNT}. Redownloading…"
       find "$${MODEL_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-      hf download "$${HF_REPO}" --revision "$${HF_REVISION}" --local-dir "$${MODEL_DIR}" 2>&1
+      if [ -n "$${HF_REVISION}" ]; then
+        hf download "$${HF_REPO}" --revision "$${HF_REVISION}" --local-dir "$${MODEL_DIR}" 2>&1
+      else
+        hf download "$${HF_REPO}" --local-dir "$${MODEL_DIR}" 2>&1
+      fi
       COUNT="$$(find . -maxdepth 1 -name '*.safetensors' | wc -l)"
       if [ "$${COUNT}" -lt "$${EXPECTED}" ]; then
         echo "[FATAL] Still only $${COUNT} shards after retry. Aborting."
@@ -150,6 +160,7 @@ spec:
           - { name: MODEL_DIR, value: "/models/dsv4" }
           - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
           - { name: HF_HOME, value: "/models/huggingface" }
+          - { name: HF_REPO, value: "drowzeys/keys-DeepSeekV4-Flash-GA-0731-Dspark-Abliterated-Anchored-Tensors" }
           - { name: HF_HUB_OFFLINE, value: "0" }
           - { name: TRANSFORMERS_OFFLINE, value: "0" }
           volumeMounts:
@@ -388,6 +399,7 @@ spec:
           - { name: MODEL_DIR, value: "/models/dsv4" }
           - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
           - { name: HF_HOME, value: "/models/huggingface" }
+          - { name: HF_REPO, value: "drowzeys/keys-DeepSeekV4-Flash-GA-0731-Dspark-Abliterated-Anchored-Tensors" }
           - { name: HF_HUB_OFFLINE, value: "0" }
           - { name: TRANSFORMERS_OFFLINE, value: "0" }
           volumeMounts:


### PR DESCRIPTION
## Summary

- Switch the DSV4 download/validation path to the gated abliterated anchored-tensor checkpoint:
  `drowzeys/keys-DeepSeekV4-Flash-GA-0731-Dspark-Abliterated-Anchored-Tensors`
- Keep the existing served-model aliases and DSpark runtime unchanged.
- The model PVC is reused, and the revision marker causes the old official checkpoint to be removed before download.

## Safety / cleanup

- This is a replacement rollout, not a second model deployment.
- The old non-abliterated weights are removed by the existing model-revision mismatch cleanup in the init download script.
- The HF repository is gated and requires the existing `hf-secret` access.

## Verification

- YAML parsed successfully (6 documents).
- Embedded download script passed `bash -n`.
- `git diff --check` passed.
- Production smoke and post-rollout checks will be run after merge.