### PR TITLE
fix(gatus): monitor StPetersburg DSV4 vLLM

### DIFF
--- a/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/base/gatus/gatus/app/helmrelease.yaml
@@ -58,6 +58,16 @@ spec:
           alerts:
             - type: discord
               send-on-resolved: true
+        - name: DSV4 vLLM (StPetersburg)
+          group: AI
+          url: http://dsv4.ai:8000/health
+          interval: 60s
+          conditions:
+            - "[STATUS] == 200"
+            - "[RESPONSE_TIME] < 2000"
+          alerts:
+            - type: discord
+              send-on-resolved: true
         # === Storage: Garage Cross-Cluster ===
         - name: Garage Local (StPetersburg)
           group: storage


### PR DESCRIPTION
## Summary
- add one St. Petersburg Gatus healthcheck for the DSV4 vLLM Service
- use the authoritative in-cluster Service URL `http://dsv4.ai:8000/health`
- preserve the existing 60s / HTTP 200 / 2s / Discord conventions

## Verification
- `git diff --check`
- `tools/check.sh talos-stpetersburg`

The live DSV4 rollout was observed separately and is currently not Ready; this PR only changes Gatus configuration and does not modify DSV4 manifests or deploy anything.