### PR TITLE
feat(ai): run public abliterated DSV4 checkpoint

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -7,7 +7,7 @@
 #                 NVFP4 sparse-MLA KV cache, LeaderWorkerSet gang scheduling.
 # Image         : ghcr.io/rajsinghtechbot/dsv4-nvfp4@sha256:67a0f4443851b3d674dd4d0369fcfb779367cf65d16ccf750d64e5c899d10250
 #                 (custom arm64 vLLM 0.21+B12X runtime with NVFP4 patches)
-# Model         : deepseek-ai/DeepSeek-V4-Flash-0731@9e165c30 (48 shards, FP8 weights)
+# Model         : lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated (74 files; public DSpark checkpoint)
 #
 # Tech2Wild-derived Stage-C NVFP4/B12X profile (upstream recipe commit 2d4820f):
 # - --max-num-seqs 6, --max-model-len 1048576 (full model context qualification)
@@ -36,8 +36,8 @@ data:
     #!/bin/bash
     set -euo pipefail
     MODEL_DIR="$${MODEL_DIR:-/models/dsv4}"
-    HF_REPO="$${HF_REPO:-deepseek-ai/DeepSeek-V4-Flash-0731}"
-    HF_REVISION="$${HF_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}"
+    HF_REPO="$${HF_REPO:-lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated}"
+    HF_REVISION="$${HF_REVISION:-9172d9db37e4181c7f79f6cf357aa5c8c6691476}"
     MODEL_MARKER="$${MODEL_DIR}/.model-revision"
     EXPECTED_MARKER="$${HF_REPO}@$${HF_REVISION}"
     EXPECTED=48
@@ -150,6 +150,7 @@ spec:
           - { name: MODEL_DIR, value: "/models/dsv4" }
           - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
           - { name: HF_HOME, value: "/models/huggingface" }
+          - { name: HF_REPO, value: "lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated" }
           - { name: HF_HUB_OFFLINE, value: "0" }
           - { name: TRANSFORMERS_OFFLINE, value: "0" }
           volumeMounts:
@@ -388,6 +389,7 @@ spec:
           - { name: MODEL_DIR, value: "/models/dsv4" }
           - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
           - { name: HF_HOME, value: "/models/huggingface" }
+          - { name: HF_REPO, value: "lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated" }
           - { name: HF_HUB_OFFLINE, value: "0" }
           - { name: TRANSFORMERS_OFFLINE, value: "0" }
           volumeMounts:


### PR DESCRIPTION
## Summary

- Switch the production DSV4 download path to public `lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated`.
- Pin the Hugging Face repository revision `9172d9db37e4181c7f79f6cf357aa5c8c6691476`.
- Preserve the existing DSpark runtime, 48-shard validation, model-revision cleanup, aliases, and cache persistence.

The previously attempted drowzeys checkpoint was gated and failed with `Access denied. This repository requires approval.` This checkpoint is public according to the Hugging Face API (`gated=false`).

## Verification

- Hugging Face API: public, gated=false, 48 safetensor shards.
- YAML: 6 documents parsed successfully.
- Embedded download script: `bash -n` passed.
- `git diff --check` passed.