### PR TITLE
fix(ai): preserve model files during snapshot publish

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -74,7 +74,7 @@ data:
     test -f "$${MODEL_DIR}.incoming/config.json"
     test "$$(find "$${MODEL_DIR}.incoming" -maxdepth 1 -name '*.safetensors' | wc -l)" -ge "$${EXPECTED}"
     find "$${MODEL_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-    cp -a "$${MODEL_DIR}.incoming"/. "$${MODEL_DIR}/"
+    cp -aL "$${MODEL_DIR}.incoming"/. "$${MODEL_DIR}/"
     rm -rf "$${MODEL_DIR}.incoming"
     cd "$${MODEL_DIR}"
     echo "[validate] Checking for $${EXPECTED} shards…"


### PR DESCRIPTION
The snapshot staging fix validated the full cache snapshot but copied staged symlinks into the model directory. Dereference links on both staging and final copy so /models/dsv4 contains regular config and weight files for vLLM. This closes the live invalid local directory failure.