### PR TITLE
fix(ai): copy HF snapshot files into model root

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -70,11 +70,11 @@ data:
     mkdir -p "$${MODEL_DIR}.incoming"
     # Dereference HF snapshot symlinks: copying links alone leaves
     # /models/dsv4/config.json and weights pointing back into the cache tree.
-    cp -aL "$${SNAPSHOT}"/. "$${MODEL_DIR}.incoming/"
+    cp -rL "$${SNAPSHOT}"/. "$${MODEL_DIR}.incoming/"
     test -f "$${MODEL_DIR}.incoming/config.json"
     test "$$(find "$${MODEL_DIR}.incoming" -maxdepth 1 -name '*.safetensors' | wc -l)" -ge "$${EXPECTED}"
     find "$${MODEL_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-    cp -aL "$${MODEL_DIR}.incoming"/. "$${MODEL_DIR}/"
+    cp -rL "$${MODEL_DIR}.incoming"/. "$${MODEL_DIR}/"
     rm -rf "$${MODEL_DIR}.incoming"
     cd "$${MODEL_DIR}"
     echo "[validate] Checking for $${EXPECTED} shards…"


### PR DESCRIPTION
The HF cache snapshot uses symlinks. The current cp -a publish step preserves those links, so /models/dsv4 lacks a usable config.json after the download init completes. Use cp -rL for both copies so the model root contains regular files and vLLM can start.