### PR TITLE
fix(ai): publish complete HF snapshot directly

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -66,16 +66,13 @@ data:
     echo "[download] Starting snapshot download ($${HF_REPO}@$${HF_REVISION})…"
     SNAPSHOT="$$(python3 -c 'import os,sys; from huggingface_hub import snapshot_download; print(snapshot_download(repo_id=sys.argv[1], revision=sys.argv[2], cache_dir="/models/hf-cache"))' "$${HF_REPO}" "$${HF_REVISION}")"
     test -d "$${SNAPSHOT}"
-    rm -rf "$${MODEL_DIR}.incoming"
-    mkdir -p "$${MODEL_DIR}.incoming"
-    # Dereference HF snapshot symlinks: copying links alone leaves
-    # /models/dsv4/config.json and weights pointing back into the cache tree.
-    cp -rL "$${SNAPSHOT}"/. "$${MODEL_DIR}.incoming/"
-    test -f "$${MODEL_DIR}.incoming/config.json"
-    test "$$(find "$${MODEL_DIR}.incoming" -maxdepth 1 -name '*.safetensors' | wc -l)" -ge "$${EXPECTED}"
+    # Validate the complete content-addressed snapshot before replacing the
+    # serving tree. Then dereference its symlinks directly into the model root;
+    # the snapshot is complete, so no partial local-dir metadata can be copied.
+    test -f "$${SNAPSHOT}/config.json"
+    test "$$(find "$${SNAPSHOT}" -maxdepth 1 -name '*.safetensors' | wc -l)" -ge "$${EXPECTED}"
     find "$${MODEL_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-    cp -rL "$${MODEL_DIR}.incoming"/. "$${MODEL_DIR}/"
-    rm -rf "$${MODEL_DIR}.incoming"
+    cp -rL "$${SNAPSHOT}"/. "$${MODEL_DIR}/"
     cd "$${MODEL_DIR}"
     echo "[validate] Checking for $${EXPECTED} shards…"
     COUNT="$$(find . -maxdepth 1 -name '*.safetensors' | wc -l)"


### PR DESCRIPTION
The previous staged copy validates the snapshot but the final publish can still fail when the destination contains cache/symlink artifacts. Validate the completed content-addressed snapshot first, then dereference it directly into /models/dsv4. This removes the invalid local-directory startup loop.