### PR TITLE
fix(ai): validate complete model copy before publish

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -71,8 +71,16 @@ data:
     # the snapshot is complete, so no partial local-dir metadata can be copied.
     test -f "$${SNAPSHOT}/config.json"
     test "$$(find "$${SNAPSHOT}" -maxdepth 1 -name '*.safetensors' | wc -l)" -ge "$${EXPECTED}"
+    rm -rf "$${MODEL_DIR}.incoming"
+    mkdir -p "$${MODEL_DIR}.incoming"
+    # Copy the complete snapshot with links dereferenced, but do not remove the
+    # current model tree until the full copy has succeeded.
+    cp -rL "$${SNAPSHOT}"/. "$${MODEL_DIR}.incoming/"
+    test -f "$${MODEL_DIR}.incoming/config.json"
+    test "$$(find "$${MODEL_DIR}.incoming" -maxdepth 1 -name '*.safetensors' | wc -l)" -ge "$${EXPECTED}"
     find "$${MODEL_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-    cp -rL "$${SNAPSHOT}"/. "$${MODEL_DIR}/"
+    cp -rL "$${MODEL_DIR}.incoming"/. "$${MODEL_DIR}/"
+    rm -rf "$${MODEL_DIR}.incoming"
     cd "$${MODEL_DIR}"
     echo "[validate] Checking for $${EXPECTED} shards…"
     COUNT="$$(find . -maxdepth 1 -name '*.safetensors' | wc -l)"


### PR DESCRIPTION
vLLM still saw an invalid /models/dsv4 after the snapshot copy. Stage and validate the fully dereferenced model tree, including config.json and all 48 shards, before deleting the current model tree or starting either rank.