### PR TITLE
feat(ai): trial newer prem abliterated DSV4

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/dsv4.yaml
@@ -7,7 +7,7 @@
 #                 NVFP4 sparse-MLA KV cache, LeaderWorkerSet gang scheduling.
 # Image         : ghcr.io/rajsinghtechbot/dsv4-nvfp4@sha256:67a0f4443851b3d674dd4d0369fcfb779367cf65d16ccf750d64e5c899d10250
 #                 (custom arm64 vLLM 0.21+B12X runtime with NVFP4 patches)
-# Model         : lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated (74 files; public DSpark checkpoint)
+# Model         : prem-research/DeepSeek-V4-Flash-0731-abliterated@45721037 (48 shards, native FP8/FP4; MTP included)
 #
 # Tech2Wild-derived Stage-C NVFP4/B12X profile (upstream recipe commit 2d4820f):
 # - --max-num-seqs 6, --max-model-len 1048576 (full model context qualification)
@@ -36,8 +36,8 @@ data:
     #!/bin/bash
     set -euo pipefail
     MODEL_DIR="$${MODEL_DIR:-/models/dsv4}"
-    HF_REPO="$${HF_REPO:-lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated}"
-    HF_REVISION="$${HF_REVISION:-9172d9db37e4181c7f79f6cf357aa5c8c6691476}"
+    HF_REPO="$${HF_REPO:-prem-research/DeepSeek-V4-Flash-0731-abliterated}"
+    HF_REVISION="$${HF_REVISION:-457210de3a9d27d8142407cd0dac7b6ed6ad9325}"
     MODEL_MARKER="$${MODEL_DIR}/.model-revision"
     EXPECTED_MARKER="$${HF_REPO}@$${HF_REVISION}"
     EXPECTED=48
@@ -158,7 +158,7 @@ spec:
           - { name: MODEL_DIR, value: "/models/dsv4" }
           - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
           - { name: HF_HOME, value: "/models/huggingface" }
-          - { name: HF_REPO, value: "lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated" }
+          - { name: HF_REPO, value: "prem-research/DeepSeek-V4-Flash-0731-abliterated" }
           - { name: HF_HUB_OFFLINE, value: "0" }
           - { name: TRANSFORMERS_OFFLINE, value: "0" }
           volumeMounts:
@@ -397,7 +397,7 @@ spec:
           - { name: MODEL_DIR, value: "/models/dsv4" }
           - { name: HUGGING_FACE_HUB_TOKEN, valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } } }
           - { name: HF_HOME, value: "/models/huggingface" }
-          - { name: HF_REPO, value: "lovesenko/DeepSeek-V4-Flash-DSpark-Abliterated" }
+          - { name: HF_REPO, value: "prem-research/DeepSeek-V4-Flash-0731-abliterated" }
           - { name: HF_HUB_OFFLINE, value: "0" }
           - { name: TRANSFORMERS_OFFLINE, value: "0" }
           volumeMounts:


### PR DESCRIPTION
Move production from the July lovesenko DSpark abliteration to the newer 2026-08-12 prem-research ARA abliterated native FP8/FP4 checkpoint. The repo contains 48 weight shards, model index, config, tokenizer, and MTP weights and claims native DeepSeek-V4 compatibility.