### PR TITLE
feat(monitoring): alert on payment backfill holds

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/payments.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/payments.yaml
@@ -74,6 +74,30 @@ groups:
             should be retried by Stripe. Inspect the service logs and
             provider/accounting dependencies before acknowledging the alert.
 
+      - alert: BhaiyaPaymentsStripeBackfillFailures
+        expr: increase(bhaiya_payments_stripe_backfill_failures_total[15m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya payments Stripe backfill is failing
+          description: >-
+            Authenticated Stripe event recovery failed to advance a durable
+            stream cursor in the last 15 minutes. Inspect the stream and
+            reconciliation state before accepting new payment recovery.
+
+      - alert: BhaiyaPaymentsStripeBackfillManualHold
+        expr: increase(bhaiya_payments_stripe_backfill_manual_holds_total[1h]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya payments Stripe backfill requires manual review
+          description: >-
+            A Stripe event was held during authenticated backfill because its
+            identity, lifecycle, or accounting facts require operator review.
+            Resolve the hold before treating payment recovery as complete.
+
       - alert: BhaiyaPaymentsReconciliationFailures
         expr: increase(bhaiya_payments_reconciliation_failures_total[15m]) > 0
         for: 5m

--- a/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
@@ -26,6 +26,20 @@ spec:
   interval: 10m
   retryInterval: 1m
   timeout: 5m
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: bhaiya-payments
+      namespace: bhaiya
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      name: bhaiya-payments
+      namespace: bhaiya
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      name: bhaiya-payments-firefly
+      namespace: bhaiya
   decryption:
     provider: sops
     secretRef:


### PR DESCRIPTION
## Summary

The Bhaiya PrometheusAgent remote-writes payment metrics to the per-cluster Mimir ruler; it does not evaluate application `PrometheusRule` objects. Add the two Stripe recovery alerts that correspond to metrics already exported by the reviewed Bhaiya payments release:

- `BhaiyaPaymentsStripeBackfillFailures`
- `BhaiyaPaymentsStripeBackfillManualHold`

This keeps the Bhaiya HTTPRoute, service, and secret wiring in the Bhaiya repository while making recovery failures observable in the actual Ottawa alerting path.

## Validation

- `git diff --check`
- `tools/check.sh ot` was run; it is currently blocked before rendering by the repository's pre-existing Envoy Gateway chart/dashboard version mismatch (chart 1.9.1 vs dashboards 1.9.0).

No cluster mutation was performed.