### PR TITLE
fix(bhaiya): preserve payment rollout wait gate

### DIFF
--- a/clusters/talos-ottawa/flux/config/cluster.yaml
+++ b/clusters/talos-ottawa/flux/config/cluster.yaml
@@ -137,3 +137,17 @@ spec:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
         labelSelector: notifications.keiretsu.top/github-status notin (disabled)
+    # The shared child overlay defaults most application pointers to wait:false.
+    # Bhaiya explicitly opts into waiting because its payment deployment and
+    # ExternalSecret health checks are release gates.
+    - patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: bhaiya
+        spec:
+          wait: true
+      target:
+        group: kustomize.toolkit.fluxcd.io
+        kind: Kustomization
+        name: bhaiya


### PR DESCRIPTION
## Summary

The Ottawa `kubernetes-apps` overlay currently overwrites child Kustomization `wait` values to `false`. That masks Bhaiya's explicit payment rollout health gate. Add a name-targeted final patch so only the `bhaiya` child retains `wait: true`; shared substitution and all other child defaults remain unchanged.

## Validation

- `git diff --check` passed.
- `tools/check.sh talos-ottawa` reached rendering but is blocked by the repository's existing local chart/dependency fixture failures (six unrelated HelmRelease source/value errors and the expected missing GitRepository secret); no error references this patch.
- No cluster mutation performed.