### PR TITLE
Drop the resurrected tailscale-up reference grant

### DIFF
--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/reference-grants.yaml
@@ -11,16 +11,3 @@ spec:
   to:
     - kind: GarageKey
       name: bhaiya-postgres-key
----
-apiVersion: garage.rajsingh.info/v1beta1
-kind: GarageReferenceGrant
-metadata:
-  name: garage-bucket-to-sheep-adder-tsflow-key
-  namespace: tailscale-up
-spec:
-  from:
-    - kind: GarageBucket
-      namespace: garage
-  to:
-    - kind: GarageKey
-      name: sheep-adder-tsflow-key


### PR DESCRIPTION
Fixes a regression I introduced in #2569.

`b702af854 chore: purge tailscale-up manifests` removed the `garage-bucket-to-sheep-adder-tsflow-key` grant along with the rest of the `tailscale-up` namespace. #2569 removed the Buzz grant from the same file, the two changes conflicted during a rebase, and I resolved the conflict the wrong way round — keeping the deleted `tailscale-up` grant instead of dropping both.

The namespace no longer exists, so `garage-ottawa-reference-grants` fails:

```
GarageReferenceGrant/tailscale-up/garage-bucket-to-sheep-adder-tsflow-key not found: namespaces "tailscale-up" not found
```

and everything behind it is blocked on an unready dependency:

| Kustomization | Status |
|---|---|
| `garage-ottawa-reference-grants` | False — the error above |
| `garage-bucket` | False — dependency not ready |
| `garage-keys` | False — dependency not ready |
| `bhaiya` | False — dependency not ready |
| `firefly` | False — dependency not ready |
| `garage-velero-bucket` | False — dependency not ready |
| `velero` | False — dependency not ready |
| `velero-ui` | False — dependency not ready |

This drops the grant again, leaving the file with only the `bhaiya-postgres-bucket` grant it is meant to carry — matching what `main` had before #2569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)