### PR TITLE
fix(monitoring): restore SGLang Grafana dashboard

### DIFF
--- a/kubernetes/apps/base/monitoring/grafana/dashboards/vllm/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/grafana/dashboards/vllm/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - dashboards.yaml
   - gpu-dcgm.yaml
+  - sglang.yaml


### PR DESCRIPTION
## Summary

- Re-add the existing `sglang.yaml` GrafanaDashboard to the shared vLLM dashboard Kustomization.
- Preserve the existing `mimir-stpetersburg` datasource UID, `AI` folder, and Grafana instance selector.
- Do not change the healthy `ai/qwen38` ServiceMonitor.

## Root cause

`ca814bc0b` removed both the dashboard file and its Kustomization entry during the GLM-5.3 swap. `d771511ed` restored only the dashboard file, leaving it orphaned and absent from Flux output.

## Validation

- `git diff --check` passed.
- `tools/orphans.sh` passed.
- `make verify` is not defined in this repository.
- `tools/check.sh` was attempted; the sandbox and escalated run could not complete external chart/OCI fetches and timed out without a manifest diagnostic.
