### PR TITLE
fix(bhaiya): drop Flux targetNamespace before overlay owns Gateway RBAC

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -177,8 +177,10 @@ Three apps are reconciled from a `sourceRef` other than `kubernetes-manifests`,
 which is why a change here can be perfectly committed and still not move them:
 
 - `GitRepository bhaiya` → `forgejo.keiretsu.top/corp/bhaiya.git` (self-hosted
-  Forgejo), driven by a Flux `Receiver bhaiya` plus a webhook token, so Forgejo
-  pushes trigger a reconcile. Ottawa only.
+  Forgejo). This repo owns only the GitRepository, `forgejo-bhaiya` credentials,
+  and the Flux Kustomization pointer (no `targetNamespace`). The Receiver,
+  webhook token, Firefly MCP ExternalSecret, and home Gateway editor RBAC live
+  in `corp/bhaiya`'s activation overlay. Ottawa only.
 - `GitRepository firecrawl` → `github.com/firecrawl/firecrawl`, path
   `./examples/kubernetes/cluster-install`. Ottawa only.
 - `GitRepository csi-addons` → the upstream project, path `./deploy/controller`,
@@ -1308,7 +1310,7 @@ Companions:
 
 | App | Notes |
 |---|---|
-| `bhaiya` | workspace/sandbox control plane. Reconciled from its **own** GitRepository (Forgejo) via a Flux Receiver, not from this repo. `dependsOn` garage, garage-keys, cnpg-system, agent-sandbox, and cert-manager. Owns a Velero Role so it can back itself up, plus gateway RBAC and a `*.bhaiya.keiretsu.top` wildcard. |
+| `bhaiya` | workspace/sandbox control plane. Reconciled from its **own** GitRepository (Forgejo), not from this repo. This repo keeps the GitRepository, Forgejo credentials, and the Flux pointer (`dependsOn` garage, garage-keys, cnpg-system, agent-sandbox, cert-manager). The Receiver, Firefly MCP secret, and home Gateway editor Role live in `corp/bhaiya`. Platform TLS (`*.bhaiya`), k8gb apex route, GarageKey, Velero schedule, and Mimir rules stay here. |
 | `border0` | Border0 `tailzero-connector`, device `ottawa-tailzero`. Runs with `clusterRoleMode: api-admin` because it proxies the Kubernetes API, which makes it a second admin-level route into Ottawa's API outside the tailnet operator's identity model — see [What breaks when a site goes down](#what-breaks-when-a-site-goes-down). Credentials come from a `tailzero-connector-credentials` Secret. |
 | `hermes` | agent runtime (`hermes-agent`); egresses to `stpetersburg-vllm` and `aperture` on the tailnet |
 | `firecrawl` | web-scraping stack, reconciled straight from the upstream GitHub repo's `examples/kubernetes/cluster-install` path |

--- a/kubernetes/apps/ottawa/bhaiya/bhaiya-gateway-rbac.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/bhaiya-gateway-rbac.yaml
@@ -14,6 +14,8 @@ kind: Role
 metadata:
   name: bhaiya-gateway-editor
   namespace: home
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
@@ -28,6 +30,8 @@ kind: RoleBinding
 metadata:
   name: bhaiya-gateway-editor
   namespace: home
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     notifications.keiretsu.top/github-status: disabled
 spec:
-  targetNamespace: bhaiya
+  # Do not set targetNamespace. The activation overlay already namespaces
+  # every namespaced object, including home/bhaiya-gateway-editor. A Flux
+  # targetNamespace would rewrite that Role/RoleBinding into bhaiya.
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app

--- a/kubernetes/apps/ottawa/bhaiya/firefly-mcp-bhaiya-secret.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/firefly-mcp-bhaiya-secret.yaml
@@ -4,6 +4,11 @@ kind: ExternalSecret
 metadata:
   name: firefly-mcp-bhaiya-secret
   namespace: bhaiya
+  annotations:
+    # Keep this object while corp/bhaiya's activation overlay takes ownership.
+    # kubernetes-apps prune would otherwise delete it the moment this file
+    # leaves the pointer directory.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/kubernetes/apps/ottawa/bhaiya/receiver.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/receiver.yaml
@@ -4,6 +4,8 @@ kind: Receiver
 metadata:
   name: bhaiya
   namespace: bhaiya
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   type: generic-hmac
   interval: 10m

--- a/kubernetes/apps/ottawa/bhaiya/webhook-secret.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/webhook-secret.yaml
@@ -4,5 +4,7 @@ kind: Secret
 metadata:
   name: bhaiya-webhook-token
   namespace: bhaiya
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
   token: ${BHAIYA_FLUX_WEBHOOK_TOKEN}


### PR DESCRIPTION
## Summary

The `corp/bhaiya` activation overlay is about to take ownership of:

- `ExternalSecret/firefly-mcp-bhaiya-secret` (namespace `bhaiya`)
- `Receiver/bhaiya` and `Secret/bhaiya-webhook-token` (namespace `bhaiya`)
- `Role`/`RoleBinding` `bhaiya-gateway-editor` (namespace `home`)

Flux `spec.targetNamespace: bhaiya` would rewrite the home Gateway Role into the `bhaiya` namespace. This PR drops `targetNamespace` from the pointer and disables prune on the leftover objects so `kubernetes-apps` cannot delete them during the handoff.

GitRepository, `forgejo-bhaiya` credentials, the pointer Kustomization, wildcard cert, k8gb apex route, GarageKey, Velero schedule, and Mimir rules stay here.

## Ordering

1. Merge **this** PR and wait until `Kustomization/bhaiya` in `flux-system` has no `spec.targetNamespace`.
2. Then merge `corp/bhaiya` `feat/decouple-infra-glue`.
3. After that overlay is live, a follow-up PR removes the leftover files from `kubernetes/apps/ottawa/bhaiya/`.

Do not merge the Bhaiya overlay first.

## Validation

- `git diff --check`
- pointer still lists GitRepository + leftovers (prune-disabled) + Kustomization CR
- architecture notes updated for the new ownership split

No cluster mutation performed.