### PR TITLE
fix(ai): stop Qwen NEXTN !-forever and advertise real serving limits

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/README.md
+++ b/kubernetes/apps/base/ai/ai/inference/README.md
@@ -20,8 +20,9 @@ derived from `lmsysorg/sglang:qwen38flashnext` with MiaAI-Lab's published QSA
 fallback and NVFP4-KV patches)
 **Deployment**: `qwen38.yaml`, a two-member LeaderWorkerSet pinned to
 `spark-0` and `spark-1`, with SGLang TP=2 over the RDMA rail.
-**Serving profile**: 1M-token YaRN context, NVFP4 KV cache, and NEXTN
-speculative decoding (2 steps / top-k 1 / 2 draft tokens).
+**Serving profile**: 1M-token YaRN context, NVFP4 KV cache, no NEXTN
+speculative decoding. `--max-running-requests 3` matches the mamba state
+cache cap (19 slots, 5 per request). Do not advertise a higher value.
 **Endpoint**: `stpetersburg-vllm` (port 80 → 8000), also exposed internally as
 the `qwen38` Service.
 
@@ -47,16 +48,21 @@ there is no in-repo image build in this rollback.
   separate per rank. The cache-drop init container and bounded cache-drop loop
   reclaim unified memory before and during serving.
 - The memory-sensitive serving settings are `--mem-fraction-static 0.90`,
-  `--mamba-full-memory-ratio 0.3`, a `1048576` context, and NEXTN with two
-  speculative steps and two draft tokens. Do not raise these ratios or place
-  unrelated GPU workloads on either Spark without a new load qualification.
+  `--mamba-full-memory-ratio 0.3`, a `1048576` context, and
+  `--max-running-requests 3`. Do not raise the mamba ratio (or the advertised
+  running-request cap) or place unrelated GPU workloads on either Spark
+  without a new load qualification. NEXTN speculative decoding is disabled:
+  the target-verify logits kernel can race on huge prompts and pin generation
+  on a single token with `spec_accept_length=1` while GPUs stay busy.
 - Metrics are scraped once by the `qwen38` ServiceMonitor at 15-second
   intervals and stored in the St. Petersburg Mimir tenant. Do not add a second
   static ScrapeConfig for this Service; duplicate scrapes double-count counter
   rates and waste the agent's remote-write budget.
 - The shared Grafana `SGLang Inference` dashboard is model-selector driven and
   includes the scrape target, throughput, queue/KV headroom, latency,
-  speculative acceptance, and DCGM Spark GPU panels.
+  speculative acceptance, and DCGM Spark GPU panels. PrometheusRule
+  `sglang-rules` in this directory alerts when `num_running_reqs>0` while
+  generation tokens are flat, or when `spec_accept_length` is pinned at 1.0.
 - The model-download init step normalizes the checkpoint tokenizer metadata from
   its source `262144` value to `1048576` on each start. This is metadata-only;
   it prevents long prompts from being rejected by the tokenizer before SGLang's

--- a/kubernetes/apps/base/ai/ai/inference/kustomization.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - qwen38.yaml
   - secret.yaml
   - probes.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/base/ai/ai/inference/prometheusrule.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/prometheusrule.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: sglang-rules
+spec:
+  groups:
+    - name: sglang.rules
+      rules:
+        # Completions-only counter: rate() is 0 while requests are still
+        # running (huge prefill, or a decode that never EOS). A few minutes
+        # of that is a long prompt; 8m is past the ~4m 200K-token prefill
+        # this cluster has survived, and catches the !-forever wedge.
+        - alert: SGLangGenerationFlatline
+          expr: |
+            max by (cluster, namespace, pod, model_name) (sglang:num_running_reqs) > 0
+            and
+            sum by (cluster, namespace, pod, model_name) (rate(sglang:generation_tokens_total[2m])) == 0
+          for: 8m
+          annotations:
+            summary: SGLang has running requests but generation_tokens_total is flat ({{ $labels.model_name }})
+            description: >-
+              num_running_reqs has been >0 while rate(sglang:generation_tokens_total)
+              is 0 for 8m on {{ $labels.pod }}. That is longer than a healthy 200K-token
+              chunked prefill on this cluster. Either prefill is stuck or decode is
+              emitting tokens that never finish the request (the !-forever NEXTN race).
+          labels:
+            severity: critical
+
+        # NEXTN target-verify collapse: spec_accept_length pins at 1.0 on the
+        # first decode sample and stays there while GPUs keep busy. Stale
+        # last-sample gauges during idle are excluded by num_running_reqs>0.
+        - alert: SGLangSpecAcceptPinned
+          expr: |
+            max by (cluster, namespace, pod, model_name) (sglang:spec_accept_length) == 1
+            and
+            max by (cluster, namespace, pod, model_name) (sglang:num_running_reqs) > 0
+          for: 3m
+          annotations:
+            summary: SGLang spec_accept_length pinned at 1.0 with running requests ({{ $labels.model_name }})
+            description: >-
+              spec_accept_length has been exactly 1.0 for 3m while num_running_reqs>0
+              on {{ $labels.pod }}. Healthy NEXTN on this cluster varies 1.7–3.0.
+              A pin at 1.0 with GPUs busy is the garbage-decode failure mode.
+          labels:
+            severity: warning

--- a/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
@@ -208,6 +208,10 @@ spec:
             # reserve enough static-pool budget for the hybrid state cache.
             # FlashInfer autotune reaches the SM121 FA4 CuTe path, which
             # currently fails compilation with a weak-congruence error.
+            # NEXTN speculative decode is intentionally off: the target-verify
+            # logits kernel races under huge prompts and can collapse output
+            # to a single token forever. max-running-requests is the real
+            # mamba-cache cap (19 slots / 5 per request = 3), not 8.
             exec python3 -m sglang.launch_server \
               --model-path /models/qwen38 \
               --served-model-name Qwen3.8-Flash-Next-NVFP4 \
@@ -223,12 +227,8 @@ spec:
               --mamba-full-memory-ratio 0.3 \
               --mem-fraction-static 0.90 \
               --chunked-prefill-size 1024 \
-              --max-running-requests 8 \
+              --max-running-requests 3 \
               --context-length 1048576 \
-              --speculative-algorithm NEXTN \
-              --speculative-num-steps 2 \
-              --speculative-eagle-topk 1 \
-              --speculative-num-draft-tokens 2 \
               --reasoning-parser auto \
               --tool-call-parser auto \
               --enable-metrics \
@@ -378,6 +378,8 @@ spec:
             nvidia-smi --gpu-reset -i 0 >/dev/null 2>/dev/null || true
             # Keep the worker's memory profile identical to the head rank.
             # The SM121 FA4 CuTe autotune warmup is not usable in this image.
+            # NEXTN off and max-running-requests 3 must stay in lockstep with
+            # the head rank (mamba state cache silently caps 8 to 3).
             exec python3 -m sglang.launch_server \
               --model-path /models/qwen38 \
               --served-model-name Qwen3.8-Flash-Next-NVFP4 \
@@ -393,12 +395,8 @@ spec:
               --mamba-full-memory-ratio 0.3 \
               --mem-fraction-static 0.90 \
               --chunked-prefill-size 1024 \
-              --max-running-requests 8 \
+              --max-running-requests 3 \
               --context-length 1048576 \
-              --speculative-algorithm NEXTN \
-              --speculative-num-steps 2 \
-              --speculative-eagle-topk 1 \
-              --speculative-num-draft-tokens 2 \
               --reasoning-parser auto \
               --tool-call-parser auto \
               --enable-metrics \

--- a/kubernetes/apps/base/cliproxy/cliproxy/app/deployment.yaml
+++ b/kubernetes/apps/base/cliproxy/cliproxy/app/deployment.yaml
@@ -508,11 +508,12 @@ spec:
               # The St. Petersburg SGLang catalog does not publish all Qwen
               # serving-profile facts in /v1/models. Keep those facts explicit
               # so the Pi catalog and Bhaiya's generated OpenCode config describe
-              # the active route accurately. No output limit is asserted because
-              # the upstream does not publish one.
+              # the active route accurately. Assert an 8k output cap so a stuck
+              # stream cannot legally decode for the full 1,048,576 context.
               metadata_overrides = {
                   "vllm/Qwen3.8-Flash-Next-NVFP4": {
                       "context_window": 1048576,
+                      "max_tokens": 8192,
                       "name": "Qwen3.8 Flash Next",
                       "reasoning": True,
                   },

--- a/tools/check-cliproxy-pi-bridge.sh
+++ b/tools/check-cliproxy-pi-bridge.sh
@@ -49,6 +49,7 @@ if namespace["metadata_alias_sources"].get(qwen_alias) != qwen_source:
     raise SystemExit(f"{qwen_alias} must resolve metadata from {qwen_source}")
 if namespace["metadata_override"](qwen_alias) != {
     "context_window": 1048576,
+    "max_tokens": 8192,
     "name": "Qwen3.8 Flash Next",
     "reasoning": True,
 }:


### PR DESCRIPTION
## Summary
- Drop `--speculative-algorithm NEXTN` (and the matching draft-token flags) on both Qwen3.8 LWS ranks. The target-verify logits kernel races under huge prompts and can collapse decode onto token 248319 forever.
- Set `--max-running-requests 3` to match the mamba state-cache cap (19 slots / 5 per request). Stop advertising 8.
- cliproxy pi-bridge: assert `max_tokens: 8192` for `vllm/Qwen3.8-Flash-Next-NVFP4` so a stuck stream cannot legally run the full 1,048,576 context.
- PrometheusRule `sglang-rules`: alert when `num_running_reqs>0` while generation tokens are flat for 8m, and when `spec_accept_length` is pinned at 1.0 for 3m with running requests.

Incident: St. Petersburg SGLang 2026-08-31 01:28–01:33 UTC. Operational pod restart of `ai/qwen38` is separate and already in flight; this PR is GitOps only (no live apply).

## Test plan
- [x] `tools/check-cliproxy-pi-bridge.sh`
- [x] YAML parse of changed manifests
- [x] `kubectl kustomize` inference + cliproxy app (NEXTN gone, max-running-requests 3, max_tokens 8192, PrometheusRule present)
- [ ] CI flate gate on talos-stpetersburg and talos-ottawa
- [ ] After Flux: confirm qwen38 args and pi-bridge catalog