### PR TITLE
fix(dns): make forgejo.keiretsu.top resolvable in-cluster

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -446,13 +446,20 @@ Both live in `kubernetes/apps/base/k8gb/k8gb-common/config/cnames.yaml`.
 - Proxied through Cloudflare: the apex and `www` →
   `keiretsu.cdn.keiretsu.top`.
 - Pointed at `<name>.cdn.keiretsu.top`, i.e. answered by k8gb GSLB:
-  `forgejo`, `velero`, `hubble`, `logs`, `prometheus`, `opencost`, `oci`,
+  `velero`, `hubble`, `logs`, `prometheus`, `opencost`, `oci`,
   `status`, `s3`, `tailscale-logs.s3`.
 - Pointed at `ottawa.keiretsu.top`, i.e. straight to the Ottawa edge and
-  bypassing GSLB: `auth`, `home`, `bhaiya`, `grafana`, `teslamate`, `litellm`,
+  bypassing GSLB: `auth`, `home`, `bhaiya`, `forgejo`, `grafana`, `teslamate`, `litellm`,
   `woodpecker`, `infisical`, `frigate`, `monz`, `cliproxy`,
   `frigate.${LOCATION}`. `bhaiya` is pinned here on purpose — through the GSLB
-  the second WAN edge 404s about half the time.
+  the second WAN edge 404s about half the time. `forgejo` is pinned for the
+  same class of failure: public CNAME → `forgejo.cdn` follows k8gb NS
+  `ns1.dns.cdn.keiretsu.top` which has no A glue, so in-cluster lookups via
+  CoreDNS/NodeLocal (the `keiretsu.top` stub forwarded to a public recursor)
+  NXDOMAIN and Woodpecker cannot POST `/login/oauth/access_token`. Ottawa
+  CoreDNS/NodeLocal also answer `forgejo.keiretsu.top` as the public Envoy
+  Gateway VIP and forward `cdn.keiretsu.top` to the site k8gb CoreDNS VIP so
+  pods never wait on that glue.
 
 **`keiretsu-top-wildcards`** (labels `dns-target=cloudflare`,
 `dns-scope=public-only`):

--- a/kubernetes/apps/base/k8gb/k8gb-common/config/cnames.yaml
+++ b/kubernetes/apps/base/k8gb/k8gb-common/config/cnames.yaml
@@ -38,10 +38,14 @@ spec:
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"
+    # Pin to the Ottawa edge, not forgejo.cdn (k8gb). Recursors cache
+    # NS ns1.dns.cdn.keiretsu.top with no A glue, so the CNAME hop
+    # NXDOMAINs in-cluster and breaks Woodpecker's Forgejo OAuth token
+    # exchange. forgejo.cdn.keiretsu.top remains the GSLB name.
     - dnsName: "forgejo.${COMMON_DOMAIN}"
       recordType: CNAME
       targets:
-        - "forgejo.cdn.${COMMON_DOMAIN}"
+        - "ottawa.${COMMON_DOMAIN}"
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/kube-system/cilium-ottawa/config/coredns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/config/coredns.yaml
@@ -40,9 +40,26 @@ data:
       cache 30
       forward . 10.169.69.51
     }
+    # k8gb owns cdn.keiretsu.top (NS-delegated). Recursors cache NS
+    # ns1.dns.cdn.keiretsu.top with no A glue, so following the public
+    # CNAME forgejo → forgejo.cdn from 1.1.1.1 NXDOMAINs and breaks
+    # in-cluster OAuth (woodpecker-server → forgejo.keiretsu.top).
+    # Answer the delegated zone from the local k8gb CoreDNS VIP instead.
+    cdn.keiretsu.top:53 {
+      errors
+      cache 30
+      forward . 10.169.10.53
+    }
     keiretsu.top:53 {
       errors
       cache 30
+      # Split-horizon: pods must not hairpin the WAN VIP for Forgejo.
+      # forgejo-cdn HTTPRoute is on gateway/public (10.169.10.15).
+      hosts {
+        10.169.10.15 forgejo.keiretsu.top
+        ttl 30
+        fallthrough
+      }
       forward . 1.1.1.1
     }
     ts.net {

--- a/kubernetes/apps/base/kube-system/cilium-ottawa/config/nodelocaldns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/config/nodelocaldns.yaml
@@ -79,12 +79,26 @@ data:
       forward . 10.169.69.51
       prometheus :9253
     }
+    cdn.keiretsu.top:53 {
+      errors
+      cache 30
+      reload
+      loop
+      bind 0.0.0.0
+      forward . 10.169.10.53
+      prometheus :9253
+    }
     keiretsu.top:53 {
       errors
       cache 30
       reload
       loop
       bind 0.0.0.0
+      hosts {
+        10.169.10.15 forgejo.keiretsu.top
+        ttl 30
+        fallthrough
+      }
       forward . 1.1.1.1
       prometheus :9253
     }

--- a/kubernetes/apps/base/kube-system/cilium-robbinsdale/config/coredns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-robbinsdale/config/coredns.yaml
@@ -40,6 +40,11 @@ data:
       cache 30
       forward . 10.50.69.51
     }
+    cdn.keiretsu.top:53 {
+      errors
+      cache 30
+      forward . 10.50.10.53
+    }
     keiretsu.top:53 {
       errors
       cache 30

--- a/kubernetes/apps/base/kube-system/cilium-robbinsdale/config/nodelocaldns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-robbinsdale/config/nodelocaldns.yaml
@@ -79,6 +79,15 @@ data:
       forward . 10.50.69.51
       prometheus :9253
     }
+    cdn.keiretsu.top:53 {
+      errors
+      cache 30
+      reload
+      loop
+      bind 0.0.0.0
+      forward . 10.50.10.53
+      prometheus :9253
+    }
     keiretsu.top:53 {
       errors
       cache 30

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/coredns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/coredns.yaml
@@ -35,6 +35,11 @@ data:
             response set ra
         }
     }
+    cdn.keiretsu.top:53 {
+      errors
+      cache 30
+      forward . 10.73.10.53
+    }
     keiretsu.top:53 {
       errors
       cache 30

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/nodelocaldns.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/config/nodelocaldns.yaml
@@ -70,6 +70,15 @@ data:
         }
         prometheus :9253
         }
+    cdn.keiretsu.top:53 {
+      errors
+      cache 30
+      reload
+      loop
+      bind 0.0.0.0
+      forward . 10.73.10.53
+      prometheus :9253
+    }
     keiretsu.top:53 {
       errors
       cache 30


### PR DESCRIPTION
## Why

Woodpecker Forgejo OAuth is failing server-side:

```
Post "https://forgejo.keiretsu.top/login/oauth/access_token":
dial tcp: lookup forgejo.keiretsu.top on 10.2.0.10:53: no such host
```

Ottawa CoreDNS / NodeLocal stub `keiretsu.top` to a public recursor. The public CNAME is `forgejo` → `forgejo.cdn.keiretsu.top`. Recursors cache k8gb NS `ns1.dns.cdn.keiretsu.top` with **no A glue** (Cloudflare still publishes `ottawa`/`robbinsdale`/`stpetersburg` as NS). Following that CNAME NXDOMAINs in-cluster even while a laptop lookup sometimes succeeds.

## What

- Pin public `forgejo.keiretsu.top` CNAME at `ottawa.keiretsu.top` (same pattern as woodpecker/bhaiya). `forgejo.cdn` stays the GSLB name.
- Ottawa CoreDNS + NodeLocal: split-horizon A for `forgejo.keiretsu.top` → public Envoy Gateway VIP `10.169.10.15`.
- All three clusters: forward `cdn.keiretsu.top` to the site k8gb CoreDNS VIP (`*.10.53`) so pods never wait on glue-less NS.

No Tailscale CGNAT addresses in public DNS.

## Verify

`tools/check.sh` ✓ three clusters. `tools/check-diagram.sh` ✓.

After merge, from a woodpecker-namespace pod:
- `forgejo.keiretsu.top` A → `10.169.10.15` (Ottawa)
- `POST https://forgejo.keiretsu.top/login/oauth/access_token` no longer NXDOMAIN
- woodpecker-server logs drop `cannot authenticate user` / `no such host`