### PR TITLE
fix(ai): escape Qwen downloader constants for Flux

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
@@ -26,6 +26,7 @@ data:
     EXPECTED_MARKER="$${HF_REPO}@$${HF_REVISION}"
     EXPECTED_SHARDS=206
     EXPECTED_CONFIG_ARCHITECTURE="Qwen4ExpForConditionalGeneration"
+    export EXPECTED_SHARDS EXPECTED_CONFIG_ARCHITECTURE
 
     # The checkpoint's tokenizer_config.json still advertises the original
     # 262144-token window. SGLang is deliberately launched with the extended


### PR DESCRIPTION
## Summary
- export downloader constants before the embedded Python validation runs
- prevent Flux strict envsubst from treating `${EXPECTED_SHARDS}` and `${EXPECTED_CONFIG_ARCHITECTURE}` as deployment variables

## Verification
- `./tools/check.sh sp`
- `git diff --check`
- observed live ai-inference Kustomization failure after PR 2580: `variable not set (strict mode): "EXPECTED_SHARDS"`