### PR TITLE
monitoring: surface Kata sandbox loss before sessions disappear

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
@@ -44,8 +44,10 @@ groups:
   - name: kata-virtiofs.rules
     rules:
       # A fixed Nix workspace image can legitimately use roughly 30% of the
-      # daemon's FD limit for its overlay-backed rootfs. The thresholds leave
-      # that bounded baseline alone while detecting the old unbounded PVC path.
+      # daemon's FD limit for its overlay-backed rootfs. A level-only signal is
+      # deliberately warning: the incident data showed a steady ~57% plateau
+      # without proving that the level caused the sandbox loss. Growth and an
+      # observed termination are the high-salience signals below.
       - alert: KataVirtioFSFileDescriptorPressure
         expr: |
           (
@@ -62,8 +64,55 @@ groups:
           summary: >-
             Kata virtio-fs for {{ $labels.namespace }}/{{ $labels.pod }} is using
             {{ printf "%.0f" $value }}% of its file-descriptor limit.
+          description: >-
+            This is a level-only signal, not proof of an imminent sandbox loss.
+            Check KataVirtioFSFileDescriptorGrowth for a rising signal and
+            inspect the sandbox/node before it becomes unavailable. If the
+            workspace is degraded, restart-to-remount is the recovery; do not
+            reset or recreate the workspace because those paths can discard the
+            PVC.
         labels:
           severity: warning
+
+      - alert: KataVirtioFSFileDescriptorGrowth
+        expr: |
+          (
+            deriv(
+              (
+                max by (cluster, namespace, pod) (
+                  container_file_descriptors{namespace="bhaiya",pod=~"sandbox-.+"}
+                )
+                /
+                max by (cluster, namespace, pod) (
+                  container_ulimits_soft{namespace="bhaiya",pod=~"sandbox-.+",ulimit="max_open_files"}
+                )
+              )[30m:]
+            ) * 100 * 60 > 1
+          )
+          and
+          (
+            (
+              max by (cluster, namespace, pod) (
+                container_file_descriptors{namespace="bhaiya",pod=~"sandbox-.+"}
+              )
+              /
+              max by (cluster, namespace, pod) (
+                container_ulimits_soft{namespace="bhaiya",pod=~"sandbox-.+",ulimit="max_open_files"}
+              )
+            ) * 100 > 25
+          )
+        for: 5m
+        annotations:
+          summary: >-
+            Kata virtio-fs for {{ $labels.namespace }}/{{ $labels.pod }} is
+            climbing at {{ printf "%.1f" $value }} percentage points per minute.
+          description: >-
+            Inspect the sandbox and its node now; this alert detects sustained
+            growth rather than a steady file-descriptor level. If the workspace
+            is degraded, restart-to-remount is the recovery; do not reset or
+            recreate the workspace because those paths can discard the PVC.
+        labels:
+          severity: critical
 
       - alert: KataVirtioFSFileDescriptorCritical
         expr: |
@@ -81,6 +130,57 @@ groups:
           summary: >-
             Kata virtio-fs for {{ $labels.namespace }}/{{ $labels.pod }} is using
             {{ printf "%.0f" $value }}% of its file-descriptor limit.
+          description: >-
+            Treat this sustained high level as urgent and inspect the Kata
+            runtime/node. If the workspace is degraded, restart-to-remount is
+            the recovery; do not reset or recreate the workspace because those
+            paths can discard the PVC.
+        labels:
+          severity: critical
+
+      # kube-state-metrics and the event exporter do not expose SandboxChanged,
+      # Dead agent, or missing clh.sock as Prometheus metrics. The observed
+      # failure did leave an actionable proxy: the Kata workspace container's
+      # last termination became Error/exit 255. Keep this bounded to recent
+      # terminations so the last-termination gauge does not page forever.
+      - alert: KataSandboxExit255
+        expr: |
+          (
+            (
+              kube_pod_container_status_last_terminated_exitcode{
+                namespace="bhaiya",pod=~"sandbox-.+",container="workspace"
+              } == 255
+            )
+            and on (cluster, namespace, pod, uid)
+            kube_pod_container_status_last_terminated_reason{
+              namespace="bhaiya",pod=~"sandbox-.+",container="workspace",reason="Error"
+            }
+          )
+          and on (cluster, namespace, pod, uid)
+          max by (cluster, namespace, pod, uid) (
+            kube_pod_runtimeclass_name_info{
+              namespace="bhaiya",pod=~"sandbox-.+",runtimeclass_name=~"kata-.*"
+            }
+          )
+          and on (cluster, namespace, pod, uid)
+          (
+            time()
+            - kube_pod_container_status_last_terminated_timestamp{
+                namespace="bhaiya",pod=~"sandbox-.+",container="workspace"
+              }
+            < 15 * 60
+          )
+        for: 0m
+        annotations:
+          summary: >-
+            Kata sandbox {{ $labels.namespace }}/{{ $labels.pod }} terminated
+            its workspace container with exit code 255.
+          description: >-
+            kube-state-metrics does not retain the exact SandboxChanged, Dead
+            agent, or missing clh.sock event name; inspect pod events and
+            Kata/containerd logs to identify the cause. Restart-to-remount is
+            the recovery; do not reset or recreate the workspace because those
+            paths can discard the PVC.
         labels:
           severity: critical
 


### PR DESCRIPTION
## Summary

- Add `KataVirtioFSFileDescriptorGrowth`, a critical alert for sustained FD-utilization growth above 1 percentage point per minute once utilization is above 25%.
- Add `KataSandboxExit255`, a critical recent-termination alert for the observed Kata workspace `Error`/exit-255 signature.
- Add runbook-style descriptions to all Kata alerts with the restart-to-remount recovery and the warning not to reset/recreate workspaces.

## Evidence and scope

Related incident: [corp/bhaiya#328](https://forgejo.keiretsu.top/corp/bhaiya/issues/328), especially comments [2969](https://forgejo.keiretsu.top/corp/bhaiya/issues/328#issuecomment-2969), [2976](https://forgejo.keiretsu.top/corp/bhaiya/issues/328#issuecomment-2976), and [2978](https://forgejo.keiretsu.top/corp/bhaiya/issues/328#issuecomment-2978).

Mimir metric discovery on `mimir-ottawa` confirmed `container_file_descriptors`, `container_ulimits_soft`, `kube_pod_container_status_last_terminated_exitcode`, `kube_pod_container_status_last_terminated_reason`, `kube_pod_container_status_last_terminated_timestamp`, and `kube_pod_runtimeclass_name_info`. The historical query at 2026-09-01 02:26Z showed the affected sandbox containers at `Error`/exit `255`, including `sandbox-raj-codes`, and the recent timestamp join evaluates correctly. The growth query evaluates during the earlier FD step and is empty during the later steady plateau.

No metric exists for the exact `SandboxChanged`, `Dead agent`, or missing `clh.sock` event, and kube-state-metrics exposes only generic termination reasons (`Completed`, `Error`, `OOMKilled`). The new exit-255 rule therefore uses the observed downstream proxy and explicitly directs operators to pod events and Kata/containerd logs for the exact cause; it does not invent a nonexistent event metric.

Alert delivery is intentionally unchanged. Existing Mimir-to-Alertmanager wiring, severity routing, and Discord receiver remain in place.

## Severity decision

The existing >50% level-only alert remains `warning` deliberately: the corrected incident evidence shows a steady ~57% plateau is not by itself proof of imminent loss. Critical severity is reserved for the actionable growth signal, the existing >75% level, and the observed recent exit-255 termination.

## Validation

- YAML parsing and targeted alert-structure assertions pass.
- Exact new PromQL expressions were accepted by Mimir queries.
- `tools/check.sh talos-ottawa` and the full `tools/check.sh` were run. The local render environment currently fails on unrelated pre-existing chart/config readiness issues (`blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, `homer-operator`, and a St. Petersburg Cilium cluster-name validation); the changed rule file itself parses cleanly.

Do not reset or recreate an affected workspace: restart-to-remount is the recovery, because reset/recreate can discard the PVC.