### PR TITLE
monitoring: add Ceph alerts and node-labelled Talos logs

### DIFF
--- a/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
+++ b/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
@@ -41,6 +41,10 @@ spec:
             Format      json
             Chunk_Size  32KB
             Buffer_Size 128KB
+            # Talos JSON does not include a hostname. Fluent Bit 5.1.1's TCP
+            # input records the peer address without changing collection or
+            # applying a relabel/drop rule.
+            Source_Address_Key node_address
 
       filters: |
         [FILTER]
@@ -86,7 +90,7 @@ spec:
             Uri                    /insert/loki/api/v1/push
             header                 VL-Msg-Field msg
             labels                 cluster=${CLUSTER_NAME}, job=talos
-            label_keys             $talos-service
+            label_keys             $talos-service,$node_address
             line_format            json
             compress               gzip
     extraPorts:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -20,6 +20,7 @@ configMapGenerator:
     files:
       - rules/bhaiya.yaml
       - rules/blackbox.yaml
+      - rules/ceph.yaml
       - rules/flux.yaml
       - rules/garage.yaml
       - rules/k8gb.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -35,6 +35,7 @@ spec:
             - --id=talos-ottawa
             - /rules/bhaiya.yaml
             - /rules/blackbox.yaml
+            - /rules/ceph.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
@@ -58,6 +59,7 @@ spec:
             - --id=talos-robbinsdale
             - /rules/bhaiya.yaml
             - /rules/blackbox.yaml
+            - /rules/ceph.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
@@ -77,6 +79,7 @@ spec:
             - --id=talos-stpetersburg
             - /rules/bhaiya.yaml
             - /rules/blackbox.yaml
+            - /rules/ceph.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
@@ -60,7 +60,7 @@ groups:
           ) > 0.80
         for: 15m
         annotations:
-          summary: Ceph cluster is above 80% used ({{ printf "%.1f" ($value * 100) }}%)
+          summary: Ceph cluster is above 80% used ({{ $value | humanizePercentage }})
           description: >-
             Ceph storage has been above 80% used for 15 minutes. This is an
             early warning ahead of the configured nearfull boundary; account

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
@@ -1,0 +1,139 @@
+# Ceph alerts use actionable conditions rather than the aggregate health status.
+# BLUESTORE_SLOW_OP_ALERT is currently latched at HEALTH_WARN while slow ops,
+# OSD availability, and PG health remain clear, so ceph_health_status > 0 would
+# create a permanently firing alert without identifying an active failure.
+namespace: monitoring
+groups:
+  - name: ceph.rules
+    rules:
+      - alert: CephSlowOps
+        expr: |
+          max by (cluster) (ceph_healthcheck_slow_ops) > 0
+        for: 10m
+        annotations:
+          summary: Ceph is reporting blocked slow operations
+          description: >-
+            Ceph has reported one or more slow operations for 10 minutes.
+            Inspect ceph health detail, the affected clients, and OSD latency.
+            This is the actionable slow-operation signal; do not infer it from
+            the latched BLUESTORE_SLOW_OP_ALERT warning.
+        labels:
+          severity: critical
+
+      - alert: CephOSDDown
+        expr: |
+          min by (cluster, ceph_daemon) (ceph_osd_up) == 0
+        for: 10m
+        annotations:
+          summary: Ceph OSD {{ $labels.ceph_daemon }} is down
+          description: >-
+            OSD {{ $labels.ceph_daemon }} has been reported down for 10
+            minutes. Check Ceph quorum, the OSD pod, and the underlying disk
+            before recovery or replacement actions.
+        labels:
+          severity: critical
+
+      - alert: CephPGsUnhealthy
+        expr: |
+          (
+            sum by (cluster) (ceph_pg_down)
+            + sum by (cluster) (ceph_pg_incomplete)
+            + sum by (cluster) (ceph_pg_inconsistent)
+          ) > 0
+        for: 10m
+        annotations:
+          summary: Ceph has unhealthy placement groups
+          description: >-
+            Ceph has reported one or more down, incomplete, or inconsistent
+            placement groups for 10 minutes. Check Ceph health detail and PG
+            state before treating workspace or stateful-workload errors as
+            application failures.
+        labels:
+          severity: critical
+
+      - alert: CephClusterNearFull
+        expr: |
+          (
+            max by (cluster) (ceph_cluster_total_used_bytes)
+            /
+            max by (cluster) (ceph_cluster_total_bytes)
+          ) > 0.80
+        for: 15m
+        annotations:
+          summary: Ceph cluster is above 80% used ({{ printf "%.1f" ($value * 100) }}%)
+          description: >-
+            Ceph storage has been above 80% used for 15 minutes. This is an
+            early warning ahead of the configured nearfull boundary; account
+            for stranded or undeletable PVC data when planning reclamation.
+        labels:
+          severity: warning
+
+      - alert: CephHealthError
+        expr: |
+          max by (cluster) (ceph_health_status) == 2
+        for: 5m
+        annotations:
+          summary: Ceph health is HEALTH_ERR
+          description: >-
+            Ceph has reported HEALTH_ERR for 5 minutes. Inspect ceph health
+            detail and the active failure before acknowledging the alert. The
+            HEALTH_WARN state is intentionally not paged because the current
+            warning includes a known latched check.
+        labels:
+          severity: critical
+
+  - name: bhaiya-sandbox.rules
+    rules:
+      # kube_pod_labels is exported by two opencost targets in this tenant, so
+      # deduplicate it before joining to kube_pod_info. Alert only on a drop
+      # from at least two nodes to one; the current one-node exposure is known
+      # and should not create a permanently firing alert on first load.
+      - alert: BhaiyaSandboxNodeConcentration
+        expr: |
+          (
+            count by (cluster) (
+              count by (cluster, node) (
+                kube_pod_info{
+                  namespace="bhaiya",
+                  created_by_kind="Sandbox",
+                  node!=""
+                }
+                * on (cluster, namespace, pod, uid) group_left()
+                max by (cluster, namespace, pod, uid) (
+                  kube_pod_labels{
+                    namespace="bhaiya",
+                    label_bhaiya_corp_workload="workspace"
+                  }
+                )
+              )
+            ) < 2
+          )
+          and on (cluster)
+          (
+            count by (cluster) (
+              count by (cluster, node) (
+                kube_pod_info{
+                  namespace="bhaiya",
+                  created_by_kind="Sandbox",
+                  node!=""
+                } offset 1h
+                * on (cluster, namespace, pod, uid) group_left()
+                max by (cluster, namespace, pod, uid) (
+                  kube_pod_labels{
+                    namespace="bhaiya",
+                    label_bhaiya_corp_workload="workspace"
+                  } offset 1h
+                )
+              )
+            ) >= 2
+          )
+        for: 10m
+        annotations:
+          summary: Bhaiya workspace sandboxes are concentrated on one node
+          description: >-
+            The distinct-node count for workspace Sandboxes dropped below two
+            after being at least two an hour earlier. Check scheduler placement
+            and restore node diversity before a single-node event takes down
+            the fleet.
+        labels:
+          severity: warning


### PR DESCRIPTION
Closes #2599
Closes #2600

## Summary

- Add actionable Ceph alerts to the Mimir rule loader:
  - slow operations
  - per-OSD down state
  - down/incomplete/inconsistent placement groups
  - cluster capacity above 80%
  - HEALTH_ERR only
- Add a transition-aware BhaiyaSandboxNodeConcentration alert for a drop from at least two nodes to one.
- Add the Fluent Bit TCP peer address as the node_address label on Talos logs.

The existing aggregate ceph_health_status > 0 trap is intentionally not used. The current BLUESTORE_SLOW_OP_ALERT is latched at HEALTH_WARN while actionable Ceph conditions are clear.

## Mimir verification

I queried mimir-ottawa with the exact alert expressions before shipping them:

| Alert | Expression result now |
| --- | --- |
| CephSlowOps | ceph_healthcheck_slow_ops = 0; predicate returns no series |
| CephOSDDown | all 14 ceph_osd_up series are 1; predicate returns no series |
| CephPGsUnhealthy | ceph_pg_down, ceph_pg_incomplete, and ceph_pg_inconsistent are all 0; predicate returns no series |
| CephClusterNearFull | ceph_cluster_total_used_bytes / ceph_cluster_total_bytes = 0.1009 (10.1%); 80% predicate returns no series |
| CephHealthError | ceph_health_status = 1 (HEALTH_WARN); == 2 predicate returns no series |

The optional sandbox expression is also verified. It sees 11 workspace Sandboxes on one node now. Its transition-aware predicate returns no series because the count was already one node an hour earlier, so it does not arrive as a permanently firing alert.

## Node labels

Fluent Bit chart 0.58.1 uses Fluent Bit image 5.1.1. The upstream 5.1.1 TCP input supports Source_Address_Key; it injects the TCP peer address into each JSON record. The Talos Loki output promotes that field as node_address.

This is deliberately an address label rather than a synthesized hostname: it is the node identity available at the log-pipeline boundary and can be correlated with Kubernetes node InternalIP. No collection, retention, routing, relabel/drop, or duplicate-series behavior was changed. Dedicated Kata shim, Cloud Hypervisor, and virtiofsd lifecycle streams are still not shipped separately; this change leaves that out-of-scope gap visible.

## Validation

- YAML parsing and git diff --check pass.
- tools/check.sh talos-ottawa and tools/check.sh were run. The changed mimir and fluent-bit resources render successfully; local rendering still exits on the documented pre-existing unrelated failures involving blackbox-exporter, grafana-operator, kube-prometheus-stack, smartctl-exporter, homer-operator, and St. Petersburg Cilium cluster-name validation.
- PR #2598 was already merged before this branch and changed only kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml; this PR does not modify that file.