### PR TITLE
monitoring: give ceph rules a unique Mimir namespace

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
@@ -2,7 +2,11 @@
 # BLUESTORE_SLOW_OP_ALERT is currently latched at HEALTH_WARN while slow ops,
 # OSD availability, and PG health remain clear, so ceph_health_status > 0 would
 # create a permanently firing alert without identifying an active failure.
-namespace: monitoring
+#
+# The namespace must be unique across every file listed in loader-job.yaml.
+# mimirtool rejects the ENTIRE sync with "repeated namespace attempted to be
+# loaded" if two loaded files share one, which silently blocks all rule updates.
+namespace: ceph
 groups:
   - name: ceph.rules
     rules:


### PR DESCRIPTION
#2603 declared `namespace: monitoring` in ceph.yaml, which monitoring.yaml
already uses. mimirtool rejects the entire sync when two loaded files share a
namespace, so mimir-config-loader has been failing since that merge:

  level=error msg="repeated namespace attempted to be loaded"
            namespace=monitoring file=/rules/monitoring.yaml
  mimirtool: error: sync operation unsuccessful, unable to parse rules files

Six loader pods in Error, 0/1 completions. No rule updates were reaching the
ruler for any cluster — the new Ceph and sandbox-concentration alerts were not
live, and no future rule change would have applied either. Already-loaded rules
kept evaluating, so this was silent.

Every other loaded file already uses a unique namespace (bhaiya-fleet, blackbox,
flux, garage, k8gb, bhaiya, smartctl, zot). node-health.yaml also declares
`monitoring` but is absent from loader-job.yaml, which is why the collision only
appeared now.

Verified no namespace is duplicated across the eleven files listed in
loader-job.yaml, and added a comment recording the constraint so the next rule
file does not repeat it.

## Impact

`mimir-config-loader` has been failing since #2603 merged — six pods in `Error`, `0/1` completions. This blocks **all** rule updates for every cluster, not just the new Ceph rules. Already-loaded rules keep evaluating, which is why nothing alerted about it.

## Verification

```
bhaiya.yaml   -> bhaiya-fleet     garage.yaml   -> garage      payments.yaml -> bhaiya
blackbox.yaml -> blackbox         k8gb.yaml     -> k8gb        smartctl.yaml -> smartctl
ceph.yaml     -> ceph  (was monitoring)          zot.yaml      -> zot
flux.yaml     -> flux             media.yaml    -> (none)      monitoring.yaml -> monitoring

DUPLICATES: none
```

Rules and alerts unchanged: `ceph.rules` (CephSlowOps, CephOSDDown, CephPGsUnhealthy, CephClusterNearFull, CephHealthError) and `bhaiya-sandbox.rules` (BhaiyaSandboxNodeConcentration).

## Follow-ups, not in scope here

- `node-health.yaml` declares rules (NodeKernelDeadlock, NodeReadonlyFilesystem) but is **absent from loader-job.yaml**, so those alerts are inert.
- `media.yaml` declares no namespace at all.
- Nothing detects this failure mode. A completed-Job or loader-success check would have surfaced it immediately instead of leaving rule sync silently broken.