### PR TITLE
feat(monitoring): alert on provider fence availability

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya.yaml
@@ -4,8 +4,8 @@
 # in the bhaiya namespace apply cleanly and then never fire. They live here
 # instead, alongside rules/payments.yaml which already followed this pattern.
 #
-# Covers the control plane, the MCP and SSH edges, payments, CNPG, and the
-# OpenCost cost pipeline.
+# Covers the control plane, provider-fence, the MCP and SSH edges, payments,
+# CNPG, and the OpenCost cost pipeline.
 #
 # The Mimir rule namespace below must be unique across every file listed in
 # loader-job.yaml: mimirtool rejects the whole sync with "repeated namespace
@@ -16,6 +16,58 @@ namespace: bhaiya-fleet
 groups:
 - name: bhaiya.fleet.availability
   rules:
+  - alert: BhaiyaProviderFenceUnavailable
+    expr: |
+      kube_deployment_spec_replicas{
+        namespace="bhaiya",
+        deployment="bhaiya-provider-fence"
+      } > 0
+      and on(namespace, deployment)
+      kube_deployment_status_replicas_available{
+        namespace="bhaiya",
+        deployment="bhaiya-provider-fence"
+      } < 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Bhaiya provider fence has no available replica
+      description: >-
+        The provider-fence Deployment is configured to run but has no
+        available replica. Its fail-closed webhook can reject Bhaiya mutations;
+        inspect pod readiness, Deployment events, and the active rollout.
+  - alert: BhaiyaProviderFenceRolloutStalled
+    expr: |
+      kube_deployment_status_condition{
+        namespace="bhaiya",
+        deployment="bhaiya-provider-fence",
+        condition="Progressing",
+        status="false",
+        reason="ProgressDeadlineExceeded"
+      } == 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Bhaiya provider-fence rollout is stalled
+      description: >-
+        Kubernetes has not observed progress for the provider-fence rollout
+        within its deadline. Because its webhook fails closed, inspect image
+        availability, readiness, TLS, and Deployment events immediately.
+  - alert: BhaiyaProviderFencePDBAtRisk
+    expr: |
+      kube_poddisruptionbudget_status_current_healthy{
+        namespace="bhaiya",
+        poddisruptionbudget="bhaiya-provider-fence"
+      } < 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Bhaiya provider-fence disruption budget is unavailable
+      description: >-
+        The provider-fence PDB has had no healthy pod for 5 minutes; voluntary
+        disruption protection cannot preserve the fail-closed admission path.
   - alert: BhaiyaServiceNoReadyReplicas
     expr: |
       (


### PR DESCRIPTION
## Summary

- Add `BhaiyaProviderFenceUnavailable` for zero available replicas.
- Add `BhaiyaProviderFenceRolloutStalled` for a failed progressing condition.
- Add `BhaiyaProviderFencePDBAtRisk` for loss of the one-pod disruption floor.
- Keep the existing `rules/bhaiya.yaml` loader wiring; no `loader-job.yaml` or Ceph changes.

The provider-fence webhook fails closed, so an unavailable Deployment can reject Bhaiya workspace mutations and cleanup. These alerts provide an early signal before that control-plane outage is discovered indirectly.

Companion: corp/bhaiya PR #377 adds the provider-fence PDB these rules monitor.

## Validation

- YAML parsed successfully with `yq`.
- The alert expressions were queried against the `mimir-ottawa` datasource; the healthy current state returns no firing vectors.
- `tools/check.sh talos-ottawa` ran 107 checks successfully but is blocked by five unrelated missing Helm dependencies and two skipped GitRepository secrets in this checkout.
- `tools/check.sh --quick` is blocked by the pre-existing missing `kubernetes/apps/base/agent-sandbox/agent-sandbox/kustomization.yaml` path.