### PR TITLE
monitoring: alert on Ceph OSD watch timeouts

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/ceph.yaml
@@ -24,6 +24,22 @@ groups:
         labels:
           severity: critical
 
+      - alert: CephOSDWatchTimeouts
+        expr: |
+          sum by (cluster) (increase(ceph_osd_watch_timeouts[5m])) > 0
+        annotations:
+          summary: Ceph OSD watch timeouts or blocklists detected
+          description: >-
+            The Ceph OSD watch-timeout counter increased by {{ $value | humanize
+            }} in the last 5 minutes. This detects a storage/runtime event
+            already in progress; it cannot prevent the first Kata sandbox
+            timeout. Check whether workspaces are being torn down and inspect
+            Ceph, RBD, and node runtime logs. Restart an affected workspace to
+            remount its volumes; never reset or recreate it, because that can
+            discard the PVC.
+        labels:
+          severity: critical
+
       - alert: CephOSDDown
         expr: |
           min by (cluster, ceph_daemon) (ceph_osd_up) == 0


### PR DESCRIPTION
## Summary

- Add `CephOSDWatchTimeouts` to the existing `ceph.rules` group.
- Alert on the counter's five-minute increase, not its absolute value:
  `sum by (cluster) (increase(ceph_osd_watch_timeouts[5m])) > 0`.
- Keep the rule in the existing `ceph` namespace, so no loader or Kustomize wiring changes are needed.

## Detection evidence

Mimir verification for `mimir-ottawa` found that `ceph_osd_watch_timeouts` is a counter (“Number of watches that timed out or were blocklisted”):

- Current `sum(ceph_osd_watch_timeouts)`: 18.
- Current `sum(increase(ceph_osd_watch_timeouts[5m]))`: 0, so the alert is quiet on arrival.
- The preceding seven-day hourly increase was zero except for the September 1 incident.
- During that incident the total was 0 through 02:24:45Z, 11 at 02:25:00Z, and 18 at 02:25:15Z.

This is an in-progress cascade detector, not a preventive warning: no exposed signal warned before the first Kata sandbox timeout. The annotation tells the responder to check for sandbox teardown and use restart-to-remount recovery. It explicitly says never to reset or recreate an affected workspace because that can discard its PVC.

I did not add a duplicate kernel-log alert. The metric is cleaner, avoids log-ingestion delay, and avoids alert fatigue from a second rule for the same event.

## Validation

- `kustomize build --enable-helm kubernetes/apps/base/mimir/mimir-ottawa` passed.
- YAML/query structure validation and `git diff --check` passed.
- `tools/check.sh talos-ottawa` and the full `tools/check.sh` were attempted locally; both reached the repository render gate and were terminated by its 120-second cap under the currently oversubscribed host. This is incomplete local validation, not a pass. The changed file renders cleanly; the known unrelated local render failures are blackbox-exporter, grafana-operator, kube-prometheus-stack, smartctl-exporter, homer-operator, and the St. Petersburg Cilium cluster-name validation. GitHub CI is the merge gate.

No cluster mutation was performed; Flux remains the loading path. Related investigation: corp/bhaiya#328.