### PR TITLE
fix(monitoring): detect Mimir rule loader failures

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -25,7 +25,9 @@ configMapGenerator:
       - rules/garage.yaml
       - rules/k8gb.yaml
       - rules/media.yaml
+      - rules/mimir-loader.yaml
       - rules/monitoring.yaml
+      - rules/node-health.yaml
       - rules/payments.yaml
       - rules/smartctl.yaml
       - rules/zot.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -40,7 +40,9 @@ spec:
             - /rules/garage.yaml
             - /rules/k8gb.yaml
             - /rules/media.yaml
+            - /rules/mimir-loader.yaml
             - /rules/monitoring.yaml
+            - /rules/node-health.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/zot.yaml
@@ -64,7 +66,9 @@ spec:
             - /rules/garage.yaml
             - /rules/k8gb.yaml
             - /rules/media.yaml
+            - /rules/mimir-loader.yaml
             - /rules/monitoring.yaml
+            - /rules/node-health.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/zot.yaml
@@ -84,7 +88,9 @@ spec:
             - /rules/garage.yaml
             - /rules/k8gb.yaml
             - /rules/media.yaml
+            - /rules/mimir-loader.yaml
             - /rules/monitoring.yaml
+            - /rules/node-health.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/zot.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
@@ -1,0 +1,59 @@
+# The single loader Job has one container per Mimir tenant. Its Job status is
+# therefore the aggregate signal for rule delivery to Ottawa, Robbinsdale, and
+# St. Petersburg. Keep this namespace unique across every file passed to
+# mimirtool: one repeated namespace aborts the entire sync for every tenant.
+namespace: mimir-loader
+groups:
+  - name: mimir-rule-loader.rules
+    rules:
+      - alert: MimirRuleLoaderFailing
+        expr: |
+          max by (cluster, namespace, job_name) (
+            kube_job_status_failed{
+              namespace="mimir",
+              job_name=~"mimir-config-loader.*"
+            }
+          ) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Mimir rule loader Job is failing
+          description: >-
+            The mimir-config-loader Job has failed. Its three tenant sync
+            containers deliver every native rule group to the Ottawa,
+            Robbinsdale, and St. Petersburg Mimir rulers; inspect the Job and
+            its logs before relying on a newly changed alert.
+
+      - alert: MimirRuleLoaderStale
+        expr: |
+          (
+            time() - max by (cluster, namespace, job_name) (
+              max_over_time(
+                kube_job_status_completion_time{
+                  namespace="mimir",
+                  job_name=~"mimir-config-loader.*"
+                }[24h]
+              )
+            ) > 24 * 60 * 60
+          )
+          or
+          (
+            absent_over_time(
+              kube_job_status_completion_time{
+                namespace="mimir",
+                job_name=~"mimir-config-loader.*"
+              }[24h]
+            )
+            and on ()
+            (count(kube_node_info{cluster="talos-ottawa"}) > 0)
+          )
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Mimir rule loader has not completed successfully in 24 hours
+          description: >-
+            No successful mimir-config-loader completion has been observed in
+            the last 24 hours. This also covers the loader Job not being
+            created; inspect Flux, the Job, and the three tenant sync logs.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
@@ -239,25 +239,6 @@ groups:
   # GPU rules are inert on Ottawa/Robbinsdale because DCGM families are absent.
   # St. Petersburg is the only current NVIDIA/DCGM cluster; do not add GPU
   # scrape requirements to CPU-only nodes or to the Intel-plugin cluster.
-  # Node-health rules live in this file too so mimirtool receives one namespace
-  # per tenant and cannot reject a repeated namespace file.
-  - name: node-health.rules
-    rules:
-      - alert: NodeKernelDeadlock
-        expr: kube_node_status_condition{condition="KernelDeadlock",status="true"} == 1
-        for: 10m
-        labels:
-          severity: critical
-        annotations:
-          summary: Kernel deadlock reported on node {{ $labels.node }}
-      - alert: NodeReadonlyFilesystem
-        expr: kube_node_status_condition{condition="ReadonlyFilesystem",status="true"} == 1
-        for: 10m
-        labels:
-          severity: critical
-        annotations:
-          summary: Read-only filesystem reported on node {{ $labels.node }}
-
   - name: gpu.rules
     rules:
       - record: node_gpu_temperature_celsius:max

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
@@ -1,7 +1,8 @@
 # Node health alerts for the NPD conditions written by the v0.8.19
 # node-problem-detector DaemonSet. These rules are evaluated by Mimir ruler;
 # node-readiness-controller independently applies only a NoSchedule taint.
-namespace: monitoring
+# Keep this namespace unique across every file passed to mimirtool.
+namespace: node-health
 groups:
   - name: node-health.rules
     rules:


### PR DESCRIPTION
Closes #2605.

Adds MimirRuleLoaderFailing and MimirRuleLoaderStale in the unique mimir-loader namespace. The failed signal aggregates the kube-state-metrics Job series; the stale signal uses the last 24 hours of kube_job_status_completion_time plus an absence branch for a loader Job that is no longer created. The absence branch is gated to the Ottawa tenant because mimir-config-loader is one Ottawa Job with three tenant-sync containers.

Activates rules/node-health.yaml under the unique node-health namespace, moves its duplicate group out of monitoring.yaml, and adds both rule files to the ConfigMap generator and all three tenant container argument lists. The loaded namespace set remains unique; media.yaml has no explicit namespace and is intentionally unchanged.

Live verification before the change found kube_job_status_failed, kube_job_status_active, kube_job_status_succeeded, and kube_job_status_completion_time in all three Mimir datasources. Ottawa's current loader was succeeded=1, failed=0; both prospective alert expressions returned no firing series in all three datasources. The current successful loader and Mimir rules API also confirm mimirtool accepts media.yaml without an explicit namespace.

Local tools/check.sh talos-ottawa timed out twice with Flate exit 124 and the full check timed out with the same wedge; these are validation-incomplete, not passes. tools/check.sh --quick stopped at the pre-existing missing kustomization under kubernetes/apps/base/agent-sandbox/agent-sandbox before reaching Mimir. GitHub CI is the merge gate.