### PR TITLE
fix(logging): map Talos syslog bodies into VictoriaLogs messages

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1141,9 +1141,13 @@ One per cluster.
   `talconfig.yaml`, and **Robbinsdale does not** — so Robbinsdale contributes
   service logs but no kernel logs, and an empty kernel view for those nodes is
   expected rather than a broken collector
-- **filters** — kubernetes metadata, then `nest`
+- **filters** — kubernetes metadata, then `nest`; for `syslogd` records, the
+  existing `content` field is copied to `msg` so the normal Talos output can
+  select it without re-emitting the record
 - **outputs** — two loki-protocol outputs to `${VICTORIA_LOGS_HOST}:9428`,
-  gzip, with `VL-Msg-Field log` for `kube.*` and `msg` for `talos.*`
+  gzip, with `VL-Msg-Field log` for `kube.*` and `msg` for `talos.*`; the
+  Talos output promotes its existing `tag` field (such as `kata` or
+  `virtiofsd`) as a stream label
 
 ### Grafana — single pane, Ottawa only
 

--- a/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
+++ b/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
@@ -67,6 +67,16 @@ spec:
             Nested_under kubernetes
             Add_prefix   kubernetes.
 
+        # Most Talos JSON records put their body in `msg`, but syslogd wraps
+        # the original syslog body in `content`. Copy it only for syslogd so
+        # the existing Loki output can select the right field without
+        # re-emitting or dropping the original record.
+        [FILTER]
+            Name         modify
+            Match        talos.*
+            Condition    Key_Value_Equals talos-service syslogd
+            Hard_copy    content msg
+
       outputs: |
         [OUTPUT]
             Name                   loki
@@ -90,7 +100,7 @@ spec:
             Uri                    /insert/loki/api/v1/push
             header                 VL-Msg-Field msg
             labels                 cluster=${CLUSTER_NAME}, job=talos
-            label_keys             $talos-service,$node_address
+            label_keys             $talos-service,$node_address,$tag
             line_format            json
             compress               gzip
     extraPorts:


### PR DESCRIPTION
## Summary

Talos `syslogd` records arrive as JSON with their original body in `content`, while the Fluent Bit Loki output tells VictoriaLogs to read `msg`. VictoriaLogs therefore stores the body under `content` and synthesizes a missing-message placeholder for `_msg`.

This change:

- conditionally copies `content` to `msg` only when `talos-service=syslogd`;
- promotes the existing syslogd `tag` (`kata`, `virtiofsd`, etc.) as a Loki stream label;
- preserves the existing collection path, retention, and record fields; and
- documents the mapping.

The conditional in-place copy avoids a rewrite/re-emission path, so it does not intentionally drop or duplicate records.

## Evidence

Before this change, incident-window records had `_msg` set to VictoriaLogs’ missing-field placeholder, while the complete body was present in `content`; current post-#2603 records show the same behavior with `node_address` present. The `_msg` issue predates #2603: #2603 added only `Source_Address_Key node_address` and the matching label key, not `VL-Msg-Field msg`.

Historical records remain diagnosable through `content`, but ingestion configuration cannot rewrite already-retained records. New records will have a proper `_msg`; existing records will retain their old shape.

## Validation

- `helm lint` against Fluent Bit chart 0.58.1 / app 5.1.1: passed.
- `git diff --check`: passed.
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh talos-ottawa`: completed normally; failed on pre-existing missing chart/value dependencies (`blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, `homer-operator`).
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh`: completed normally; stopped on the same pre-existing Ottawa fixture failures. No timeout was treated as a pass.
- No cluster mutation was performed.