### PR TITLE
fix(garage): scope cluster-wide keys to required buckets

### DIFF
--- a/kubernetes/apps/base/garage/garage-bucket/key.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/key.yaml
@@ -7,9 +7,35 @@ spec:
   clusterRef:
     name: garage
   name: "WebUI Sidecar Key"
-  allBuckets:
-    read: true
-    write: true
+  bucketPermissions:
+    - bucketRef:
+        name: tracearr-postgres
+      read: true
+      write: true
+    - bucketRef:
+        name: immich-postgres
+      read: true
+      write: true
+    - bucketRef:
+        name: tailscale-logs
+      read: true
+      write: true
+    - bucketRef:
+        name: mimir
+      read: true
+      write: true
+    - bucketRef:
+        name: bookorbit-postgres
+      read: true
+      write: true
+    - bucketRef:
+        name: omnibus-postgres
+      read: true
+      write: true
+    - bucketRef:
+        name: velero
+      read: true
+      write: true
   secretTemplate:
     name: garage-webui-sidecar
     accessKeyIdKey: AWS_ACCESS_KEY_ID

--- a/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
@@ -8,8 +8,6 @@ spec:
     name: garage
     namespace: garage
   name: "Hermes S3 Reader Key"
-  allBuckets:
-    read: true
   secretTemplate:
     name: hermes-s3
     accessKeyIdKey: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## What changed

- Remove `allBuckets` from the retired Hermes S3 key, leaving it without bucket permissions while retaining its rollback secret manifest.
- Replace the web UI sidecar key's cluster-wide permission with explicit read/write permissions for the seven platform buckets in the `garage` namespace: `tracearr-postgres`, `immich-postgres`, `tailscale-logs`, `mimir`, `bookorbit-postgres`, `omnibus-postgres`, and `velero`.

## Why

`allBuckets` makes the operator evaluate these keys against every bucket, including private Bhaiya workspace buckets. A denied cross-namespace reference then fails the unrelated bucket reconcile. The web UI enumerates buckets through Garage's admin API; its sidecar needs S3 object operations only for the explicitly listed platform buckets.

Dynamic workspace buckets and all other application namespaces are intentionally excluded. No `GarageReferenceGrant` is added in `bhaiya`.

Related upstream operator report: https://github.com/rajsinghtech/garage-operator/issues/360