### PR TITLE
fix(logging): preserve Kubernetes log messages in VictoriaLogs

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1141,12 +1141,14 @@ One per cluster.
   `talconfig.yaml`, and **Robbinsdale does not** — so Robbinsdale contributes
   service logs but no kernel logs, and an empty kernel view for those nodes is
   expected rather than a broken collector
-- **filters** — kubernetes metadata, then `nest`; for `syslogd` records, the
-  existing `content` field is copied to `msg` so the normal Talos output can
-  select it without re-emitting the record
+- **filters** — Kubernetes metadata is merged into the record and its
+  `kubernetes.*` fields are retained; unparsed container lines fall back from
+  `log` to `msg`, while temporary Kubernetes label aliases are removed before
+  shipping. Talos `syslogd` records likewise copy `content` to `msg`
 - **outputs** — two loki-protocol outputs to `${VICTORIA_LOGS_HOST}:9428`,
-  gzip, with `VL-Msg-Field log` for `kube.*` and `msg` for `talos.*`; the
-  Talos output promotes its existing `tag` field (such as `kata` or
+  gzip, with `VL-Msg-Field msg` for both `kube.*` and `talos.*`; Kubernetes
+  streams are labelled `namespace`, `pod`, `container`, and `stream`, while
+  the Talos output promotes its existing `tag` field (such as `kata` or
   `virtiofsd`) as a stream label
 
 ### Grafana — single pane, Ottawa only

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1151,6 +1151,14 @@ One per cluster.
   the Talos output promotes its existing `tag` field (such as `kata` or
   `virtiofsd`) as a stream label
 
+**Historical Kubernetes log query:** records ingested before the Kubernetes
+message/label mapping was corrected may have their body in the structured
+`msg` field but no `_msg` value or stream labels. Search those records by their
+retained fields, for example
+`kubernetes.namespace_name:bhaiya and msg:"ensure workspace routes"`.
+Fixing the pipeline does not rewrite VictoriaLogs history, so old records do
+not acquire `_msg`, `namespace`, `pod`, `container`, or `stream` labels.
+
 ### Grafana — single pane, Ottawa only
 
 grafana-operator based: app + instance + dashboards + datasources. Datasources:

--- a/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
+++ b/kubernetes/apps/base/fluent-bit/fluent-bit/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
             Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
             Merge_Log           On
-            Keep_Log            Off
+            Keep_Log            On
             K8S-Logging.Parser  On
             K8S-Logging.Exclude On
             Labels              On
@@ -66,6 +66,33 @@ spec:
             Operation    lift
             Nested_under kubernetes
             Add_prefix   kubernetes.
+
+        # The nest filter keeps the existing kubernetes.* field names, but
+        # those are literal dotted keys rather than a nested map. Copy the
+        # metadata needed for stream labels to temporary root keys before the
+        # Loki output reads them.
+        [FILTER]
+            Name         modify
+            Match        kube.*
+            Hard_copy    kubernetes.namespace_name __fluentbit_namespace
+            Hard_copy    kubernetes.pod_name       __fluentbit_pod
+            Hard_copy    kubernetes.container_name __fluentbit_container
+
+        # Merge_Log puts structured application messages in `msg`. For a
+        # record that could not be parsed, preserve its original `log` value
+        # as the message instead of sending a record with no message field.
+        [FILTER]
+            Name         modify
+            Match        kube.*
+            Condition    Key_Does_Not_Exist msg
+            Hard_copy    log msg
+
+        # The output uses `msg` for every Kubernetes record; the raw input
+        # field is no longer needed after the fallback above.
+        [FILTER]
+            Name         modify
+            Match        kube.*
+            Remove       log
 
         # Most Talos JSON records put their body in `msg`, but syslogd wraps
         # the original syslog body in `content`. Copy it only for syslogd so
@@ -84,10 +111,10 @@ spec:
             Host                   ${VICTORIA_LOGS_HOST}
             Port                   9428
             Uri                    /insert/loki/api/v1/push
-            header                 VL-Msg-Field log
-            labels                 cluster=${CLUSTER_NAME}, job=fluent-bit
-            label_keys             $kubernetes['namespace_name'],$kubernetes['pod_name'],$kubernetes['container_name'],$stream
-            remove_keys            kubernetes,stream
+            header                 VL-Msg-Field msg
+            labels                 namespace=$__fluentbit_namespace, pod=$__fluentbit_pod, container=$__fluentbit_container, cluster=${CLUSTER_NAME}, job=fluent-bit
+            label_keys             $stream
+            remove_keys            kubernetes,stream,__fluentbit_namespace,__fluentbit_pod,__fluentbit_container
             auto_kubernetes_labels off
             line_format            json
             compress               gzip


### PR DESCRIPTION
## Summary

- keep the Kubernetes input's raw `log` field until a missing `msg` can be filled, then remove the temporary raw field before shipping
- preserve the existing flattened `kubernetes.*` fields while copying namespace, pod, and container into temporary keys for explicit `namespace`, `pod`, and `container` stream labels
- select `msg` as the VictoriaLogs message field for Kubernetes records

## Root cause

The Kubernetes filter had `Merge_Log On` and `Keep_Log Off`, so structured application JSON was merged into the record and its parsed `msg` survived, but the Loki output still selected the deleted `log` field. VictoriaLogs therefore stored the record fields but generated its missing-message placeholder for `_msg`. Separately, `nest lift` changed the metadata into literal dotted keys while the output tried to read it as a nested map, so the intended Kubernetes stream labels were omitted. This affects Kubernetes logs generally, not just the `bhaiya` namespace.

Historical ingestion is not rewritten by this change. Existing structured Bhaiya records remain recoverable through their stored fields (for example, `kubernetes.namespace_name:bhaiya and msg:"ensure workspace routes"`), but they will not gain a populated `_msg` or new stream labels retroactively. Records whose only body was a raw `log` value that was already discarded remain unrecoverable.

## Safety

The change does not alter inputs, retention, or routing. It uses in-place `modify` filters only: no records are intentionally dropped or re-emitted. Parsed `msg` values are preserved; unparsed records use their original `log` as the message.

## Validation

- `helm lint` for Fluent Bit chart 0.58.1: pass
- `git diff --check`: pass
- `tools/check.sh talos-ottawa`: reached render diagnostics; blocked by existing missing OCI chart dependencies and missing Homer values
- `tools/check.sh`: reached render diagnostics; same baseline failures plus the known St. Petersburg Cilium cluster-name validation and Robbinsdale missing OCI dependencies
- neither repository render run timed out

## Downstream audit

The affected configuration is the shared Kubernetes `kube.*` pipeline deployed by Fluent Bit in Ottawa, Robbinsdale, and St. Petersburg, so the scope is all Kubernetes namespaces collected in those clusters, not only `bhaiya`.

- The active CliProxy dashboard queries retained `kubernetes.namespace_name` and related fields, so it remains compatible.
- The repository's Flux log dashboard (`kubernetes/apps/base/flux-system/flux-system-common/monitoring/dashboards/logs.json`) is stale/unprovisioned, points at a Loki datasource that is not present in live Grafana, and expects `namespace`, `stream`, and `app`; `app` was already absent. It is not an active consumer whose results will silently change.
- No active saved queries were found that depend on the missing Kubernetes stream-label shape. Once deployed, selectors using `namespace`, `pod`, `container`, or `stream` will begin matching current records; existing field-based queries continue to work.

## Relation to #2603

#2603 changed only the `talos.*` TCP peer field and Talos stream labels. It did not modify the Kubernetes filter or `kube.*` output, so it is not the cause of this defect.