### PR TITLE
fix(monitoring): alert on reconciler cycle health

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -19,6 +19,7 @@ configMapGenerator:
   - name: mimir-rules
     files:
       - rules/bhaiya.yaml
+      - rules/bhaiya-reconciler.yaml
       - rules/blackbox.yaml
       - rules/ceph.yaml
       - rules/flux.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -34,6 +34,7 @@ spec:
             - --address=http://mimir-gateway.mimir.svc.cluster.local:8080
             - --id=talos-ottawa
             - /rules/bhaiya.yaml
+            - /rules/bhaiya-reconciler.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/flux.yaml
@@ -60,6 +61,7 @@ spec:
             - --address=http://mimir-gateway.mimir.svc.cluster.local:8080
             - --id=talos-robbinsdale
             - /rules/bhaiya.yaml
+            - /rules/bhaiya-reconciler.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/flux.yaml
@@ -82,6 +84,7 @@ spec:
             - --address=http://mimir-gateway.mimir.svc.cluster.local:8080
             - --id=talos-stpetersburg
             - /rules/bhaiya.yaml
+            - /rules/bhaiya-reconciler.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/flux.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
@@ -1,0 +1,74 @@
+# The reconciler emits cycle-level results: success, blocked, or error. These
+# alerts intentionally stay at that level because the metric has no workspace
+# label. A workspace-specific page needs a separate bounded metric from Bhaiya;
+# inspect the reconciler logs for the slug while resolving the alert.
+#
+# Keep this namespace unique across every file passed to mimirtool. A repeated
+# namespace aborts the complete sync for every Mimir tenant.
+namespace: bhaiya-reconciler
+groups:
+  - name: bhaiya-reconciler.rules
+    rules:
+      - alert: BhaiyaReconcileBlocked
+        expr: |
+          sum by (cluster) (
+            increase(
+              bhaiya_reconcile_cycles_total{
+                job="bhaiya",
+                container="bhaiya",
+                result="blocked"
+              }[5m]
+            )
+          ) > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya reconciliation is blocked pending operator review
+          description: >-
+            At least one review-blocked reconciliation cycle was recorded in
+            the last five minutes. Blocked cycles do not advance the last
+            successful-cycle timestamp and will not clear without operator
+            action; inspect the reconciler logs for the affected workspace and
+            the provider object that needs review.
+
+      - alert: BhaiyaReconcileErrors
+        expr: |
+          sum by (cluster) (
+            increase(
+              bhaiya_reconcile_cycles_total{
+                job="bhaiya",
+                container="bhaiya",
+                result="error"
+              }[15m]
+            )
+          ) > 2
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Bhaiya reconciliation has sustained cycle errors
+          description: >-
+            More than two ordinary or mixed-error reconciliation cycles were
+            recorded in every sustained fifteen-minute window. Inspect the
+            reconciler logs and the affected provider or workspace operation;
+            this is distinct from a review-only blocked cycle.
+
+      - alert: BhaiyaReconcileLastSuccessStale
+        expr: |
+          time() - max by (cluster) (
+            bhaiya_reconcile_last_success_timestamp_seconds{
+              job="bhaiya",
+              container="bhaiya"
+            }
+          ) > 6 * 60 * 60
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya has not completed a clean reconciliation cycle in six hours
+          description: >-
+            The latest successful reconciliation cycle is more than six hours
+            old. The reconciler may still be running while repeatedly failing
+            or blocking on a workspace, so inspect both its cycle result and
+            the per-workspace logs before relying on desired-state convergence.


### PR DESCRIPTION
## Summary

- Alert on review-blocked reconciliation cycles promptly.
- Alert on sustained ordinary or mixed cycle errors separately.
- Alert when the last clean reconciliation cycle is stale.
- Load the new `bhaiya-reconciler` namespace for Ottawa, Robbinsdale, and St. Petersburg.

## Production evidence and thresholds

- Ottawa exposes `bhaiya_reconcile_cycles_total` with `result` values `error` and `success`; the metric has scrape labels only (`cluster`, `job`, pod/container metadata, and `result`), not a workspace label.
- The current live query showed about 20.5 error cycles and 5.1 successful cycles in the last hour, about 155.9 errors and 5.1 successes in the last six hours, and a last-success age of about 19 minutes.
- Healthy six-hour buckets in #2613 had about 75.5–125.3 successes; the incident had zero for about 42 hours. Observed five-minute cycle rates were about 0.0037–0.0222/sec (one cycle per roughly 45–270 seconds) despite the 30-second base interval.
- Accordingly, blocked uses any increment in a five-minute window with `for: 1m`; errors require more than two cycles in 15 minutes and `for: 15m`; stale success is six hours old with `for: 15m`.
- No `result="blocked"` series is present in the current live query. Logs show `raj-trades`' pending-review error mixed with ordinary teardown/tombstone errors, which correctly remains `result="error"` under #395 semantics.

## Namespace and validation

- `bhaiya-reconciler` is unique across every loader argument; all three containers include the new file. `media.yaml` still has no `namespace:` and the last completed three-container loader Job succeeded with it in every argument list, confirming mimirtool tolerates that form.
- The exact new PromQL expressions parse against Ottawa Mimir and the blocked/stale expressions are empty at present.
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh talos-ottawa`: changed Mimir resources passed; only documented pre-existing blackbox-exporter, grafana-operator, kube-prometheus-stack, smartctl-exporter, and homer-operator dependency failures remain.
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh`: same documented Ottawa/Robbinsdale baseline.
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh talos-stpetersburg`: documented pre-existing blackbox-exporter, kube-prometheus-stack, and Cilium cluster-name validation failures.

A workspace-scoped alert label requires bounded per-workspace instrumentation in Bhaiya and is outside this manifests-only change; operators should use the reconciler logs to identify the slug.