### PR TITLE
fix(monitoring): identify blocked reconcile workspace

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
@@ -1,7 +1,8 @@
-# The reconciler emits cycle-level results: success, blocked, or error. These
-# alerts intentionally stay at that level because the metric has no workspace
-# label. A workspace-specific page needs a separate bounded metric from Bhaiya;
-# inspect the reconciler logs for the slug while resolving the alert.
+# The reconciler emits cycle-level results: success, blocked, or error. Keep the
+# cycle alert for compatibility while the bounded workspace gauge provides the
+# actionable page. The gauge identifies the workspace whose reconcile operation
+# returned ErrPendingReview; related stale provider objects can belong to other
+# workspaces and must not be attributed to this label.
 #
 # Keep this namespace unique across every file passed to mimirtool. A repeated
 # namespace aborts the complete sync for every Mimir tenant.
@@ -31,6 +32,47 @@ groups:
             successful-cycle timestamp and will not clear without operator
             action; inspect the reconciler logs for the affected workspace and
             the provider object that needs review.
+
+      - alert: BhaiyaReconcileWorkspaceBlocked
+        expr: |
+          max by (cluster, workspace) (
+            bhaiya_reconcile_blocked_workspaces{
+              job="bhaiya",
+              container="bhaiya",
+              workspace!="__overflow__"
+            }
+          ) > 0
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya reconciliation is blocked for workspace {{ $labels.workspace }}
+          description: >-
+            Workspace {{ $labels.workspace }} returned ErrPendingReview during
+            its reconcile operation. This label names the blocked workspace;
+            stale provider objects observed while reconciling another workspace
+            can be a separate failure and are not attributed to this label.
+            The block requires operator review and will not clear on its own.
+
+      - alert: BhaiyaReconcileBlockedOverflow
+        expr: |
+          max by (cluster) (
+            bhaiya_reconcile_blocked_workspaces{
+              job="bhaiya",
+              container="bhaiya",
+              workspace="__overflow__"
+            }
+          ) > 0
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya has more blocked workspaces than the alert can name
+          description: >-
+            More than 64 workspaces returned ErrPendingReview in the current
+            reconcile pass. The workspace gauge intentionally exposes only a
+            bounded set of names plus this overflow signal; inspect Bhaiya
+            logs and metrics to enumerate the affected workspaces.
 
       - alert: BhaiyaReconcileErrors
         expr: |


### PR DESCRIPTION
Closes #2613.

Add actionable visibility for the new bounded Bhaiya blocked-workspace gauge:

- add BhaiyaReconcileWorkspaceBlocked with one alert instance per named workspace;
- add BhaiyaReconcileBlockedOverflow for the explicit 64-label bound;
- keep the cycle-level BhaiyaReconcileBlocked alert during rollout so older Bhaiya images remain observable;
- explain that the workspace label identifies the reconcile operation returning ErrPendingReview, not necessarily the workspace owning related stale provider objects.

The existing unique namespace remains `bhaiya-reconciler`; it is already listed once in the kustomization ConfigMap generator and once for each tenant in loader-job.yaml, so changing the file rolls the loader hash without introducing a namespace collision.

Validation:
- `tools/check.sh talos-ottawa`: Mimir rendered; failed only on pre-existing blackbox-exporter, grafana-operator, kube-prometheus-stack, smartctl-exporter, and homer-operator chart/config issues.
- `KMAN_CHECK_TIMEOUT=600 tools/check.sh`: completed with the same pre-existing Ottawa/Robbinsdale chart issues.
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh talos-stpetersburg`: failed only on the known blackbox-exporter, kube-prometheus-stack, and Cilium cluster-name validation.
- No production mutation.