### PR TITLE
revert(garage): restore appliable cluster keys

### DIFF
--- a/kubernetes/apps/base/garage/garage-bucket/key.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/key.yaml
@@ -7,35 +7,9 @@ spec:
   clusterRef:
     name: garage
   name: "WebUI Sidecar Key"
-  bucketPermissions:
-    - bucketRef:
-        name: tracearr-postgres
-      read: true
-      write: true
-    - bucketRef:
-        name: immich-postgres
-      read: true
-      write: true
-    - bucketRef:
-        name: tailscale-logs
-      read: true
-      write: true
-    - bucketRef:
-        name: mimir
-      read: true
-      write: true
-    - bucketRef:
-        name: bookorbit-postgres
-      read: true
-      write: true
-    - bucketRef:
-        name: omnibus-postgres
-      read: true
-      write: true
-    - bucketRef:
-        name: velero
-      read: true
-      write: true
+  allBuckets:
+    read: true
+    write: true
   secretTemplate:
     name: garage-webui-sidecar
     accessKeyIdKey: AWS_ACCESS_KEY_ID

--- a/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
@@ -8,6 +8,8 @@ spec:
     name: garage
     namespace: garage
   name: "Hermes S3 Reader Key"
+  allBuckets:
+    read: true
   secretTemplate:
     name: hermes-s3
     accessKeyIdKey: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## Summary

Revert the GarageKey scoping from `b3b9710` / #2619.

The GarageKey CRD defaults the omitted `allBuckets` struct to all-false during server-side apply, and the admission webhook rejects that value. This leaves `flux-system/garage-bucket` NotReady and blocks `garage-keys`, `bhaiya`, and subsequent production deploys.

This restores the previously appliable declarations:

- `garage/webui-sidecar-key`: `allBuckets.read=true,write=true`
- `hermes/hermes-s3-key`: `allBuckets.read=true`

This is an emergency unblock only. It restores the pre-existing broad-access exposure; it does not add a `GarageReferenceGrant` in `bhaiya`. Proper least-privilege scoping remains pending an operator/CRD-compatible approach and owner review.

After merge, verify `garage-bucket` becomes Ready, then `garage-keys`, `bhaiya`, and the deployed revision catch up.