### PR TITLE
fix(monitoring): restore Ottawa etcd metrics scraping

### DIFF
--- a/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
@@ -227,6 +227,10 @@ spec:
 
     kubeEtcd:
       enabled: false
+      serviceMonitor:
+        metricRelabelings:
+          - targetLabel: cluster
+            replacement: ${CLUSTER_NAME}
 
     kube-state-metrics:
       enabled: true

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
@@ -228,6 +228,9 @@ spec:
     kubeEtcd:
       enabled: false
       serviceMonitor:
+        # Talos exposes this endpoint over plaintext without authentication;
+        # do not send the Prometheus service-account token to the node.
+        bearerTokenFile: ""
         metricRelabelings:
           - targetLabel: cluster
             replacement: ${CLUSTER_NAME}

--- a/kubernetes/apps/ottawa/monitoring/monitoring.yaml
+++ b/kubernetes/apps/ottawa/monitoring/monitoring.yaml
@@ -17,6 +17,22 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  patches:
+    - target:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        name: kube-prometheus-stack
+      patch: |-
+        - op: replace
+          path: /spec/values/kubeEtcd/enabled
+          value: true
+        - op: add
+          path: /spec/values/kubeEtcd/endpoints
+          value:
+            - 192.168.169.117 # asuka
+            - 192.168.169.119 # kaji
+            - 192.168.169.118 # rei
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## What changed

- Keep the shared kube-prometheus-stack etcd scrape disabled by default.
- Enable it for Ottawa through the Ottawa Flux monitoring overlay.
- Use the verified control-plane addresses only: `192.168.169.117` (asuka), `192.168.169.119` (kaji), and `192.168.169.118` (rei).
- Add the existing `${CLUSTER_NAME}` metric relabeling to the chart-generated etcd ServiceMonitor.

The chart creates the headless `kube-system` Service, explicit Endpoints, and ServiceMonitor for these non-Pod Talos etcd endpoints. `shiro` (`192.168.169.116`) is intentionally absent because it is a worker and does not run etcd.

Closes the Ottawa stage of #2627. Robbinsdale and St. Petersburg will be enabled only after Ottawa native metrics are confirmed in Mimir.

## Validation

- Direct read-only endpoint checks returned `etcd_server_has_leader 1` from all three Ottawa control-plane addresses; `shiro:2381` did not answer.
- Local `tools/check.sh talos-ottawa` was attempted. It reached rendering but failed on the pre-existing local missing OCI/values dependencies for `blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, and `homer-operator`; this was an ordinary render failure, not a timeout. CI is the merge gate.
- No cluster mutation was performed.
