### PR TITLE
fix(monitoring): enable etcd metrics in remaining clusters

### DIFF
--- a/kubernetes/apps/robbinsdale/monitoring/monitoring.yaml
+++ b/kubernetes/apps/robbinsdale/monitoring/monitoring.yaml
@@ -17,6 +17,22 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  patches:
+    - target:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        name: kube-prometheus-stack
+      patch: |-
+        - op: replace
+          path: /spec/values/kubeEtcd/enabled
+          value: true
+        - op: add
+          path: /spec/values/kubeEtcd/endpoints
+          value:
+            - 192.168.50.82 # stone
+            - 192.168.50.51 # tank
+            - 192.168.50.112 # titan
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/kubernetes/apps/stpetersburg/monitoring/monitoring.yaml
+++ b/kubernetes/apps/stpetersburg/monitoring/monitoring.yaml
@@ -17,6 +17,20 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  patches:
+    - target:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        name: kube-prometheus-stack
+      patch: |-
+        - op: replace
+          path: /spec/values/kubeEtcd/enabled
+          value: true
+        - op: add
+          path: /spec/values/kubeEtcd/endpoints
+          value:
+            - 192.168.73.248 # orin-0
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Summary

Enable the chart-generated etcd Service, Endpoints, and ServiceMonitor in Robbinsdale and St. Petersburg using explicit, verified control-plane addresses.

Ottawa was enabled and verified separately in #2629:
- Prometheus targets for asuka, kaji, and rei are up.
- Mimir returns `etcd_server_has_leader`, `etcd_server_leader_changes_seen_total`, and `up` for `cluster="talos-ottawa"`.
- WAL histogram `_count` and `_sum` series return range data.

Endpoint checks for this change returned `etcd_server_has_leader 1` from:
- Robbinsdale: stone `192.168.50.82`, tank `192.168.50.51`, titan `192.168.50.112`
- St. Petersburg: orin-0 `192.168.73.248`

The shared base remains disabled by default, and the ServiceMonitor sends no bearer token because Talos exposes plaintext metrics without client authentication.

Closes #2627

## Validation

- `git diff --check`
- Direct read-only `:2381/metrics` checks for all configured endpoints
- `tools/check.sh talos-robbinsdale` — manifest changes parsed; blocked by pre-existing missing OCI chart dependencies: blackbox-exporter, kube-prometheus-stack, smartctl-exporter.
- `tools/check.sh talos-stpetersburg` — manifest changes parsed; blocked by pre-existing missing OCI chart dependencies (blackbox-exporter, kube-prometheus-stack) and the known Cilium cluster-name validation.
