### PR TITLE
feat(monitoring): alert on payments provider health

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/payments.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/payments.yaml
@@ -62,6 +62,47 @@ groups:
             The bhaiya-payments PDB has had no healthy pod for 5 minutes;
             voluntary disruption protection cannot preserve webhook service.
 
+      - alert: BhaiyaPaymentsStripeUnavailable
+        expr: |
+          min by (provider) (
+            bhaiya_payments_provider_health{provider="stripe"}
+          ) < 1
+          and on() kube_deployment_spec_replicas{
+            namespace="bhaiya",
+            deployment="bhaiya-payments"
+          } > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya payments cannot reach Stripe
+          description: >-
+            Stripe has failed the payments service's bounded provider-health
+            check for 5 minutes. The payments replicas remain Ready for
+            webhooks and API traffic, but Stripe-dependent mutations are
+            failing closed; inspect the payments egress path and provider
+            status.
+
+      - alert: BhaiyaPaymentsFireflyUnavailable
+        expr: |
+          min by (provider) (
+            bhaiya_payments_provider_health{provider="firefly"}
+          ) < 1
+          and on() kube_deployment_spec_replicas{
+            namespace="bhaiya",
+            deployment="bhaiya-payments"
+          } > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya payments cannot reach Firefly
+          description: >-
+            Firefly has failed the payments service's bounded provider-health
+            check for 5 minutes. Webhooks remain reachable for provider retry,
+            while accounting-dependent operations fail closed until the
+            accounting path recovers.
+
       - alert: BhaiyaPaymentsWebhookFailures
         expr: increase(bhaiya_payments_webhook_failures_total[10m]) > 0
         for: 5m


### PR DESCRIPTION
Add canonical Mimir alerts for the new payments provider-health metrics. Stripe and Firefly failures alert after five minutes while the payments Deployment is active. Readiness remains available for webhook/API traffic and provider-dependent operations fail closed in the application.

The matching application change is corp/bhaiya PR #421. No live Stripe charging or live-mode selection is enabled.

Validation in the application repository:
- CGO_ENABLED=0 go test ./... -count=1
- CGO_ENABLED=0 make verify-go
- CGO_ENABLED=0 make render
- CGO_ENABLED=0 go test -timeout 900s ./deploy -count=1
- CGO_ENABLED=0 make verify

Manifest render/tests will be verified by this PR CI.