### PR TITLE
fix(garage): narrow allBuckets key exposure

### DIFF
--- a/kubernetes/apps/base/garage/garage-bucket/README.md
+++ b/kubernetes/apps/base/garage/garage-bucket/README.md
@@ -1,0 +1,32 @@
+# Garage web UI key scope
+
+`webui-sidecar-key` is intentionally limited to these six platform buckets:
+
+- `tracearr-postgres`
+- `immich-postgres`
+- `tailscale-logs`
+- `mimir`
+- `bookorbit-postgres`
+- `omnibus-postgres`
+
+The key has read and write object permissions with `owner: false`. The web UI
+sidecar uses the credential for user-selected bucket object administration:
+listing and downloading objects, uploading objects, creating folder markers,
+and deleting objects or prefixes. Removing write permission would leave those
+controls visible but non-functional, so the hardening boundary is the reviewed
+bucket allowlist rather than read-only access.
+
+`velero` is deliberately excluded while the policy decision in
+[kubernetes-manifests#2637](https://github.com/keiretsu-labs/kubernetes-manifests/issues/2637)
+is open. It is a disaster-recovery bucket and has its own dedicated Velero
+credential. `bhaiya-postgres` and `firefly-postgres` are also excluded because
+their database backup workloads have dedicated credentials. The live
+`git-s3-awslabs-1787539999` bucket has no current repository definition or
+consumer evidence, so it is excluded as legacy or generated data.
+
+The allowlist is intentionally Git-managed and fails closed. The admin-token
+UI may still show an unlisted bucket's metadata, but the sidecar's object list,
+read, upload, folder, and delete operations will fail until a reviewed
+`bucketPermissions` entry is added here and reconciled by Flux. Do not generate
+this list automatically from all `GarageBucket` objects: doing so would grant
+new database or private workspace buckets access without review.

--- a/kubernetes/apps/base/garage/garage-bucket/key.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket/key.yaml
@@ -7,9 +7,31 @@ spec:
   clusterRef:
     name: garage
   name: "WebUI Sidecar Key"
-  allBuckets:
-    read: true
-    write: true
+  bucketPermissions:
+    - bucketRef:
+        name: tracearr-postgres
+      read: true
+      write: true
+    - bucketRef:
+        name: immich-postgres
+      read: true
+      write: true
+    - bucketRef:
+        name: tailscale-logs
+      read: true
+      write: true
+    - bucketRef:
+        name: mimir
+      read: true
+      write: true
+    - bucketRef:
+        name: bookorbit-postgres
+      read: true
+      write: true
+    - bucketRef:
+        name: omnibus-postgres
+      read: true
+      write: true
   secretTemplate:
     name: garage-webui-sidecar
     accessKeyIdKey: AWS_ACCESS_KEY_ID

--- a/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/garagekey.yaml
@@ -8,8 +8,6 @@ spec:
     name: garage
     namespace: garage
   name: "Hermes S3 Reader Key"
-  allBuckets:
-    read: true
   secretTemplate:
     name: hermes-s3
     accessKeyIdKey: AWS_ACCESS_KEY_ID

--- a/tools/verify-garage-key-scope.sh
+++ b/tools/verify-garage-key-scope.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Verify the reconciled GarageKey scopes without changing cluster state.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+readonly FLUX_NAMESPACE="flux-system"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+command -v jq >/dev/null || die "jq is required"
+
+kube() {
+  "$REPO_ROOT/tools/kc.sh" ot "$@"
+}
+
+check_flux_ready() {
+  local name="$1"
+  local ready
+  ready="$(kube -n "$FLUX_NAMESPACE" get kustomization "$name" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
+  [[ "$ready" == "True" ]] || die "Flux $name Kustomization is not Ready: ${ready:-<missing>}"
+  echo "  Flux $name: Ready=True"
+}
+
+check_no_cluster_wide_access() {
+  local namespace="$1"
+  local name="$2"
+  local key_json="$3"
+  jq -e '
+    ((.spec.allBuckets // {}) | (.read // false) == false and (.write // false) == false and (.owner // false) == false) and
+    (.status.clusterWide == false) and
+    ([.spec.bucketPermissions // [] | .[]] | length == 0)
+  ' <<<"$key_json" >/dev/null || \
+    die "$namespace/$name still has effective cluster-wide or bucket permissions"
+  echo "  $namespace/$name: no effective allBuckets or bucket permissions"
+}
+
+check_web_ui_scope() {
+  local key_json="$1"
+  local expected='[{"name":"bookorbit-postgres","owner":false,"read":true,"write":true},{"name":"immich-postgres","owner":false,"read":true,"write":true},{"name":"mimir","owner":false,"read":true,"write":true},{"name":"omnibus-postgres","owner":false,"read":true,"write":true},{"name":"tailscale-logs","owner":false,"read":true,"write":true},{"name":"tracearr-postgres","owner":false,"read":true,"write":true}]'
+  local actual
+  actual="$(jq -c '
+    [.spec.bucketPermissions // [] | .[] |
+      {name: .bucketRef.name, owner: (.owner // false), read: (.read // false), write: (.write // false)}]
+    | sort_by(.name)
+  ' <<<"$key_json")"
+  [[ "$actual" == "$expected" ]] || die "web UI key scope differs from expected: $actual"
+  jq -e '((.spec.allBuckets // {}) | (.read // false) == false and (.write // false) == false and (.owner // false) == false) and (.status.clusterWide == false)' \
+    <<<"$key_json" >/dev/null || die "garage/webui-sidecar-key remains cluster-wide"
+  echo "  garage/webui-sidecar-key: six explicit read/write scopes, owner=false"
+}
+
+echo "Checking read-only post-reconcile GarageKey state"
+check_flux_ready garage-bucket
+check_flux_ready hermes
+
+web_key="$(kube -n garage get garagekey webui-sidecar-key -o json)"
+hermes_key="$(kube -n hermes get garagekey hermes-s3-key -o json)"
+check_web_ui_scope "$web_key"
+check_no_cluster_wide_access hermes hermes-s3-key "$hermes_key"
+
+echo "GarageKey scope verification passed without mutating Garage or Kubernetes."


### PR DESCRIPTION
## Summary

- remove `allBuckets` from the retired Hermes rollback-anchor key while retaining the `GarageKey` and generated `hermes-s3` Secret
- replace the web UI sidecar key's cluster-wide read/write baseline with explicit read/write, `owner:false` permissions for six approved platform buckets
- replace the draft verification helper's live upload/delete and forbidden `kubectl apply --dry-run=server` with exact, read-only live-state checks
- document the reviewed allowlist and fail-closed behavior for new buckets

## Scope rationale

The six web UI buckets are `tracearr-postgres`, `immich-postgres`, `tailscale-logs`, `mimir`, `bookorbit-postgres`, and `omnibus-postgres`. The sidecar source proves it requires list/read plus upload, folder-marker write, object deletion, and recursive prefix deletion for a user-selected bucket. It does not prove that this exact six-bucket policy is exhaustive; the allowlist is intentionally Git-managed and fails closed. New or unlisted buckets remain metadata-visible through the admin-token UI, but sidecar object operations fail until a reviewed manifest entry is reconciled.

`velero` is deliberately excluded pending the open decision in [#2637](https://github.com/keiretsu-labs/kubernetes-manifests/issues/2637). It is disaster-recovery data with a dedicated Velero credential, so this PR does not give the general web UI write/delete access to it. `bhaiya-postgres` and `firefly-postgres` are excluded because their database backup workloads have dedicated credentials. The live `git-s3-awslabs-1787539999` bucket has no current tracked definition or consumer evidence and remains excluded as legacy/generated data.

The sidecar's `write` permission is retained for the six approved buckets because removing it would break upload, folder creation, single-object deletion, and recursive deletion controls. `owner:false` remains because the sidecar does not need bucket administration. A generated allowlist is intentionally not used: it would silently grant future private/workload buckets.

## Revert history

The prior narrowing was deliberately reverted by Raj Singh in `e5170aa0bb454ef1bf0bc149dbdc4db074c29193` (`revert(garage): restore appliable web UI key`) and adjacent `c5eebbad3106c65dbb2001059f3da58127a04fcf` (`revert(garage): restore appliable Hermes key`), combined in `6cf7ff39f`. The leaf reverts have no detailed body or issue reference. Contemporaneous garage-operator issue [#361](https://github.com/rajsinghtech/garage-operator/issues/361) explains the reason: operator v0.7.6 rejected the SSA transition when omitted `allBuckets` materialized as an all-false object, causing Flux `garage-bucket` NotReady and blocking dependents. Operator PR [#362](https://github.com/rajsinghtech/garage-operator/pull/362) fixed that admission path and it is included in live v0.7.7. This was an admission/GitOps migration failure, not a web UI runtime failure or unrelated rollback.

No `GarageReferenceGrant` is added, no bucket is modified, no restart is required, and no degraded multipart path is exercised. Hermes retains its key and Secret with no permissions for reversible rollback handling.

## Commits

- `0753815a` `fix(garage): clear retired Hermes key permissions`
- `dc24d310` `fix(garage): scope web UI key to approved buckets`
- `17b5663e` `test(garage): verify key scopes read-only`

## Validation

- `bash -n tools/verify-garage-key-scope.sh`
- `git diff --check`
- `tools/check.sh ot` attempted; it was blocked by pre-existing render dependency failures (`blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, `homer-operator` chart sources/values), not by these manifests.
- GitHub checks from the prior commit were green; the post-push run is being verified.
- No live mutation or multipart upload/delete test was run.

Please review the scope policy and rollback implications before merging.