### PR TITLE
fix(bhaiya): allow long-drain rollouts to complete

### DIFF
--- a/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
+++ b/kubernetes/apps/ottawa/bhaiya/bhaiya.yaml
@@ -26,7 +26,11 @@ spec:
     name: bhaiya
   interval: 10m
   retryInterval: 1m
-  timeout: 5m
+  # Bhaiya's MCP and SSH edges may legitimately drain for 930 seconds. Keep
+  # enough room for their 1053-second Deployment progress budget plus Flux
+  # apply/status propagation; the previous 5-minute timeout failed the whole
+  # Kustomization before a healthy long-lived-session rollout could finish.
+  timeout: 20m
   wait: true
   healthChecks:
     - apiVersion: apps/v1


### PR DESCRIPTION
## Summary

The Bhaiya MCP and SSH Deployments deliberately allow up to 930 seconds for long-lived session drains, but the Bhaiya Flux Kustomization waited only 5 minutes. That made a healthy drain fail the entire application Kustomization before the replacement became Ready.

Raise the Flux wait budget to 20 minutes. The application branch pairs this with a 1,053-second Deployment progress budget; the remaining 147 seconds covers Flux apply/status propagation.

Related application change: corp/bhaiya `fix/deployment-rollout-scheduling`.
