### PR TITLE
fix(velero): permit bhaiya to label PodVolumeBackups

### DIFF
--- a/kubernetes/apps/base/velero/velero/bhaiya-rbac.yaml
+++ b/kubernetes/apps/base/velero/velero/bhaiya-rbac.yaml
@@ -22,11 +22,18 @@ rules:
   - apiGroups: ["velero.io"]
     resources:
       - backupstoragelocations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["velero.io"]
+    resources:
       - podvolumebackups
     verbs:
       - get
       - list
       - watch
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

Allow Bhaiya's Velero label-repair path to apply the workspace label to PodVolumeBackups without granting mutation access to BackupStorageLocations.

## Exact RBAC change

Split the combined `velero.io` rule:

- `backupstoragelocations`: `get`, `list`, `watch`
- `podvolumebackups`: `get`, `list`, `watch`, `patch`

No `update` is granted for PodVolumeBackups. `internal/provision/velero.go` lists PVBs and `EnsureVeleroPodVolumeBackupLabels` calls `fencedDynamicApply`; that helper sends `types.ApplyPatchType` through the dynamic client. Server-side apply requires the `patch` verb. There is no PVB create or update call path.

This keeps BSLs, including the production backup location, read-only to Bhaiya.

## Validation

- `kubectl kustomize kubernetes/apps/base/velero/velero` passes and renders the split rules.
- Live Ottawa server-side dry-run is being run before merge.
- Post-reconcile validation will check the Bhaiya logs and reconcile success metric, rather than treating the manifest merge as success.