### PR TITLE
fix(monitoring): alert when reconciliation stops succeeding

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
@@ -1,8 +1,14 @@
 # The reconciler emits cycle-level results: success, blocked, or error. Keep the
-# cycle alert for compatibility while the bounded workspace gauge provides the
+# cycle alerts for compatibility while the bounded workspace gauge provides the
 # actionable page. The gauge identifies the workspace whose reconcile operation
 # returned ErrPendingReview; related stale provider objects can belong to other
 # workspaces and must not be attributed to this label.
+#
+# last_success_timestamp is updated only after a complete successful pass. Take
+# the newest value across replicas: the non-leader's value is harmless, and the
+# maximum remains the last real success during a leader transfer. Do not gate
+# this alert on bhaiya_reconcile_leader; no leader is itself a no-success
+# condition and must not suppress the signal.
 #
 # Keep this namespace unique across every file passed to mimirtool. A repeated
 # namespace aborts the complete sync for every Mimir tenant.
@@ -42,7 +48,7 @@ groups:
               workspace!="__overflow__"
             }
           ) > 0
-        for: 30s
+        for: 5m
         labels:
           severity: critical
         annotations:
@@ -103,14 +109,15 @@ groups:
               job="bhaiya",
               container="bhaiya"
             }
-          ) > 6 * 60 * 60
-        for: 15m
+          ) > 10 * 60
+        for: 5m
         labels:
           severity: critical
         annotations:
-          summary: Bhaiya has not completed a clean reconciliation cycle in six hours
+          summary: Bhaiya reconciliation has stopped completing successful cycles
           description: >-
-            The latest successful reconciliation cycle is more than six hours
-            old. The reconciler may still be running while repeatedly failing
-            or blocking on a workspace, so inspect both its cycle result and
-            the per-workspace logs before relying on desired-state convergence.
+            No successful reconciliation cycle has completed for more than ten
+            minutes. Check `kubectl logs -n bhaiya deploy/bhaiya | grep
+            'reconcile workspace resources'` for the aggregated error, then
+            inspect the cycle result and affected workspace before relying on
+            desired-state convergence.


### PR DESCRIPTION
## What changed

- Alert when the newest successful Bhaiya reconciliation cycle is more than 10 minutes old.
- Require the condition for 5 minutes before paging.
- Require a named `ErrPendingReview` workspace gauge to remain present for 5 minutes before the per-workspace blocked alert fires.
- Keep the existing cycle-result alerts and Mimir ruler wiring unchanged.

The last-success gauge is updated only after a complete successful pass. The expression takes the maximum across replicas so a leader transfer does not reset the last real success. It deliberately does not require `bhaiya_reconcile_leader == 1`: losing leadership must not hide a no-success condition.

The 10-minute threshold is well above the healthy Ottawa cycle age (normally under 90 seconds) and catches the incident where cycles took about 300 seconds and no success samples were emitted. The duration histogram is not given a separate alert because there is no established duration SLO and its finite buckets stop at 120 seconds; last-success directly measures the convergence failure.

## Verification

- The live Mimir expression was empty in the healthy Ottawa state.
- Evaluating the same expression over 2026-09-02 08:45–09:20 UTC returned a firing vector at every 5-minute sample; the leader remained present, error increases were continuous, and success had no samples.
- The rendered changed rules ConfigMap passed `kubectl apply --server-side --dry-run=server` against Ottawa with context `ottawa-k8s-operator.keiretsu.ts.net`. A full-base dry-run also validated the other objects but encountered the expected immutable existing `mimir-config-loader` Job update; Flux replaces that Job via its `force: enabled` annotation.
- `tools/check.sh talos-ottawa` reached the render and failed only on the repository's existing unavailable fixture dependencies: blackbox-exporter, grafana-operator, kube-prometheus-stack, smartctl-exporter, and homer-operator. The changed rule was included in the render output.
- All nine GitHub checks completed successfully.

Closes the reconcile alerting gap described in the incident report.