### PR TITLE
feat(monitoring): alert on stale workspace-image publication

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -20,6 +20,7 @@ configMapGenerator:
     files:
       - rules/bhaiya.yaml
       - rules/bhaiya-reconciler.yaml
+      - rules/bhaiya-workspace-image.yaml
       - rules/blackbox.yaml
       - rules/ceph.yaml
       - rules/flux.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -35,6 +35,7 @@ spec:
             - --id=talos-ottawa
             - /rules/bhaiya.yaml
             - /rules/bhaiya-reconciler.yaml
+            - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/flux.yaml
@@ -62,6 +63,7 @@ spec:
             - --id=talos-robbinsdale
             - /rules/bhaiya.yaml
             - /rules/bhaiya-reconciler.yaml
+            - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/flux.yaml
@@ -85,6 +87,7 @@ spec:
             - --id=talos-stpetersburg
             - /rules/bhaiya.yaml
             - /rules/bhaiya-reconciler.yaml
+            - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/flux.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
@@ -1,0 +1,70 @@
+# Workspace-image publication is checked by Bhaiya itself and remote-written
+# into the per-cluster Mimir tenant. This must be a native Mimir ruler file;
+# PrometheusRule objects in the bhaiya namespace are not evaluated in
+# agent-mode Prometheus.
+#
+# Keep this namespace unique across every file passed to mimirtool. A repeated
+# namespace aborts the complete rule sync for every tenant.
+namespace: bhaiya-workspace-image
+groups:
+  - name: bhaiya-workspace-image.rules
+    rules:
+      - alert: BhaiyaWorkspaceImagePublicationStale
+        expr: |
+          max by (cluster, image, version) (
+            bhaiya_workspace_image_intended_info{
+              job="bhaiya",
+              container="bhaiya"
+            }
+          )
+          and on (cluster, image, version)
+          max by (cluster, image, version) (
+            bhaiya_workspace_image_registry_probe_status{
+              job="bhaiya",
+              container="bhaiya",
+              status="missing"
+            } == 1
+          )
+        for: 75m
+        labels:
+          severity: critical
+        annotations:
+          summary: Intended workspace image {{ $labels.version }} is not published
+          description: >-
+            Bhaiya's workspace-image dispatcher intended
+            {{ $labels.image }}:{{ $labels.version }}, but its bounded registry
+            probe has received a definitive HTTP 404 for at least 75 minutes.
+            Inspect the workspace-image-v{{ $labels.version }} Woodpecker tag
+            pipeline, especially admission failures and missing registry
+            credentials, then verify the manifest and adoption handoff. This
+            is distinct from a probe error: network, auth, and registry errors
+            are reported by the separate unknown-state alert.
+
+      - alert: BhaiyaWorkspaceImagePublicationProbeUnavailable
+        expr: |
+          max by (cluster, image, version) (
+            bhaiya_workspace_image_intended_info{
+              job="bhaiya",
+              container="bhaiya"
+            }
+          )
+          and on (cluster, image, version)
+          max by (cluster, image, version) (
+            bhaiya_workspace_image_registry_probe_status{
+              job="bhaiya",
+              container="bhaiya",
+              status="probe_error"
+            } == 1
+          )
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Workspace image publication status is unknown
+          description: >-
+            Bhaiya cannot determine whether the intended workspace image
+            {{ $labels.image }}:{{ $labels.version }} is published. The
+            registry probe is failing (network, authentication, or server
+            error), so this alert does not claim the tag is missing. Restore
+            registry reachability and inspect Bhaiya's probe status before
+            treating the release as stale.


### PR DESCRIPTION
## Summary

Add the missing observability and Mimir ruler alert for workspace-image publication freshness.

The paired Bhaiya change is [corp/bhaiya#449](https://forgejo.keiretsu.top/corp/bhaiya/pulls/449), which exposes:

- `bhaiya_workspace_image_intended_info` for the dispatch-authoritative `workspace-image/VERSION`;
- `bhaiya_workspace_image_registry_probe_status{status="published|missing|probe_error"}` from a bounded manifest GET;
- a last definitive probe timestamp and returned manifest digest.

This rule is installed through the native Mimir ruler loader. It does not use a `PrometheusRule`, because agent-mode Prometheus remote-writes the metrics and does not evaluate those CRs.

## Alert contract

- `BhaiyaWorkspaceImagePublicationStale` matches only an intended version whose registry probe has received a definitive 404 (`status="missing"`).
- `BhaiyaWorkspaceImagePublicationProbeUnavailable` separately reports unknown probe state (`status="probe_error"`) after 15 minutes.
- A network/auth/registry failure therefore cannot masquerade as a missing image.
- The missing-publication alert uses `for: 75m`: the documented normal release budget is 2700s prepare + 870s promote = 59m30s, with 15m30s for queueing and registry handoff. A 45-minute hold would page during a normal slow build.

The current real condition is workspace image `0.3.243`; its public registry manifest endpoint returns HTTP 404. Once the Bhaiya image is deployed, the expression should evaluate to the stale alert condition. The same query will be rechecked after the registry secret is restored and publication succeeds.

## Validation

- `kubectl kustomize kubernetes/apps/base/mimir/mimir-ottawa` — passed.
- Targeted rendered `mimir-rules-<hash>` ConfigMap server-side dry-run against Ottawa — passed:
  `configmap/mimir-rules-m4mb2b89k8 serverside-applied (server dry run)`.
- The Bhaiya metric tests and full validation are recorded in #449.

No cluster mutation, image publication, or registry-secret change was performed.