### PR TITLE
fix(mimir): move ingester storage off shiro /var

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -20,6 +20,27 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          # The chart's persistentVolume mode adds volumeClaimTemplates to the
+          # StatefulSet. That field cannot be added to the existing StatefulSet
+          # in place, so keep the chart's emptyDir mode and replace only the
+          # mutable pod-template volume with the separately managed claim.
+          # The test operation makes a chart volume-order change fail closed.
+          - target:
+              kind: StatefulSet
+              name: mimir-ingester
+            patch: |-
+              - op: test
+                path: /spec/template/spec/volumes/2/name
+                value: storage
+              - op: remove
+                path: /spec/template/spec/volumes/2/emptyDir
+              - op: add
+                path: /spec/template/spec/volumes/2/persistentVolumeClaim
+                value:
+                  claimName: storage-mimir-ingester-0
   values:
     rollout_operator:
       enabled: false
@@ -79,6 +100,11 @@ spec:
               endpoint: ${COMMON_S3_ENDPOINT}
               bucket_name: mimir
               insecure: true
+        blocks_storage:
+          tsdb:
+            # The first rollout moves the ingester from emptyDir to RBD. Flush
+            # and ship the current head before Kubernetes removes the old pod.
+            flush_blocks_on_shutdown: true
         limits:
           compactor_blocks_retention_period: 7d
           ingestion_rate: 500000
@@ -93,6 +119,9 @@ spec:
       zoneAwareReplication:
         enabled: false
       persistentVolume:
+        # Adding chart-managed volumeClaimTemplates would be rejected as an
+        # immutable StatefulSet update. The PVC is managed beside this release
+        # and the post-renderer switches the pod template to it.
         enabled: false
       extraArgs:
         "-ingester.ring.replication-factor": "1"

--- a/kubernetes/apps/base/mimir/mimir-ottawa/ingester-pvc.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/ingester-pvc.yaml
@@ -1,0 +1,27 @@
+---
+# Mimir's ingester TSDB/WAL must not share shiro's /var-backed NVMe with
+# containerd, Garage, and the rest of the node. Keep this claim separate from
+# the Helm chart so the existing StatefulSet does not need an immutable
+# volumeClaimTemplates transition.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-mimir-ingester-0
+  annotations:
+    # Keep the TSDB data if this manifest is ever removed from the Flux source;
+    # deleting the claim would delete its RBD because the storage class uses
+    # reclaimPolicy=Delete.
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block-replicated
+  resources:
+    requests:
+      # Current local ingester blocks are ~3.6GiB; leave room for WAL, indexes,
+      # compaction, and growth rather than using the chart's 2Gi default.
+      storage: 20Gi

--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: mimir
 resources:
   - helmrelease.yaml
+  - ingester-pvc.yaml
   - ingress-ts.yaml
   - ingress-qf-ts.yaml
   # Keep the Helm-owned Service in Flux's inventory while removing the legacy


### PR DESCRIPTION
## Summary

Moves the Ottawa Mimir ingester TSDB/WAL from shiro's /var-backed emptyDir to a 20Gi RBD PVC.

- Adds the separately managed `storage-mimir-ingester-0` PVC using `ceph-block-replicated`.
- Uses a Helm post-renderer to replace the generated ingester `storage` emptyDir with that claim.
- Keeps chart-managed `volumeClaimTemplates` disabled because adding them to the existing StatefulSet is rejected as an immutable update.
- Enables Mimir `flush_blocks_on_shutdown` so the first rollout compacts and ships the current head before the old emptyDir pod is removed.
- Does not change auth, monitoring telemetry, Talos configuration, or privileged workload policy.

## Validation

- `kustomize build --enable-helm kubernetes/apps/base/mimir/mimir-ottawa`: passed.
- Rendered Helm output and post-rendered StatefulSet inspected: `/data` uses the PVC and no longer uses `emptyDir`.
- Live server-side dry-run of the changed PVC and HelmRelease: passed.
- Live server-side dry-run of the post-rendered ingester StatefulSet under `helm-controller`: passed.
- The full base dry-run also encounters an unrelated existing immutable `mimir-config-loader` Job defaulting conflict; it was not treated as a pass.
- Cluster workload has not been restarted or otherwise mutated by this PR.