### PR TITLE
feat(monitoring): alert on SSH backend failures and session loss

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
       - rules/bhaiya.yaml
       - rules/bhaiya-reconciler.yaml
       - rules/bhaiya-provider-provisioning.yaml
+      - rules/bhaiya-ssh.yaml
       - rules/bhaiya-workspace-image.yaml
       - rules/blackbox.yaml
       - rules/ceph.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -36,6 +36,7 @@ spec:
             - /rules/bhaiya.yaml
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
+            - /rules/bhaiya-ssh.yaml
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
@@ -65,6 +66,7 @@ spec:
             - /rules/bhaiya.yaml
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
+            - /rules/bhaiya-ssh.yaml
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
@@ -90,6 +92,7 @@ spec:
             - /rules/bhaiya.yaml
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
+            - /rules/bhaiya-ssh.yaml
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-ssh.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-ssh.yaml
@@ -1,0 +1,82 @@
+# SSH session metrics are emitted by internal/sshgateway and scraped from the
+# bhaiya-ssh Service. These alerts deliberately use the gateway's bounded
+# result labels rather than the service package's private health-listener
+# counters: the public /metrics endpoint exposes the former to Mimir.
+#
+# Expected client disconnects, orderly command completion, authorization
+# denials, and planned drains are excluded. A nonzero increase is enough to
+# report the first genuine backend or unexpected transport failure; the
+# lookback plus `for` period prevents a single scrape from becoming an alert.
+# Keep this namespace unique across every file passed to mimirtool.
+namespace: bhaiya-ssh
+groups:
+  - name: bhaiya-ssh.rules
+    rules:
+      - alert: BhaiyaSSHBackendUnavailable
+        expr: |
+          (
+            sum by (cluster) (
+              increase(
+                bhaiya_ssh_authentication_attempts_total{
+                  job="bhaiya-ssh",
+                  result="unavailable"
+                }[5m]
+              )
+            ) > 0
+          )
+          or
+          (
+            sum by (cluster) (
+              increase(
+                bhaiya_ssh_reauthorization_attempts_total{
+                  job="bhaiya-ssh",
+                  result="unavailable"
+                }[5m]
+              )
+            ) > 0
+          )
+          or
+          (
+            sum by (cluster) (
+              increase(
+                bhaiya_ssh_session_terminations_total{
+                  job="bhaiya-ssh",
+                  reason=~"authorization_unavailable|terminal_error"
+                }[5m]
+              )
+            ) > 0
+          )
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya SSH backend failure detected in {{ $labels.cluster }}
+          description: >-
+            The SSH edge recorded an authorization backend outage or a
+            workspace session-stream failure in the last five minutes. This
+            excludes ordinary command exits, explicit authorization denials,
+            and expected client disconnects. Inspect bhaiya-ssh logs and the
+            authorization and workspace-session backends before users lose
+            established sessions.
+
+      - alert: BhaiyaSSHUnexpectedDisconnect
+        expr: |
+          sum by (cluster) (
+            increase(
+              bhaiya_ssh_session_disconnects_total{
+                job="bhaiya-ssh",
+                cause="transport"
+              }[5m]
+            )
+          ) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: Bhaiya SSH session lost unexpectedly in {{ $labels.cluster }}
+          description: >-
+            The SSH edge recorded a session terminated by a transport failure
+            in the last five minutes. Planned drains and orderly client closes
+            are excluded. Check the SSH edge, its network path, and the client
+            session before treating this as an authorization or workspace
+            backend failure.


### PR DESCRIPTION
Relates to corp/bhaiya#471 (SSH session-loss and authorization-backend alerting).
Coordinates with corp/bhaiya#469, which is already on bhaiya main as
e3754ca1. That change adds a bounded client banner for initial authorization
outages; it does not add a metric, so this PR uses the existing
scrape-visible gateway metrics.

## What changed

Adds native Mimir ruler alerts for the `bhaiya-ssh` job:

- `BhaiyaSSHBackendUnavailable` watches direct authorization-unavailable
  results, mid-session `authorization_unavailable` terminations, and
  workspace session-stream `terminal_error` terminations.
- `BhaiyaSSHUnexpectedDisconnect` watches only the gateway's direct
  `cause="transport"` classification.

Both rules aggregate by `cluster`, use a nonzero `increase` over five minutes,
and require two minutes before firing. Normal command completion, explicit
authorization denials/revocations, orderly client closes, and planned drains
are excluded. The thresholds deliberately detect the first real failure rather
than requiring a noisy total.

The rules are wired into the generated `mimir-rules` ConfigMap and all three
tenant loader containers. The service-local counters in `services/ssh` are not
used because the deployed public `/metrics` endpoint exposes the gateway
registry, not that package's private health listener.

## Validation

- `kustomize build kubernetes/apps/base/mimir/mimir-ottawa` renders both rules
  and all three loader arguments.
- Mimir-Ottawa historical queries proved the backend expression nonzero for
  retained production events on 2026-08-31 around 06:27Z (authorization and
  reauthorization unavailable) and 07:35Z (terminal error). No
  `cause="transport"` sample is retained in the seven-day window, so the
  unexpected-transport alert is not claimed to have historical incident
  proof.
- A live Ottawa `kubectl apply --server-side --dry-run=server` reached API
  admission. The ordinary full-base invocation reported the existing
  Flux-managed field ownership conflicts; the forced dry-run then admitted
  every resource except the already-existing immutable loader Job. A second
  dry-run validated the rendered resources with that Job renamed to a new
  dry-run name, and admitted it as well. No live resource was changed.

The repository-wide local Flate gate is currently blocked by unrelated local
environment/dependency failures (initially missing `tar`; with the exact
Flate binary, missing chart-source dependencies and invalid non-Ottawa cluster
inputs). No rule-specific render failure was reported.
