### PR TITLE
feat(node-health): expose NPD telemetry and alerts

### DIFF
--- a/kubernetes/apps/base/kube-system/node-health/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/node-health/app/kustomization.yaml
@@ -7,10 +7,14 @@ resources:
   - ./nrr-rule.yaml
   - ./npd-rbac.yaml
   - ./npd-daemonset.yaml
+  - ./npd-service.yaml
+  - ./npd-servicemonitor.yaml
+  - ./npd-networkpolicy.yaml
 configMapGenerator:
   - name: node-problem-detector-config
     files:
       - kernel-monitor.json
+      - health-checker-kubelet.json
     options:
       disableNameSuffixHash: true
       labels:

--- a/kubernetes/apps/base/kube-system/node-health/app/npd-daemonset.yaml
+++ b/kubernetes/apps/base/kube-system/node-health/app/npd-daemonset.yaml
@@ -37,7 +37,10 @@ spec:
           command:
             - /node-problem-detector
             - --logtostderr
+            - --prometheus-address=0.0.0.0
+            - --prometheus-port=20257
             - --config.system-log-monitor=/config/kernel-monitor.json
+            - --config.custom-plugin-monitor=/config/health-checker-kubelet.json
           env:
             - name: NODE_NAME
               valueFrom:
@@ -45,18 +48,25 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
+          ports:
+            - name: metrics
+              containerPort: 20257
+              protocol: TCP
           resources:
             requests: {cpu: 10m, memory: 80Mi}
             limits: {cpu: 100m, memory: 128Mi}
           volumeMounts:
             - {name: kmsg, mountPath: /dev/kmsg, readOnly: true}
             - {name: log, mountPath: /var/log, readOnly: true}
+            - {name: talos-binaries, mountPath: /home/kubernetes/bin, readOnly: true}
             - {name: config, mountPath: /config, readOnly: true}
       volumes:
         - name: kmsg
           hostPath: {path: /dev/kmsg}
         - name: log
           hostPath: {path: /var/log}
+        - name: talos-binaries
+          hostPath: {path: /home/kubernetes/bin}
         - name: config
           configMap:
             name: node-problem-detector-config

--- a/kubernetes/apps/base/kube-system/node-health/app/npd-networkpolicy.yaml
+++ b/kubernetes/apps/base/kube-system/node-health/app/npd-networkpolicy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: node-problem-detector-metrics
+  namespace: kube-system
+spec:
+  description: Allow only the monitoring Prometheus agent to scrape NPD metrics.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: detector
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus-agent
+            app.kubernetes.io/instance: kube-prometheus-stack
+            operator.prometheus.io/name: kube-prometheus-stack
+      toPorts:
+        - ports:
+            - port: "20257"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: /metrics$

--- a/kubernetes/apps/base/kube-system/node-health/app/npd-service.yaml
+++ b/kubernetes/apps/base/kube-system/node-health/app/npd-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: node-problem-detector
+    app.kubernetes.io/component: metrics
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/component: detector
+  ports:
+    - name: metrics
+      port: 20257
+      targetPort: metrics
+      protocol: TCP

--- a/kubernetes/apps/base/kube-system/node-health/app/npd-servicemonitor.yaml
+++ b/kubernetes/apps/base/kube-system/node-health/app/npd-servicemonitor.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: node-problem-detector
+    app.kubernetes.io/component: metrics
+spec:
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+      metricRelabelings:
+        - targetLabel: cluster
+          replacement: ${CLUSTER_NAME}

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
@@ -5,6 +5,18 @@ namespace: monitoring
 groups:
   - name: container.rules
     rules:
+      - alert: BhaiyaPodEvicted
+        expr: kube_pod_status_reason{namespace="bhaiya",reason="Evicted"} == 1
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya pod {{ $labels.pod }} was evicted from node {{ $labels.node }}.
+          description: >-
+            This is a kubelet eviction signal, distinct from a container
+            OOMKilled termination or a Kata sandbox exit. Correlate the pod
+            event with pod info, node pressure, and
+            NodeKubeletUnhealthyWhileReady.
+
       - alert: OomKilled
         expr: |
           (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1)

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
@@ -6,7 +6,15 @@ groups:
   - name: container.rules
     rules:
       - alert: BhaiyaPodEvicted
-        expr: kube_pod_status_reason{namespace="bhaiya",reason="Evicted"} == 1
+        expr: |
+          max by (cluster, namespace, pod, uid, reason) (
+            kube_pod_status_reason{namespace="bhaiya",reason="Evicted"}
+          )
+          * on (cluster, namespace, pod, uid) group_left(node)
+          max by (cluster, namespace, pod, uid, node) (
+            kube_pod_info{namespace="bhaiya",node!=""}
+          )
+          == 1
         labels:
           severity: critical
         annotations:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
@@ -15,6 +15,7 @@ groups:
             kube_pod_info{namespace="bhaiya",node!=""}
           )
           == 1
+        for: 0m
         labels:
           severity: critical
         annotations:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
@@ -1,4 +1,4 @@
-# Node health alerts for the NPD conditions written by the v0.8.19
+# Node health alerts for the NPD conditions written by node-problem-detector.
 # node-problem-detector DaemonSet. These rules are evaluated by Mimir ruler;
 # node-readiness-controller independently applies only a NoSchedule taint.
 # Keep this namespace unique across every file passed to mimirtool.
@@ -20,3 +20,31 @@ groups:
           severity: critical
         annotations:
           summary: Read-only filesystem reported on node {{ $labels.node }}
+
+      - alert: NodeKubeletUnhealthyWhileReady
+        expr: |
+          kube_node_status_condition{condition="KubeletUnhealthy",status="true"} == 1
+          and on (cluster, node)
+          kube_node_status_condition{condition="Ready",status="true"} == 1
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Node {{ $labels.node }} reports KubeletUnhealthy while remaining Ready.
+          description: >-
+            The Kubernetes node condition is inconsistent. Inspect the node's
+            lastHeartbeatTime and Kubelet/containerd/Kata logs; this alert is
+            intentionally independent of Ready so a stale KubeletUnhealthy
+            condition is not hidden by generic node-readiness alerts.
+
+      - alert: NodeKernelOOMKill
+        expr: increase(problem_counter{reason="OOMKilling"}[10m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: Node {{ $labels.node }} recorded a kernel OOM kill.
+          description: >-
+            Node-problem-detector observed the kernel OOM-kill signature. This
+            distinguishes host-level memory pressure from a Kata sandbox
+            teardown; correlate it with the affected pod's termination reason
+            and node memory metrics.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
@@ -39,6 +39,7 @@ groups:
 
       - alert: NodeKernelOOMKill
         expr: increase(problem_counter{reason="OOMKilling"}[10m]) > 0
+        for: 0m
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
## Summary

Adds the missing node-health telemetry needed to diagnose `SandboxChanged` / exit-255 workspace failures without changing or remediating any node or workspace.

The key defect was that `health-checker-kubelet.json` already existed in this repository but was **never wired into node-problem-detector**. NPD only loaded the kernel monitor, so the `KubeletUnhealthy` condition had no active producer. This is the same silent failure shape found elsewhere today: the check exists, but nothing calls it. This PR loads the checker, mounts the Talos `/home/kubernetes/bin/health-checker` binary, and exposes the resulting NPD metrics.

## Changes

- Wire `/config/health-checker-kubelet.json` into NPD and mount `/home/kubernetes/bin` read-only.
- Bind NPD metrics to `0.0.0.0:20257`.
- Add the NPD metrics Service and ServiceMonitor. The ServiceMonitor selects `app.kubernetes.io/component: metrics` because Flux `commonMetadata` can clobber the name label.
- Add a restricted Cilium ingress rule allowing only the monitoring Prometheus agent to `GET /metrics` on port `20257`.
- Add Mimir ruler alerts:
  - `NodeKubeletUnhealthyWhileReady`: catches the actionable inconsistency independently of generic readiness.
  - `NodeKernelOOMKill`: detects the node-level NPD kernel OOM signature.
  - `BhaiyaPodEvicted`: detects kubelet eviction and joins `kube_pod_status_reason` to `kube_pod_info` so the alert retains node attribution.
- Alert annotations point operators to the next diagnostic surface rather than claiming an RCA.

## Concrete case

Ottawa node `shiro` has been observed with `Ready=True` and `KubeletUnhealthy=True`, while its heartbeat was frozen at `2026-08-21T16:01:07Z`. That inconsistency was invisible to the existing generic alerts. This alert detects the condition, but kube-state-metrics does not expose `lastHeartbeatTime`; exact heartbeat age still requires Kubernetes API or exporter work and is explicitly **not** covered here.

## Verification

- Each of the three new alerts was tested in both directions with synthetic `promtool` tests: it fires on its triggering condition and stays silent with normal/zero input.
- `promtool check rules` passes: 4 node-health rules and 29 monitoring rules.
- Scoped node-health `kustomize build` renders 23 objects and includes the checker config, binary mount, `0.0.0.0:20257`, Service, ServiceMonitor, and Cilium policy.
- `git diff --check` passes.
- `tools/check.sh talos-ottawa` completed its render but did not pass cleanly: it is blocked by five pre-existing missing dependencies (`blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, `homer-operator`) and two missing GitRepository secrets. No changed-file diagnostic was reported. This is not presented as a passing gate.

## Related issue boundaries

- [corp/bhaiya#414](https://forgejo.keiretsu.top/corp/bhaiya/issues/414): this PR supplies the NPD/kubelet-health, node OOM, and pod-eviction telemetry portion only. It does not provide exact heartbeat-age measurement or Kata/VMM lifecycle telemetry.
- [#2641](https://github.com/keiretsu-labs/kubernetes-manifests/issues/2641): not closed. The investigation found ordinary virtiofsd syslog was collected through Talos syslog -> Fluent Bit -> VictoriaLogs and must be queried from the `content` field, not `_msg`. However, Cloud Hypervisor process stderr/exit status and virtiofsd process exit/I/O-error records were genuinely uncollected because the runtime drops them; NPD does not add that lifecycle instrumentation.
- [#2640](https://github.com/keiretsu-labs/kubernetes-manifests/issues/2640): not closed. KubePrism metrics do not exist in the deployed Talos/go-loadbalancer version, and relevant Warn diagnostics are suppressed at the source. This is not merely a collector or `_msg` query problem.
- [#2639](https://github.com/keiretsu-labs/kubernetes-manifests/issues/2639): not closed. Kata cAdvisor block-I/O attribution is genuinely absent/unlabelled for the checked sandboxes; the issue needs a bounded cgroup/Kata recorder or a separately reviewed privileged eBPF design.
- [#2636](https://github.com/keiretsu-labs/kubernetes-manifests/issues/2636): not closed. CSI logs are collected, but durable successful stage/map/unmap device history and PVC attribution are not retained; this needs CSI/node-level recording and longer retention.
- [#2212](https://github.com/keiretsu-labs/kubernetes-manifests/issues/2212): not closed. The Ottawa warning source is now identified as BlueStore slow operations, concentrated on four OSDs on `kaji` and one on `shiro`. This telemetry may help correlate a future node OOM/kubelet event, but it cannot identify or remediate the Ceph warning source.

No cordon, drain, reboot, config change, workspace restart, or other live remediation was performed.