### PR TITLE
test: prove CephFS RWX with disposable Ottawa probe

### DIFF
--- a/docs/reference/cephfs-rwx-probe.md
+++ b/docs/reference/cephfs-rwx-probe.md
@@ -15,14 +15,16 @@ place, appends records to a shared journal, writes and hashes a 482 MiB file,
 then deletes the test files. The shared journal is checked for all records from
 both writers, which tests concurrent visibility and detects lost appends. The
 probe prints measured small-file and sequential throughput plus average
-per-file latency in its pod logs.
+per-file latency in its pod logs. It records a durable marker before the
+second revision so the remount check has a discriminating control.
 
 The first revision leaves both pods ready after the workload. Change the
 `cephfs-proof.keiretsu.top/rollout` value in the Deployment pod template through
 GitOps for the second revision. The resulting replacement pods validate the
 marker from the first revision after a fresh volume mount and report
 `remount-validated`. This two-revision sequence is intentional: a container
-restart alone would not prove a CSI unmount/remount.
+restart alone would not prove a CSI unmount/remount, while a GitOps Deployment
+rollout replaces pods and forces a fresh mount.
 
 The phase request supplies the current Garage S3 comparison points: about
 `42 ms` average HTTP latency and `47 MiB/s` registry reads. Record those beside

--- a/docs/reference/cephfs-rwx-probe.md
+++ b/docs/reference/cephfs-rwx-probe.md
@@ -1,0 +1,50 @@
+# Ottawa CephFS RWX probe
+
+This is a deliberately disposable Phase 2 probe for the Ottawa `rook-cephfs`
+StorageClass. It is not a service and must not become one. The claim is `3Gi`
+and `ReadWriteMany`: that is a few GiB so two concurrent `482 MiB` test files,
+the small-file corpus, and filesystem overhead fit with headroom, while making
+the non-production intent obvious.
+
+## What it proves
+
+The two Deployment replicas require different nodes (and explicitly exclude
+`shiro`) while mounting the same claim. Each pod writes a marker and waits for
+the other marker, writes 2,000 unique 4 KiB files using temp-file rename into
+place, appends records to a shared journal, writes and hashes a 482 MiB file,
+then deletes the test files. The shared journal is checked for all records from
+both writers, which tests concurrent visibility and detects lost appends. The
+probe prints measured small-file and sequential throughput plus average
+per-file latency in its pod logs.
+
+The first revision leaves both pods ready after the workload. Change the
+`cephfs-proof.keiretsu.top/rollout` value in the Deployment pod template through
+GitOps for the second revision. The resulting replacement pods validate the
+marker from the first revision after a fresh volume mount and report
+`remount-validated`. This two-revision sequence is intentional: a container
+restart alone would not prove a CSI unmount/remount.
+
+The phase request supplies the current Garage S3 comparison points: about
+`42 ms` average HTTP latency and `47 MiB/s` registry reads. Record those beside
+the probe's `MEASURE` lines in the recovery findings file; they are comparison
+baselines, not measurements made by this probe.
+
+## Failure behavior boundary
+
+This probe does not interrupt Ceph, a monitor, an MDS, an OSD, or a node. It can
+show the mounted-pod behavior only for faults that occur naturally during the
+run. A brief forced volume outage would require an authorized failure
+experiment; without one, do not claim a result. Reasonably, a mounted process
+may block or return I/O errors while the kernel/CSI path recovers, and a fresh
+mount should depend on the CephFS and CSI control plane being available.
+
+## Teardown
+
+After measurements and review, remove `./cephfs-proof` from
+`kubernetes/apps/ottawa/kustomization.yaml` in a follow-up GitOps commit (or
+remove the `cephfs-proof` pointer directory). The child Kustomization has
+`prune: true`, so Flux removes the Deployment and ConfigMap; deleting the
+probe namespace removes the PVC and its `Delete`-policy CephFS subvolume. Verify
+with read-only `tools/kc.sh ot get pvc -n cephfs-proof` and
+`tools/kc.sh ot get pods -n cephfs-proof` after reconciliation. Do not manually
+delete production objects.

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -28,10 +28,10 @@ diagram in the [README](../../README.md#architecture).
 
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
-| `ottawa` | 4 | 58 | 121 |
+| `ottawa` | 4 | 59 | 122 |
 | `robbinsdale` | 3 | 43 | 87 |
 | `stpetersburg` | 3 | 39 | 79 |
-| **total** | **10** | **140** | **287** |
+| **total** | **10** | **141** | **288** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -112,6 +112,7 @@ diagram in the [README](../../README.md#architecture).
 | Fleet management | `open-cluster-management-agent` | `ocm-agent` |
 | GPU, RDMA and inference | `k8s-gpu-dra-driver` | `k8s-gpu-dra-driver` → ns `kube-system` |
 | Application workloads | `bhaiya` | `bhaiya` |
+| Application workloads | `cephfs-proof` | `cephfs-rwx-disposable-probe` |
 | Application workloads | `cliproxy` | `cliproxy` |
 | Application workloads | `firecrawl` | `firecrawl` |
 | Application workloads | `firefly` | `firefly`, `firefly-mcp` |

--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/configmap.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/configmap.yaml
@@ -25,7 +25,11 @@ data:
     }
 
     now_ns() {
-      date +%s%N
+      value=$$(date +%s%N)
+      case "$${value}" in
+        *[!0-9]*) date +%s000000000 ;;
+        *) printf '%s' "$${value}" ;;
+      esac
     }
 
     elapsed_ms() {

--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/configmap.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/configmap.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cephfs-rwx-disposable-probe-script
+  labels:
+    app.kubernetes.io/name: cephfs-rwx-disposable-probe
+data:
+  probe.sh: |
+    #!/bin/sh
+    set -eu
+
+    root=/probe
+    state="$${root}/state"
+    work="$${root}/work-$${HOSTNAME}"
+    host="$${HOSTNAME}"
+    small_count=2000
+    small_bytes=4096
+    large_bytes=505413632
+
+    mkdir -p "$${state}" "$${work}" "$${root}/status"
+
+    log() {
+      printf '%s probe=%s %s\n' "$$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$${host}" "$${1}"
+    }
+
+    now_ns() {
+      date +%s%N
+    }
+
+    elapsed_ms() {
+      start="$${1}"
+      end="$$(now_ns)"
+      value=$$(awk "BEGIN { printf \"%d\", ($${end} - $${start}) / 1000000 }")
+      if [ "$${value}" -lt 1 ]; then
+        value=1
+      fi
+      printf '%s' "$${value}"
+    }
+
+    mib_per_second() {
+      bytes="$${1}"
+      milliseconds="$${2}"
+      awk "BEGIN { printf \"%.2f\", ($${bytes} / 1048576) / ($${milliseconds} / 1000) }"
+    }
+
+    wait_for_peer() {
+      deadline=$$(date +%s)
+      deadline=$$(($${deadline} + 180))
+      while [ "$$(date +%s)" -lt "$${deadline}" ]; do
+        if [ "$$(find "$${state}" -maxdepth 1 -name 'writer-*' -type f | wc -l)" -ge 2 ]; then
+          return 0
+        fi
+        sleep 1
+      done
+      log "FAIL peer-writer-timeout"
+      exit 1
+    }
+
+    verify_journal() {
+      expected=$$(($${small_count} / 20 * 2))
+      actual=$$(wc -l < "$${state}/journal")
+      unique=$$(sort -u "$${state}/journal" | wc -l)
+      if [ "$${actual}" -ne "$${expected}" ] || [ "$${unique}" -ne "$${expected}" ]; then
+        log "FAIL journal-lines expected=$${expected} actual=$${actual} unique=$${unique}"
+        exit 1
+      fi
+      log "PASS concurrent-journal lines=$${actual} unique=$${unique}"
+    }
+
+    marker="$${state}/probe-complete"
+    ready="$${root}/status/ready-$${host}"
+
+    if [ ! -f "$${marker}" ]; then
+      log "START rwx=ReadWriteMany claim=cephfs-rwx-disposable-probe"
+
+      printf 'writer=%s\nwritten-before-restart=true\n' "$${host}" > "$${state}/writer-$${host}"
+      sync
+      wait_for_peer
+      for writer in "$${state}"/writer-*; do
+        grep -q '^written-before-restart=true$' "$${writer}"
+      done
+      log "PASS cross-pod-visibility writers=2"
+
+      start=$$(now_ns)
+      index=1
+      while [ "$${index}" -le "$${small_count}" ]; do
+        dd if=/dev/zero of="$${work}/small-$${index}.tmp" bs="$${small_bytes}" count=1 conv=fsync status=none
+        printf '%s:%s\n' "$${host}" "$${index}" >> "$${work}/small-$${index}.tmp"
+        mv "$${work}/small-$${index}.tmp" "$${work}/small-$${index}.blob"
+        if [ $$(($${index} % 20)) -eq 0 ]; then
+          printf '%s:%s\n' "$${host}" "$${index}" >> "$${state}/journal"
+        fi
+        index=$$(($${index} + 1))
+      done
+      sync
+      small_ms=$$(elapsed_ms "$${start}")
+      small_total_bytes=$$(($${small_count} * $${small_bytes}))
+      small_rate=$$(mib_per_second "$${small_total_bytes}" "$${small_ms}")
+      small_avg=$$(awk "BEGIN { printf \"%.3f\", $${small_ms} / $${small_count} }")
+      log "MEASURE small_files count=$${small_count} bytes=$${small_total_bytes} elapsed_ms=$${small_ms} throughput_MiB_s=$${small_rate} avg_write_latency_ms=$${small_avg}"
+
+      start=$$(now_ns)
+      dd if=/dev/zero of="$${work}/large-$${host}.tmp" bs=1M count=482 conv=fsync status=none
+      mv "$${work}/large-$${host}.tmp" "$${work}/large-$${host}.blob"
+      large_ms=$$(elapsed_ms "$${start}")
+      large_rate=$$(mib_per_second "$${large_bytes}" "$${large_ms}")
+      large_hash=$$(sha256sum "$${work}/large-$${host}.blob" | cut -d ' ' -f 1)
+      log "MEASURE sequential_large_file bytes=$${large_bytes} size_MiB=482 elapsed_ms=$${large_ms} throughput_MiB_s=$${large_rate} sha256=$${large_hash}"
+
+      if [ "$$(wc -c < "$${work}/large-$${host}.blob")" -ne "$${large_bytes}" ]; then
+        log "FAIL large-file-size"
+        exit 1
+      fi
+      rm -f "$${work}/large-$${host}.blob"
+      find "$${work}" -name 'small-*.blob' -delete
+      if [ -n "$$(find "$${work}" -type f -print -quit)" ]; then
+        log "FAIL small-file-delete"
+        exit 1
+      fi
+      log "PASS rename-and-delete small_files=$${small_count} large_file_bytes=$${large_bytes}"
+
+      touch "$${state}/completed-$${host}"
+      deadline=$$(date +%s)
+      deadline=$$(($${deadline} + 180))
+      while [ "$$(find "$${state}" -maxdepth 1 -name 'completed-*' -type f | wc -l)" -lt 2 ]; do
+        if [ "$$(date +%s)" -ge "$${deadline}" ]; then
+          log "FAIL peer-completion-timeout"
+          exit 1
+        fi
+        sleep 1
+      done
+      verify_journal
+      printf 'written-before-restart=true\ncompleted-by=%s\n' "$${host}" > "$${marker}"
+      sync
+      log "PASS pre-restart-persistence-marker marker=$${marker}"
+      touch "$${ready}"
+      log "READY initial-pass-complete awaiting-GitOps-rollout=true"
+      while :; do
+        sleep 3600
+      done
+    fi
+
+    if ! grep -q '^written-before-restart=true$' "$${marker}"; then
+      log "FAIL pre-restart-marker-content"
+      exit 1
+    fi
+    log "PASS restart-persistence remount-validated marker=$${marker}"
+    touch "$${ready}"
+    log "READY all-probes-passed restart_count_expected_at_least_one=true"
+    while :; do
+      sleep 3600
+    done

--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/deployment.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/deployment.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cephfs-rwx-disposable-probe
+  labels:
+    app.kubernetes.io/name: cephfs-rwx-disposable-probe
+    cephfs-proof.keiretsu.top/disposable: "true"
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cephfs-rwx-disposable-probe
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cephfs-rwx-disposable-probe
+      annotations:
+        cephfs-proof.keiretsu.top/rollout: "initial"
+    spec:
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 65532
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - shiro
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: cephfs-rwx-disposable-probe
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: cephfs-rwx-probe
+          image: alpine:3.24
+          command: ["/bin/sh", "/scripts/probe.sh"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "test -f /probe/status/ready-$${HOSTNAME}"]
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "test -d /probe/state"]
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: probe-volume
+              mountPath: /probe
+            - name: probe-script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: probe-volume
+          persistentVolumeClaim:
+            claimName: cephfs-rwx-disposable-probe
+        - name: probe-script
+          configMap:
+            name: cephfs-rwx-disposable-probe-script
+            defaultMode: 0755

--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/kustomization.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cephfs-proof
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - configmap.yaml
+  - deployment.yaml

--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/namespace.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cephfs-proof
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/pvc.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/pvc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cephfs-rwx-disposable-probe
+  labels:
+    app.kubernetes.io/name: cephfs-rwx-disposable-probe
+    cephfs-proof.keiretsu.top/disposable: "true"
+  annotations:
+    cephfs-proof.keiretsu.top/purpose: "Phase 2 RWX filesystem probe; safe to delete after measurements"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: rook-cephfs
+  resources:
+    requests:
+      storage: 3Gi

--- a/kubernetes/apps/ottawa/cephfs-proof/cephfs-rwx-disposable-probe.yaml
+++ b/kubernetes/apps/ottawa/cephfs-proof/cephfs-rwx-disposable-probe.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cephfs-rwx-disposable-probe
+  namespace: flux-system
+spec:
+  targetNamespace: cephfs-proof
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster-config
+  path: ./kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/ottawa/cephfs-proof/kustomization.yaml
+++ b/kubernetes/apps/ottawa/cephfs-proof/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cephfs-rwx-disposable-probe.yaml

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -56,6 +56,7 @@ resources:
   - ./tuppr
   - ./k8s-gpu-dra-driver
   - ./rook-ceph
+  - ./cephfs-proof
   - ./velero
   - ./vpa-system
   - ./victoria-logs


### PR DESCRIPTION
## Phase 2: prove `rook-cephfs` with a disposable RWX workload

- Adds an Ottawa-only `3Gi` `ReadWriteMany` claim on `rook-cephfs`.
- Runs two anti-affined pods on different nodes (excluding `shiro`) against the same claim.
- Exercises cross-pod markers, concurrent journal writes, rename-into-place/delete of 2,000 small files, and a 482 MiB single-file write with measured throughput/latency.
- Documents the second GitOps rollout needed to validate a fresh CSI remount and the read-only failure-behavior boundary.
- Adds an explicit teardown path; the child Kustomization uses `prune: true` and the PVC uses the StorageClass `Delete` reclaim policy.

Validation: `tools/check.sh ot` reaches the render gate but the current checkout has five pre-existing dependency failures (missing OCI chart dependencies and a missing Homer values ConfigMap); the probe itself renders. The exact output is in the run log.

Do not merge until the probe has run, measurements are recorded, and the teardown follow-up is prepared.