### PR TITLE
fix: recreate disposable CephFS probe after UID correction

### DIFF
--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/deployment.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/deployment.yaml
@@ -9,10 +9,7 @@ metadata:
 spec:
   replicas: 2
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: cephfs-rwx-disposable-probe


### PR DESCRIPTION
After #2672, the corrected UID-65532 container starts, but the Deployment's required pod anti-affinity includes the two stale failed pods from revision 1. With `maxUnavailable: 0`, the new ReplicaSet can only schedule one pod on `kaji` and deadlocks waiting for a second distinct node. This GitOps-only probe correction changes the disposable Deployment strategy to `Recreate`, allowing the controller to remove the stale ReplicaSet before starting both current pods. No Ceph, StorageClass, existing PVC, Zot, or node configuration changes.