### PR TITLE
test(cephfs): trigger second RWX probe revision

### DIFF
--- a/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/deployment.yaml
+++ b/kubernetes/apps/base/cephfs-proof/cephfs-rwx-probe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         app.kubernetes.io/name: cephfs-rwx-disposable-probe
       annotations:
-        cephfs-proof.keiretsu.top/rollout: "initial"
+        cephfs-proof.keiretsu.top/rollout: "second"
     spec:
       terminationGracePeriodSeconds: 5
       securityContext:


### PR DESCRIPTION
## Summary

- change `cephfs-proof.keiretsu.top/rollout` from `initial` to `second`
- trigger a fresh Deployment/CSI mount after the merged monotonic timing and `run-v2` changes

## Why

Flux has applied `main@sha1:8f07351b90875175718b154a126f9d836672db31`, but the ConfigMap update did not restart the existing shell processes. The current pods started before that merge and their logs still show the old `/probe/state` marker and clamped timing. This pod-template change is the GitOps-only remount/restart control.

Do not merge until the second-revision pods have been inspected and the benchmark clock passes sanity checks.

## Verification

- `git diff --check` passes.
- `tools/check.sh talos-ottawa` was retried twice; both quick attempts were blocked by unrelated missing chart dependencies/value sources (`blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, `homer-operator`). The first attempt hit the documented Flate timeout and was killed.
