### PR TITLE
chore(cephfs-proof): remove disposable probe

### DIFF
--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -56,7 +56,6 @@ resources:
   - ./tuppr
   - ./k8s-gpu-dra-driver
   - ./rook-ceph
-  - ./cephfs-proof
   - ./velero
   - ./vpa-system
   - ./victoria-logs


### PR DESCRIPTION
## Summary

- remove `./cephfs-proof` from `kubernetes/apps/ottawa/kustomization.yaml`
- allow Flux to prune the disposable CephFS probe after merge

## Teardown path

The child `cephfs-rwx-disposable-probe` Kustomization has `prune: true` and owns the probe Deployment, ConfigMap, PVC, and namespace resource. The live `rook-cephfs` StorageClass is bound to `filesystem-replicated` and has `reclaimPolicy: Delete`, so deleting the probe PVC will delete its PV and CephFS CSI subvolume. The namespace is labeled `kustomize.toolkit.fluxcd.io/prune: disabled`; verify the actual namespace/PVC/subvolume state after reconciliation rather than manually deleting anything.

This PR does not change Ceph, OSDs, the StorageClass, or any workload. Do not merge until the final evidence has been reviewed.

## Verification

- `git diff --check` passes.
- `tools/gen-inventory.sh` reports inventory already current.
- `tools/orphans.sh` passes.
- `tools/check.sh talos-ottawa` reaches the manifest render but is blocked by the repository's existing missing chart dependencies/value sources (`blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, `homer-operator`).
