### PR TITLE
fix(garage): run patched build in Ottawa for the multipart panic

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -41,6 +41,15 @@ data:
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
   VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
+  # Garage: patched build carrying the CompleteMultipartUpload empty-blocks fix
+  # (upstream Deuxfleurs/garage#1403, still unfixed as of v2.3.0). Upstream indexes
+  # final_version.blocks.items()[0] unconditionally and the process dies before it
+  # can answer; the patch returns an internal error instead. Ottawa only, because
+  # this build is linux/amd64 ONLY while upstream dxflrs/garage ships four
+  # platforms — every Ottawa node is amd64, the other clusters keep the default.
+  # Revert by removing this key.
+  GARAGE_IMAGE: "ghcr.io/rajsinghtech/garage:v2.3.0-multipart-fix-175b6b750fcfdf54fc0f9c5d0bd5850169d4b17a@sha256:31f5ba8bf49b5a582807e8632e2538948c9c9a202aee03cb2472da5de984ac6b"
+
   # Garage: storage layout hand-managed per-node in clusters/talos-ottawa/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.

--- a/kubernetes/apps/base/garage/garage/garagecluster.yaml
+++ b/kubernetes/apps/base/garage/garage/garagecluster.yaml
@@ -14,7 +14,11 @@ metadata:
   name: garage
 spec:
   zone: "${LOCATION}"
-  image: dxflrs/garage:v2.3.0
+  # Default is the upstream multi-arch image. A cluster may override GARAGE_IMAGE
+  # in its cluster-settings to run a patched build; any override must cover every
+  # node architecture in that cluster, since a single-arch image will not run on
+  # a mixed-arch cluster.
+  image: ${GARAGE_IMAGE:=dxflrs/garage:v2.3.0}
 
   replication:
     factor: 3


### PR DESCRIPTION
Runs a locally patched Garage build in **Ottawa only**, to verify the CompleteMultipartUpload empty-blocks fix on a live cluster.

## The defect

Garage v2.3.0 indexes `final_version.blocks.items()[0]` unconditionally in `src/api/s3/multipart.rs`. When the assembled final version has no blocks the process panics and dies before it can answer the request:

```
panicked at src/api/s3/multipart.rs:479:3:
index out of bounds: the len is 0 but the index is 0
```

Ottawa's `garage-gateway-1-0` has taken this repeatedly — restart count 5, most recently `2026-09-03T17:22:34Z`, exit 139. It degrades Zot's write path, which is why workspace-image `promote` has been failing on its push budget and 13 image versions have been built but never delivered.

**There is nothing upstream to pick up.** Deuxfleurs/garage#1403 is *closed* — the reporter's symptom went away when they switched from `consistency_mode = "dangerous"` to `consistent`, and a maintainer noted on that thread that Garage shouldn't panic regardless and they'd fix it "once we know how it happens." The dereference is still present in `v2.3.0`, `main-v2` and `next-v3`, and there is no release after v2.3.0.

## The change

`spec.image` becomes substitutable, defaulting to the current upstream image, and Ottawa sets `GARAGE_IMAGE` to the patched build. Robbinsdale and St. Petersburg are untouched — they resolve the default and do not roll.

The patch itself replaces the index with `.first()` and returns an internal error, matching how the rest of that file handles missing data. The empty-blocks case is an internal consistency condition rather than a malformed request, so it maps to an internal error rather than a 4xx. Its GitHub Actions build compiled `garage_api_s3` from the patched source, passed all 36 S3 API unit tests, and compared the image binary byte-for-byte against what it built.

## Two things a reviewer should weigh

**The patched build is `linux/amd64` only.** Upstream `dxflrs/garage:v2.3.0` publishes `linux/arm64`, `linux/amd64`, `linux/386` and `linux/arm`. Every Ottawa node is amd64 (`asuka`, `kaji`, `rei`, `shiro`), so this is safe there — and it is precisely why the override is scoped to Ottawa rather than applied to the base. A comment on the substitution records the constraint so nobody widens it accidentally.

**Blast radius within Ottawa is the whole GarageCluster.** The CRD exposes only a top-level `spec.image`; there is no per-gateway or per-node override, so a finer canary is not possible. This rolls both gateways and the storage tier, affecting every Ottawa consumer — Forgejo, Mimir, Immich, Tracearr, the Postgres backup buckets, tailscale-logs and Velero.

The image is pinned by tag **and** digest so the running artifact is unambiguous.

## Revert

Remove `GARAGE_IMAGE` from `clusters/talos-ottawa/flux/vars/cluster-settings.yaml`; the default restores the upstream multi-arch image.

## What success looks like

No `index out of bounds` panic in the gateway logs under a real `CompleteMultipartUpload`, a registry push that previously timed out completing, and no restart-count growth on `garage-gateway-*`.