### PR TITLE
feat(monitoring): alert on incomplete k8gb published target sets

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -28,6 +28,7 @@ configMapGenerator:
       - rules/flux.yaml
       - rules/garage.yaml
       - rules/k8gb.yaml
+      - rules/k8gb-dns.yaml
       - rules/media.yaml
       - rules/mimir-loader.yaml
       - rules/monitoring.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -43,6 +43,7 @@ spec:
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
+            - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
             - /rules/monitoring.yaml
@@ -73,6 +74,7 @@ spec:
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
+            - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
             - /rules/monitoring.yaml
@@ -99,6 +101,7 @@ spec:
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
+            - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
             - /rules/monitoring.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/k8gb-dns.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/k8gb-dns.yaml
@@ -19,7 +19,8 @@ groups:
           min_over_time(
             k8gb_endpoint_status_num{
               namespace="k8gb",
-              name=~"gatus-status|garage-s3-cdn|hubble|keiretsu-web"
+              name=~"gatus-status|garage-s3-cdn|hubble|keiretsu-web",
+              dns_name!~"localtargets-.*"
             }[5m]
           ) < 3
         for: 1m
@@ -39,7 +40,8 @@ groups:
           min_over_time(
             k8gb_endpoint_status_num{
               namespace="k8gb",
-              name=~"dashboard-cdn|forgejo|opencost|velero|zot-public"
+              name=~"dashboard-cdn|forgejo|opencost|velero|zot-public",
+              dns_name!~"localtargets-.*"
             }[5m]
           ) < 1
         for: 1m
@@ -68,14 +70,16 @@ groups:
             min_over_time(
               k8gb_endpoint_status_num{
                 namespace="k8gb",
-                name=~"gatus-status|garage-s3-cdn|hubble|keiretsu-web"
+                name=~"gatus-status|garage-s3-cdn|hubble|keiretsu-web",
+                dns_name!~"localtargets-.*"
               }[5m]
             ) < 3
             or
             min_over_time(
               k8gb_endpoint_status_num{
                 namespace="k8gb",
-                name=~"dashboard-cdn|forgejo|opencost|velero|zot-public"
+                name=~"dashboard-cdn|forgejo|opencost|velero|zot-public",
+                dns_name!~"localtargets-.*"
               }[5m]
             ) < 1
           )

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/k8gb-dns.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/k8gb-dns.yaml
@@ -1,0 +1,94 @@
+# These alerts are evaluated by the per-cluster Mimir tenants. The native
+# k8gb_gslb_errors_total metric is a generic reconciliation-error counter in
+# v0.20.0: it has no error-reason label, so it cannot identify an
+# ExposedIPResolutionError on its own.
+#
+# k8gb_endpoint_status_num is the final published target count. The common
+# replicated GSLBs below should contain all three clusters; the Ottawa-only
+# GSLBs should contain only Ottawa's one target. dashboard-ts-cdn and ts-gateway
+# are intentionally excluded: they read direct Gateway addresses rather than
+# the exposed-hostname resolution path and need separate target semantics.
+#
+# Keep this namespace unique across every file passed to mimirtool.
+namespace: k8gb-dns
+groups:
+  - name: k8gb-dns.rules
+    rules:
+      - alert: K8gbReplicatedTargetSetIncomplete
+        expr: |
+          min_over_time(
+            k8gb_endpoint_status_num{
+              namespace="k8gb",
+              name=~"gatus-status|garage-s3-cdn|hubble|keiretsu-web"
+            }[5m]
+          ) < 3
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: >-
+            k8gb GSLB {{ $labels.name }} has an incomplete published target set
+          description: >-
+            {{ $labels.name }} ({{ $labels.dns_name }}) published fewer than
+            three targets during the last five minutes; the expected set is
+            Ottawa, Robbinsdale, and St. Petersburg. This is the user-visible
+            GSLB failure signal even when the k8gb pod and CoreDNS remain Ready.
+
+      - alert: K8gbOttawaOnlyTargetMissing
+        expr: |
+          min_over_time(
+            k8gb_endpoint_status_num{
+              namespace="k8gb",
+              name=~"dashboard-cdn|forgejo|opencost|velero|zot-public"
+            }[5m]
+          ) < 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: >-
+            k8gb GSLB {{ $labels.name }} lost its published target
+          description: >-
+            {{ $labels.name }} ({{ $labels.dns_name }}) published no target
+            during the last five minutes; the expected Ottawa-only set contains
+            one target. This is the user-visible GSLB failure signal even when
+            the k8gb pod and CoreDNS remain Ready.
+
+      - alert: K8gbPossibleExposedIPResolutionError
+        expr: |
+          (
+            sum by (namespace, name) (
+              increase(
+                k8gb_gslb_errors_total{namespace="k8gb"}[5m]
+              )
+            ) >= 2
+          )
+          and on (namespace, name)
+          (
+            min_over_time(
+              k8gb_endpoint_status_num{
+                namespace="k8gb",
+                name=~"gatus-status|garage-s3-cdn|hubble|keiretsu-web"
+              }[5m]
+            ) < 3
+            or
+            min_over_time(
+              k8gb_endpoint_status_num{
+                namespace="k8gb",
+                name=~"dashboard-cdn|forgejo|opencost|velero|zot-public"
+              }[5m]
+            ) < 1
+          )
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            k8gb {{ $labels.name }} has repeated reconciliation errors with
+            target loss
+          description: >-
+            k8gb recorded at least two reconciliation errors for {{ $labels.name
+            }} in the last five minutes while its published target set was
+            incomplete. v0.20.0 does not label k8gb_gslb_errors_total by reason,
+            so confirm ExposedIPResolutionError in the k8gb events/logs; the
+            authoritative impact signal is the corresponding target-set alert.


### PR DESCRIPTION
Adds an evaluated Mimir rule group for the k8gb DNS failure in #2348, where St. Petersburg intermittently loses edge-hostname resolution while every k8gb and CoreDNS pod stays Ready and recovery is automatic — so nothing surfaces it.

## Why it alerts on target sets rather than the error counter

The obvious rule would be on `k8gb_gslb_errors_total{reason="ExposedIPResolutionError"}`. That reason label **does not exist** in k8gb v0.20.0 — the counter is a generic reconciliation-error total, and a healthy-state query showed alerting on it unqualified would be noisy.

So the rules alert on the user-visible harm instead: `k8gb_endpoint_status_num` falling below the expected published target count. Replicated GSLBs should carry all three clusters; Ottawa-only GSLBs should carry one. A third rule correlates repeated reconciliation errors *with* target loss as a warning, and its annotation states plainly that the reason must be confirmed from events or logs.

`localtargets-*` series are excluded, and `dashboard-ts-cdn` / `ts-gateway` are excluded because they read direct Gateway addresses rather than the exposed-hostname resolution path.

## Firing proof

Evaluated against the live St. Petersburg tenant, not asserted from the expression's shape:

- **Fires:** at `2026-09-04T01:02:00Z` the replicated-target expression returned `garage-s3-cdn` / `s3.cdn.keiretsu.top` with value `2` against an expected `3`, and the correlated error expression returned the same GSLB at `3.3333`. The target expression returned `2` again at `01:54:40Z`.
- **Quiet when healthy:** the replicated expression was empty at `00:59:40Z`, `01:10:00Z` and `02:10:00Z`; the Ottawa-only expression was empty at `01:02:00Z`, `01:54:40Z` and `02:10:00Z`; the correlated expression was empty at `00:59:40Z`, `01:10:00Z` and `02:10:00Z`.

That covers both directions, including the `localtargets` exclusion.

## Wiring

Rules load through the existing `mimir-config-loader` Job, which syncs once per tenant — the file is added to all three containers (`--id=talos-ottawa`, `talos-robbinsdale`, `talos-stpetersburg`), so it is evaluated in St. Petersburg where the failure occurs, despite living under `mimir-ottawa/` with the other shared rules. Namespace `k8gb-dns` is unique, as the loader requires.

The Job's immutable `spec.template` is handled by the existing `kustomize.toolkit.fluxcd.io/force: enabled` annotation plus the hash-suffixed rules ConfigMap, so a rule change rolls the Job rather than wedging the kustomization.

A PrometheusRule CR was deliberately not used: Ottawa runs Prometheus in Agent mode, so such a CR is inert.

## Limits

These detect an incomplete or lost published target set. They do not name the cause — v0.20.0 gives no reason label. Once k8gb exposes one (or an events-to-metrics exporter supplies it), the direct rule becomes `sum by (namespace, name) (increase(k8gb_gslb_errors_total{reason="ExposedIPResolutionError"}[5m])) >= 2` with a short `for`.

The underlying network question in #2348 — UDP timeouts to the single configured edge resolver `1.1.1.1` — is not addressed here and remains open. This makes the next occurrence visible; it does not fix it.

The `check.sh` failures on this branch are the pre-existing ones tracked in #2684 (unavailable OCI chart sources, `homer-operator` values); the changed Mimir and k8gb objects rendered successfully.
