### PR TITLE
fix(garage): deploy read-path panic fix in Ottawa

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -41,14 +41,16 @@ data:
   COMMON_S3_ENDPOINT: "garage-gateway.garage.svc.cluster.local:3900"
   VICTORIA_LOGS_HOST: "victoria-logs-victoria-logs-single-server.monitoring"
 
-  # Garage: patched build carrying the CompleteMultipartUpload empty-blocks fix
-  # (upstream Deuxfleurs/garage#1403, still unfixed as of v2.3.0). Upstream indexes
-  # final_version.blocks.items()[0] unconditionally and the process dies before it
-  # can answer; the patch returns an internal error instead. Ottawa only, because
-  # this build is linux/amd64 ONLY while upstream dxflrs/garage ships four
-  # platforms — every Ottawa node is amd64, the other clusters keep the default.
+  # Garage: patched build carrying the CompleteMultipartUpload and GET
+  # empty-blocks fixes (upstream Deuxfleurs/garage#1403, still unfixed as of
+  # v2.3.0). Upstream indexes final_version.blocks.items()[0] during multipart
+  # completion and all_blocks[0] while reading; a zero-block version can kill
+  # the process before it can answer. The patches return an internal error for
+  # completion and an empty body for GET. Ottawa only, because this build is
+  # linux/amd64 ONLY while upstream dxflrs/garage ships four platforms — every
+  # Ottawa node is amd64, the other clusters keep the default.
   # Revert by removing this key.
-  GARAGE_IMAGE: "ghcr.io/rajsinghtech/garage:v2.3.0-multipart-fix-175b6b750fcfdf54fc0f9c5d0bd5850169d4b17a@sha256:31f5ba8bf49b5a582807e8632e2538948c9c9a202aee03cb2472da5de984ac6b"
+  GARAGE_IMAGE: "ghcr.io/rajsinghtech/garage:v2.3.0-multipart-fix-63a41e9bf41e25f27adf83752c8c9a1e6cc3e0b6@sha256:38cccb8a9ef4c20f80c372c9ae4c5cf0ef32596ee00fc5f3ce32355331798847"
 
   # Garage: storage layout hand-managed per-node in clusters/talos-ottawa/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway


### PR DESCRIPTION
## Summary

- Pin the second patched Garage v2.3.0 image in Ottawa.
- Carries both empty-block guards: `CompleteMultipartUpload` and GET of a zero-block version.
- Robbinsdale and St. Petersburg retain the upstream `dxflrs/garage:v2.3.0` default.

## Image provenance

Built by the existing fork-only `rajsinghtech/garage` GitHub Actions workflow (run [33835397301](https://github.com/rajsinghtech/garage/actions/runs/33835397301)) using the project `.#amd64` Nix release package and scratch-image verification.

Image:
`ghcr.io/rajsinghtech/garage:v2.3.0-multipart-fix-63a41e9bf41e25f27adf83752c8c9a1e6cc3e0b6@sha256:38cccb8a9ef4c20f80c372c9ae4c5cf0ef32596ee00fc5f3ce32355331798847`

The digest-qualified image was pulled successfully into an OCI layout; its manifest, config, and layer hashes matched, and the config reported `linux/amd64` with source revision `63a41e9bf41e25f27adf83752c8c9a1e6cc3e0b6`.

## Verification

- `cargo check -p garage_api_s3`: passed
- `cargo test --locked -p garage_api_s3 --lib`: 36 passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- `tools/check.sh talos-ottawa`: currently reaches 107 passed / 123 skipped but has five unrelated unavailable chart/value dependencies (`blackbox-exporter`, `grafana-operator`, `kube-prometheus-stack`, `smartctl-exporter`, `homer-operator`); the same result reproduced on retry.

Do not merge automatically; Ottawa rollout should be watched after merge.
