### PR TITLE
fix: make local Flate gate baseline-aware

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - "clusters/**"
       - "kubernetes/**"
+      - "tools/**"
+      - "Makefile"
+      - ".github/workflows/flate.yaml"
   workflow_dispatch:
 
 concurrency:
@@ -23,15 +26,16 @@ jobs:
         cluster: [talos-ottawa, talos-robbinsdale, talos-stpetersburg]
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: home-operations/flate/action@v0.6.5
         with:
           cache: true
       - name: render gate
-        # check.sh is the same bounded gate agents run locally. The flate action
-        # exports FLATE_BASE=<pr base>, so unset it to test the full head tree.
-        run: |
-          unset FLATE_BASE
-          tools/check.sh ${{ matrix.cluster }}
+        # check.sh is the same bounded gate agents run locally. Both paths use
+        # Flate's changed-only baseline: the action exports FLATE_BASE=main,
+        # while local checkouts select their default-remote merge-base.
+        run: tools/check.sh ${{ matrix.cluster }}
 
   diff:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,18 @@ test: ## Render-test all clusters with flate
 
 test-%: ## Render-test one cluster, e.g. make test-talos-ottawa
 	@$(FLATE) test all --path clusters/$*/flux/config $(FLATE_FLAGS)
-# The app tree is a second scan only in changed-only mode: its files sit
-# outside the cluster-config scan root, but must still be able to fail the
-# bounded gate when an application manifest changes.
+# Application manifests live in two trees while the migration is completed.
+# Both trees sit outside the cluster-config scan root, but must still be able
+# to fail the bounded gate when an application manifest changes. Some clusters
+# have no legacy app tree, so skip a missing path.
 ifneq ($(strip $(FLATE_BASE)),)
-	@$(FLATE) test all --path kubernetes/apps/$(patsubst talos-%,%,$*) $(FLATE_FLAGS)
+	@for path in \
+		clusters/$*/apps \
+		kubernetes/apps/$(patsubst talos-%,%,$*); do \
+		if [ -d "$$path" ]; then \
+			$(FLATE) test all --path "$$path" $(FLATE_FLAGS) || exit 1; \
+		fi; \
+	done
 endif
 
 diff: ## Show rendered diff vs origin/main for all clusters

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ test: ## Render-test all clusters with flate
 
 test-%: ## Render-test one cluster, e.g. make test-talos-ottawa
 	@$(FLATE) test all --path clusters/$*/flux/config $(FLATE_FLAGS)
+# The app tree is a second scan only in changed-only mode: its files sit
+# outside the cluster-config scan root, but must still be able to fail the
+# bounded gate when an application manifest changes.
+ifneq ($(strip $(FLATE_BASE)),)
+	@$(FLATE) test all --path kubernetes/apps/$(patsubst talos-%,%,$*) $(FLATE_FLAGS)
+endif
 
 diff: ## Show rendered diff vs origin/main for all clusters
 	@for c in $(CLUSTERS); do \

--- a/README.md
+++ b/README.md
@@ -603,9 +603,12 @@ consumed by Flux envsubst. In raw manifests, write
 
 ### Validation and diagnostics
 
-Every PR touching <code>clusters/**</code> or <code>kubernetes/**</code> runs
-the Flate matrix and per-cluster rendered-diff workflow. The local gate uses
-the same CI-pinned Flate release:
+Every PR touching <code>clusters/**</code>, <code>kubernetes/**</code>, the
+render helpers, or the Flate workflow runs the Flate matrix and per-cluster
+rendered-diff workflow. The local gate uses the same CI-pinned Flate release
+and compares the render with the default-remote merge-base, so stable
+failures from a cold cache do not make a clean tree red. Set
+<code>KMAN_CHECK_FULL_TREE=1</code> for a full-tree diagnostic:
 
 ~~~bash
 tools/check.sh

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -76,7 +76,7 @@ The local gate must pass before commit:
 
 | Command | What it checks |
 |---|---|
-| `tools/check.sh [cluster]` | CI-pinned Flate render of all three clusters |
+| `tools/check.sh [cluster]` | CI-pinned Flate changed-only render of all three clusters |
 | `tools/check-versions.sh` | `talconfig` ↔ tuppr, `CephCluster` ↔ toolbox |
 | `tools/orphans.sh` | kustomization ↔ disk drift |
 | `tools/check-diagram.sh` | the architecture docs: syntax, secrets, staleness, coverage, links |

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -58,6 +58,24 @@ if [ "$QUICK" = 1 ] && [ -n "$TARGET" ]; then
   exit 2
 fi
 
+# Flate's full-tree render includes stable failures when the local source and
+# render caches are cold, while CI restores those caches before running this
+# gate. Compare the render with a baseline instead: a clean checkout has no
+# changed resources to report, and a changed resource is still rendered and
+# can fail. The cluster target also scans the location app tree because those
+# files live outside the cluster-config scan root. The CI action supplies
+# FLATE_BASE=main; local checkouts select the merge-base with the default
+# remote (or the branch upstream as a fallback).
+# Set KMAN_CHECK_FULL_TREE=1 for an intentional full-tree diagnostic run.
+if [ -z "${KMAN_CHECK_FULL_TREE:-}" ] && [ -z "${FLATE_BASE:-}" ]; then
+  for candidate in origin/HEAD origin/main origin/master '@{u}'; do
+    if render_base="$(git merge-base HEAD "$candidate" 2>/dev/null)"; then
+      export FLATE_BASE="$render_base"
+      break
+    fi
+  done
+fi
+
 # Rendering resolves Helm/OCI chart sources through go-containerregistry, which
 # reads ~/.docker/config.json. On macOS that file sets `credsStore: osxkeychain`,
 # so every registry read shells out to docker-credential-osxkeychain and raises a

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -295,14 +295,16 @@ exits  "missing file -> exit 1"     1 "$T/where.sh" foo /no/such/file.xyz
 # ---------------------------------------------------------------- flate.sh (pinned binary; no network)
 section "flate.sh (stubbed binary)"
 fstub="$(mktemp -d)"
+flate_pin="$(sed -n 's|.*home-operations/flate/action@v\([0-9][0-9.]*\).*|\1|p' \
+  "$ROOT/.github/workflows/flate.yaml" | sort -u | head -1)"
 flate_calls="$fstub/calls"
-cat >"$fstub/flate" <<'EOF'
+cat >"$fstub/flate" <<EOF
 #!/usr/bin/env bash
-if [ "${1:-}" = "--version" ]; then
-  echo "flate version 0.5.0"
+if [ "\${1:-}" = "--version" ]; then
+  echo "flate version $flate_pin"
   exit 0
 fi
-printf '%s\n' "$*" >>"$FLATE_CALLS"
+printf '%s\n' "\$*" >>"\$FLATE_CALLS"
 EOF
 chmod +x "$fstub/flate"
 
@@ -316,7 +318,7 @@ KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" \
   "$T/flate.sh" diff all --allow-missing-secrets
 assert "explicit missing-secret flag -> no duplicate" \
   grep -q '^diff all --allow-missing-secrets$' "$flate_calls"
-assert "CI action pin matches wrapper fixture" grep -q 'home-operations/flate/action@v0.5.0' "$ROOT/.github/workflows/flate.yaml"
+assert "CI action pin matches wrapper fixture" grep -q "home-operations/flate/action@v$flate_pin" "$ROOT/.github/workflows/flate.yaml"
 
 cat >"$fstub/old-flate" <<'EOF'
 #!/usr/bin/env bash
@@ -325,13 +327,21 @@ EOF
 chmod +x "$fstub/old-flate"
 oldout="$(KMAN_FLATE_BIN="$fstub/old-flate" "$T/flate.sh" test all 2>&1)"; oldec=$?
 assert "mismatched override -> exit 2" test "$oldec" = 2
-assert "mismatch names required version" grep -q 'CI requires 0.5.0' <<<"$oldout"
+assert "mismatch names required version" grep -q "CI requires $flate_pin" <<<"$oldout"
 
 : >"$flate_calls"
 KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" make -s -C "$ROOT" test
 assert "full make gate -> three renders" test "$(wc -l <"$flate_calls" | tr -d ' ')" = 3
+
+: >"$flate_calls"
+KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" FLATE_BASE=baseline \
+  make -s -C "$ROOT" test
+assert "baseline make gate -> six renders" test "$(wc -l <"$flate_calls" | tr -d ' ')" = 6
 for cluster in talos-ottawa talos-robbinsdale talos-stpetersburg; do
   assert "full make gate -> $cluster" grep -q -- "--path clusters/$cluster/flux/config" "$flate_calls"
+  location="${cluster#talos-}"
+  assert "baseline make gate -> $location app tree" \
+    grep -q -- "--path kubernetes/apps/$location" "$flate_calls"
 done
 rm -rf "$fstub"
 
@@ -381,8 +391,7 @@ rm -rf "$mstub"
 # ---------------------------------------------------------------- flate.sh env pruning
 section "flate.sh environment pruning"
 fstub="$(mktemp -d)"
-pinned="$(sed -n 's|.*home-operations/flate/action@v\([0-9][0-9.]*\).*|\1|p' \
-  "$ROOT/.github/workflows/flate.yaml" | sort -u | head -1)"
+pinned="$flate_pin"
 # A stand-in for the UPX-packed release: it refuses to run once the environment
 # grows past what the real stub tolerates, which is exactly the failure mode.
 cat >"$fstub/flate" <<EOF

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -336,13 +336,38 @@ assert "full make gate -> three renders" test "$(wc -l <"$flate_calls" | tr -d '
 : >"$flate_calls"
 KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" FLATE_BASE=baseline \
   make -s -C "$ROOT" test
-assert "baseline make gate -> six renders" test "$(wc -l <"$flate_calls" | tr -d ' ')" = 6
+assert "baseline make gate -> eight renders" test "$(wc -l <"$flate_calls" | tr -d ' ')" = 8
 for cluster in talos-ottawa talos-robbinsdale talos-stpetersburg; do
   assert "full make gate -> $cluster" grep -q -- "--path clusters/$cluster/flux/config" "$flate_calls"
   location="${cluster#talos-}"
   assert "baseline make gate -> $location app tree" \
     grep -q -- "--path kubernetes/apps/$location" "$flate_calls"
 done
+assert "baseline make gate -> Ottawa legacy app tree" \
+  grep -q -- '--path clusters/talos-ottawa/apps' "$flate_calls"
+assert "baseline make gate -> St Petersburg legacy app tree" \
+  grep -q -- '--path clusters/talos-stpetersburg/apps' "$flate_calls"
+refute "baseline make gate -> skips missing Robbinsdale legacy tree" \
+  grep -q -- '--path clusters/talos-robbinsdale/apps' "$flate_calls"
+
+# A renderer failure from a legacy app tree must propagate through the loop;
+# this is the control for malformed YAML in that path (the real Flate parser is
+# exercised by the integration gate, while this offline test stays networkless).
+cat >"$fstub/flate" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "flate version $flate_pin"
+  exit 0
+fi
+case "\$*" in
+  *'--path clusters/talos-ottawa/apps'*) exit 1 ;;
+esac
+printf '%s\\n' "\$*" >>"\$FLATE_CALLS"
+EOF
+chmod +x "$fstub/flate"
+KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" FLATE_BASE=baseline \
+  make -s -C "$ROOT" test-talos-ottawa >/dev/null 2>&1; legacy_ec=$?
+assert "legacy app render failure -> make fails" test "$legacy_ec" != 0
 rm -rf "$fstub"
 
 # ---------------------------------------------------------------- check.sh (stubbed make; no real render)


### PR DESCRIPTION
Closes #2684.

## Summary

- Make `tools/check.sh` select the default-remote merge-base locally and keep CI's Flate baseline instead of forcing a full-tree render.
- Run the location app tree in baseline mode as well, so changes under `kubernetes/apps/**` remain visible to the gate.
- Fetch full history in the Flate render job, watch gate/workflow changes, and document changed-only behavior.
- Make the offline Flate test fixture follow the workflow's pinned version.

A clean Ottawa check now exits 0 with exactly one success line. A temporary invalid Ottawa app pointer exited 1 with the failing Kustomization named. The full local gate, diagram gate, and offline helper suite pass (`183 passed, 0 failed`).
