### PR TITLE
docs: document protected namespace retirement

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -221,6 +221,22 @@ anything there.
 Namespaces owned by an app keep the same annotation, which is why the add-app
 checklist says to leave it alone.
 
+Retiring a protected namespace takes one extra reconciliation. First leave the
+Namespace in the rendered output and remove its
+`kustomize.toolkit.fluxcd.io/prune: disabled` guard; let Flux apply that change.
+Only a later revision should remove the Namespace manifest and its location
+pointer, so the parent `kubernetes-apps` Kustomization can prune the now-
+unprotected object. If both were removed in one revision, Flux cannot clear a
+guard from an object that is no longer in its desired set. After verifying an
+orphan is empty, the operator must perform the one-time deletion with the
+cluster helper and must not strip finalizers:
+
+~~~bash
+tools/kc.sh ot get namespace border0
+tools/kc.sh ot -n border0 get all
+tools/kc.sh ot delete namespace border0
+~~~
+
 ## Tailnet overlay
 
 The tailnet `keiretsu.ts.net` is the only path between clusters. Every


### PR DESCRIPTION
## Summary

- Document the two-reconciliation handoff required before removing an app-owned Namespace protected by `kustomize.toolkit.fluxcd.io/prune: disabled`.
- Record the one-time operator cleanup path for the already-orphaned Ottawa `border0` Namespace.

## Findings

PR #2592 already removed the `border0` Namespace manifest, pointer, and parent entry. The live Namespace is still Active and empty, but its historical `prune: disabled` label means Flux excludes it from pruning; it is no longer in the `kubernetes-apps` desired inventory. A single final Git revision cannot first clear that label and then prune the object.

The safe normal flow is: keep the Namespace rendered, remove the guard, wait for Flux to reconcile, then remove the Namespace in a later revision. For this already-merged purge, after independently verifying the namespace remains empty, the operator must run `tools/kc.sh ot delete namespace border0`; do not strip finalizers. No live write was performed.

## Verification

- `tools/check.sh ot`
- `tools/check-diagram.sh`
- `git diff --check`

Do not merge this PR until reviewed.