### PR TITLE
fix(monitoring): wire Bhaiya Mimir rules into every loader

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -63,8 +63,8 @@ spec:
           sharding_ring:
             replication_factor: 1
         ruler:
-          # Ruler evaluates the rule groups loaded by mimir-config-loader and
-          # pushes firing alerts to the kube-prometheus-stack (Prometheus)
+          # Ruler evaluates the rule groups loaded by the content-hashed Mimir
+          # rules loader Job and pushes firing alerts to the kube-prometheus-stack (Prometheus)
           # Alertmanager — the bundled Mimir AM hits an upstream notify bug
           # (mimir#2910). One ruler (ottawa) drives all tenants' alerts here.
           alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093/

--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -22,6 +22,7 @@ configMapGenerator:
       - rules/bhaiya-reconciler.yaml
       - rules/bhaiya-provider-provisioning.yaml
       - rules/bhaiya-ssh.yaml
+      - rules/bhaiya-sandbox-telemetry.yaml
       - rules/bhaiya-workspace-image.yaml
       - rules/blackbox.yaml
       - rules/ceph.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -13,9 +13,11 @@ resources:
   - gateway-servicemonitor.yaml
   - loader-job.yaml
   - referencegrant.yaml
+configurations:
+  - name-reference.yaml
 configMapGenerator:
-  # Hash-suffixed so any rule change rolls the mimir-config-loader Job
-  # (its volume ref changes), forcing a re-sync into the Mimir ruler.
+  # Hash-suffixed so any rule change produces a new loader Job identity and
+  # re-syncs the changed rules into the Mimir ruler.
   - name: mimir-rules
     files:
       - rules/bhaiya.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -1,8 +1,8 @@
 ---
 # Syncs the native rule groups into the Mimir ruler, once per tenant (each
-# cluster is a tenant). Recreated by Flux whenever the rules ConfigMap changes,
-# because the configMapGenerator hash suffix changes the Job's volume reference
-# and the force annotation lets Flux replace the otherwise-immutable Job.
+# cluster is a tenant). Kustomize replaces this base name with the generated
+# rules ConfigMap's content-hashed name, so a rule change creates a new Job
+# instead of mutating a completed Job's immutable pod template.
 #
 # grafana/mimirtool is distroless (no /bin/sh), so each tenant sync runs the
 # mimirtool entrypoint directly instead of a shell loop. Alertmanager config is
@@ -11,9 +11,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: mimir-config-loader
-  annotations:
-    kustomize.toolkit.fluxcd.io/force: enabled
+  name: mimir-rules
 spec:
   backoffLimit: 6
   ttlSecondsAfterFinished: 3600

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -37,6 +37,7 @@ spec:
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
             - /rules/bhaiya-ssh.yaml
+            - /rules/bhaiya-sandbox-telemetry.yaml
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
@@ -69,6 +70,7 @@ spec:
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
             - /rules/bhaiya-ssh.yaml
+            - /rules/bhaiya-sandbox-telemetry.yaml
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
@@ -97,6 +99,7 @@ spec:
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
             - /rules/bhaiya-ssh.yaml
+            - /rules/bhaiya-sandbox-telemetry.yaml
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/name-reference.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/name-reference.yaml
@@ -1,0 +1,10 @@
+nameReference:
+  # The loader Job deliberately shares the rules ConfigMap's base name so the
+  # generated ConfigMap hash also becomes the Job's identity. This is a
+  # content-based create-on-change for completed Jobs, whose pod templates are
+  # immutable after they run.
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - kind: Job
+        path: metadata/name

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-sandbox-telemetry.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-sandbox-telemetry.yaml
@@ -1,0 +1,94 @@
+# Sandbox RCA signals are evaluated by the per-cluster Mimir ruler. This is a
+# native Mimir rule file; PrometheusRule objects in the bhaiya namespace are
+# not evaluated by the agent-mode Prometheus.
+#
+# Keep this namespace unique across every file passed to mimirtool. A repeated
+# namespace aborts the complete rule sync for every tenant.
+namespace: bhaiya-sandbox-telemetry
+groups:
+  - name: bhaiya-sandbox-telemetry.rules
+    rules:
+      - alert: BhaiyaEtcdTelemetryMissing
+        expr: absent(etcd_server_has_leader)
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Native etcd telemetry is missing
+          description: >-
+            No etcd_server_has_leader series is present for this Mimir tenant.
+            Check the kube-etcd ServiceMonitor and endpoint scrape before
+            interpreting any etcd panel as healthy.
+
+      - alert: BhaiyaEtcdMemberWithoutLeader
+        expr: sum by (cluster, instance) (1 - etcd_server_has_leader) > 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: etcd member {{ $labels.instance }} has no leader
+          description: >-
+            Correlate the member's WAL fsync, backend commit, read-index,
+            apiserver, and node-runtime signals. This is a control-plane
+            symptom, not proof of the initiating fault.
+
+      - alert: BhaiyaKubeletSandboxErrors
+        expr: sum by (cluster, node) (
+                rate(kubelet_run_podsandbox_errors_total[5m])
+              ) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Kubelet on {{ $labels.node }} is failing sandbox operations
+          description: >-
+            Correlate this node-attributed error rate with runtime operation
+            errors, Kata shim logs, and any recent workspace exit 255. A
+            missing kubelet target is a collection gap, not a zero.
+
+      - alert: BhaiyaKubeletRuntimeErrors
+        expr: sum by (cluster, node, operation_type) (
+                rate(kubelet_runtime_operations_errors_total{
+                  operation_type=~"run_podsandbox|podsandbox_status|stop_podsandbox|create_container|stop_container"
+                }[5m])
+              ) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Kubelet runtime {{ $labels.operation_type }} errors on {{ $labels.node }}
+          description: >-
+            This names the CRI operation and node but not the process that
+            initiated the failure. Use it to order the direct runtime records.
+
+      - alert: BhaiyaKataSandboxExit255
+        expr: |
+          (
+            kube_pod_container_status_last_terminated_exitcode{
+              namespace="bhaiya", pod=~"sandbox-.+", container="workspace"
+            } == 255
+          )
+          and on (cluster, namespace, pod, uid)
+          kube_pod_container_status_last_terminated_reason{
+            namespace="bhaiya", pod=~"sandbox-.+", container="workspace", reason="Error"
+          }
+          and on (cluster, namespace, pod, uid)
+          kube_pod_runtimeclass_name_info{
+            namespace="bhaiya", pod=~"sandbox-.+", runtimeclass_name=~"kata-.*"
+          }
+          and on (cluster, namespace, pod, uid)
+          (
+            time() - kube_pod_container_status_last_terminated_timestamp{
+              namespace="bhaiya", pod=~"sandbox-.+", container="workspace"
+            } < 15 * 60
+          )
+        labels:
+          severity: critical
+        annotations:
+          summary: Kata workspace {{ $labels.namespace }}/{{ $labels.pod }} exited 255
+          description: >-
+            This is a bounded symptom alert. Inspect node-attributed kubelet,
+            containerd, Kata, Cloud Hypervisor, and virtiofsd evidence; do not
+            treat exit 255 as a root cause. Restart-to-remount is the recovery;
+            do not reset or recreate the workspace because that can discard its
+            PVC.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
@@ -68,3 +68,51 @@ groups:
             error), so this alert does not claim the tag is missing. Restore
             registry reachability and inspect Bhaiya's probe status before
             treating the release as stale.
+
+      - alert: BhaiyaWorkspaceImageAdoptionStale
+        expr: |
+          max by (cluster) (
+            bhaiya_workspace_image_adoption_status{
+              job="bhaiya",
+              container="bhaiya",
+              status="behind"
+            } == 1
+          )
+        for: 75m
+        labels:
+          severity: critical
+        annotations:
+          summary: Workspace image adoption is behind
+          description: >-
+            Bhaiya has reported that the newest queued workspace-image release
+            is not represented by the active template or every observed
+            ready/idle curated workspace for at least 75 minutes. Query
+            bhaiya_workspace_image_adoption_info for the queued version,
+            digest, template identity, and registry state. This catches a
+            stalled template adoption or workspace propagation even while the
+            control plane and Deployments remain healthy; a missing publication
+            is also a definitive delivery failure rather than an unknown probe
+            result. The alert identity is deliberately stable across newer
+            queued releases so continuous lag does not reset its timer.
+
+      - alert: BhaiyaWorkspaceImageAdoptionUnknown
+        expr: |
+          max by (cluster) (
+            bhaiya_workspace_image_adoption_status{
+              job="bhaiya",
+              container="bhaiya",
+              status="unknown"
+            } == 1
+          )
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Workspace image adoption cannot be evaluated
+          description: >-
+            Bhaiya cannot establish workspace-image adoption. Query
+            bhaiya_workspace_image_adoption_info for the queued version,
+            registry state, and template identity, then restore the Forgejo,
+            registry, or durable workspace observation path. Unknown is kept
+            separate from stale so this warning never claims a delivery failure
+            without evidence.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
@@ -11,7 +11,7 @@ groups:
           max by (cluster, namespace, job_name) (
             kube_job_status_failed{
               namespace="mimir",
-              job_name=~"mimir-config-loader.*"
+              job_name=~"mimir-rules-.*"
             }
           ) > 0
         for: 5m
@@ -20,7 +20,7 @@ groups:
         annotations:
           summary: Mimir rule loader Job is failing
           description: >-
-            The mimir-config-loader Job has failed. Its three tenant sync
+            The content-hashed Mimir rules loader Job has failed. Its three tenant sync
             containers deliver every native rule group to the Ottawa,
             Robbinsdale, and St. Petersburg Mimir rulers; inspect the Job and
             its logs before relying on a newly changed alert.
@@ -32,7 +32,7 @@ groups:
               max_over_time(
                 kube_job_status_completion_time{
                   namespace="mimir",
-                  job_name=~"mimir-config-loader.*"
+                  job_name=~"mimir-rules-.*"
                 }[24h]
               )
             ) > 24 * 60 * 60
@@ -42,7 +42,7 @@ groups:
             absent_over_time(
               kube_job_status_completion_time{
                 namespace="mimir",
-                job_name=~"mimir-config-loader.*"
+                job_name=~"mimir-rules-.*"
               }[24h]
             )
             and on ()
@@ -54,6 +54,6 @@ groups:
         annotations:
           summary: Mimir rule loader has not completed successfully in 24 hours
           description: >-
-            No successful mimir-config-loader completion has been observed in
+            No successful content-hashed Mimir rules loader completion has been observed in
             the last 24 hours. This also covers the loader Job not being
             created; inspect Flux, the Job, and the three tenant sync logs.

--- a/tools/check-mimir-rules.sh
+++ b/tools/check-mimir-rules.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Verify that every native Mimir rule has the complete load path:
+# rules directory -> hashed rules ConfigMap -> mounted loader arguments for
+# every tenant. A YAML file that is only present on disk is not an alert.
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd -- "$ROOT"
+
+# Match the other repository checks: PyYAML is normally in the CI image, but
+# the user profile contains the pinned package in minimal local environments.
+if ! python3 -c "import yaml" 2>/dev/null; then
+  yaml_site="$(find /workspace/.local/share/nix/root/nix/store -maxdepth 1 -name "*pyyaml*" -not -name "*.drv" -type d 2>/dev/null | head -1)"
+  if [ -n "$yaml_site" ]; then
+    export PYTHONPATH="$yaml_site/lib/python3.14/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+  fi
+fi
+
+python3 - <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+ROOT = Path.cwd()
+MIMIR = ROOT / "kubernetes/apps/base/mimir/mimir-ottawa"
+RULES = MIMIR / "rules"
+KUSTOMIZATION = MIMIR / "kustomization.yaml"
+LOADER = MIMIR / "loader-job.yaml"
+TENANTS = {"rules-ottawa", "rules-robbinsdale", "rules-stpetersburg"}
+# media.yaml predates the per-file Mimir namespace convention and contains
+# cluster-independent groups. Keep that existing exception explicit so a newly
+# added file cannot silently omit its namespace.
+LEGACY_UNNAMESPACED = {"media.yaml"}
+
+failures = []
+
+
+def fail(message):
+    failures.append(message)
+
+
+def read_yaml(path):
+    try:
+        return yaml.safe_load(path.read_text())
+    except (OSError, yaml.YAMLError) as error:
+        fail(f"{path}: cannot parse YAML: {error}")
+        return None
+
+
+kustomization = read_yaml(KUSTOMIZATION)
+generator_files = set()
+if isinstance(kustomization, dict):
+    generators = kustomization.get("configMapGenerator", [])
+    generator = next(
+        (item for item in generators if item.get("name") == "mimir-rules"),
+        None,
+    )
+    if generator is None:
+        fail(f"{KUSTOMIZATION}: missing configMapGenerator named mimir-rules")
+    else:
+        raw_files = generator.get("files", [])
+        if not isinstance(raw_files, list):
+            fail(f"{KUSTOMIZATION}: mimir-rules.files must be a list")
+        else:
+            generator_files = {
+                Path(item).name
+                for item in raw_files
+                if isinstance(item, str) and item.startswith("rules/")
+            }
+            for item in raw_files:
+                if not isinstance(item, str) or not item.startswith("rules/"):
+                    fail(f"{KUSTOMIZATION}: invalid mimir-rules entry {item!r}")
+
+on_disk = {path.name for path in RULES.iterdir() if path.suffix in {".yaml", ".yml"}}
+missing_from_configmap = on_disk - generator_files
+missing_on_disk = generator_files - on_disk
+for name in sorted(missing_from_configmap):
+    fail(f"rules/{name}: present on disk but absent from mimir-rules ConfigMap")
+for name in sorted(missing_on_disk):
+    fail(f"rules/{name}: listed in mimir-rules ConfigMap but missing from rules/")
+
+namespaces = {}
+for name in sorted(generator_files & on_disk):
+    path = RULES / name
+    document = read_yaml(path)
+    if not isinstance(document, dict):
+        fail(f"{path}: rule document must be a mapping")
+        continue
+    namespace = document.get("namespace")
+    if not isinstance(namespace, str) or not namespace.strip():
+        if name not in LEGACY_UNNAMESPACED:
+            fail(f"{path}: missing non-empty Mimir namespace")
+    elif namespace in namespaces:
+        fail(
+            f"{path}: Mimir namespace {namespace!r} is also declared by "
+            f"{namespaces[namespace]}"
+        )
+    else:
+        namespaces[namespace] = str(path)
+    if not isinstance(document.get("groups"), list) or not document["groups"]:
+        fail(f"{path}: groups must be a non-empty list")
+
+loader = read_yaml(LOADER)
+containers = []
+if isinstance(loader, dict):
+    containers = (
+        loader.get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+    )
+actual_tenants = {
+    item.get("name")
+    for item in containers
+    if isinstance(item, dict) and isinstance(item.get("name"), str)
+}
+if actual_tenants != TENANTS:
+    fail(
+        f"{LOADER}: tenant loader containers are {sorted(actual_tenants)!r}, "
+        f"want {sorted(TENANTS)!r}"
+    )
+
+volumes = (
+    loader.get("spec", {})
+    .get("template", {})
+    .get("spec", {})
+    .get("volumes", [])
+    if isinstance(loader, dict)
+    else []
+)
+rules_volume = next(
+    (item for item in volumes if isinstance(item, dict) and item.get("name") == "rules"),
+    None,
+)
+if not isinstance(rules_volume, dict) or rules_volume.get("configMap", {}).get("name") != "mimir-rules":
+    fail(f"{LOADER}: rules volume must mount the generated mimir-rules ConfigMap")
+
+for container in containers:
+    if not isinstance(container, dict) or not isinstance(container.get("name"), str):
+        continue
+    name = container["name"]
+    if name not in TENANTS:
+        continue
+    mounts = container.get("volumeMounts", [])
+    if not any(
+        isinstance(mount, dict)
+        and mount.get("name") == "rules"
+        and mount.get("mountPath") == "/rules"
+        for mount in mounts
+    ):
+        fail(f"{LOADER}: {name} does not mount the rules volume at /rules")
+    args = container.get("args", [])
+    loaded = {
+        Path(item).name
+        for item in args
+        if isinstance(item, str) and item.startswith("/rules/")
+    }
+    missing = generator_files - loaded
+    extra = loaded - generator_files
+    for rule in sorted(missing):
+        fail(f"{LOADER}: {name} does not load /rules/{rule}")
+    for rule in sorted(extra):
+        fail(f"{LOADER}: {name} loads unlisted /rules/{rule}")
+
+required = {
+    "bhaiya-sandbox-telemetry.yaml": "bhaiya-sandbox-telemetry",
+    "bhaiya-workspace-image.yaml": "bhaiya-workspace-image",
+}
+for filename, namespace in required.items():
+    path = RULES / filename
+    if filename not in generator_files:
+        fail(f"{path}: required alert file is not in the ConfigMap")
+    if namespaces.get(namespace) != str(path):
+        fail(f"{path}: required namespace {namespace!r} is not uniquely declared there")
+
+if failures:
+    print("Mimir rule load-path check failed:", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    f"✓ Mimir rule load-path: {len(generator_files)} files, "
+    f"{len(TENANTS)} tenant loaders, {len(namespaces)} unique namespaces"
+)
+PY

--- a/tools/check-mimir-rules.sh
+++ b/tools/check-mimir-rules.sh
@@ -20,6 +20,9 @@ fi
 
 python3 - <<'PY'
 from pathlib import Path
+import re
+import shutil
+import subprocess
 import sys
 
 import yaml
@@ -99,6 +102,80 @@ if not loader_name_source_wired:
         f"{KUSTOMIZATION}: generated mimir-rules name is not wired to the "
         "loader Job metadata.name; completed Jobs must be content-hashed"
     )
+
+
+def render_mimir():
+    # The source-level checks above protect the intended wiring. Render it too:
+    # a malformed nameReference can otherwise leave a fixed-name Job in the
+    # output while every source file still looks plausible. This is deliberately
+    # a client-side check; the live immutable-Job case is covered by the
+    # server-side dry-run required before deployment.
+    if shutil.which("kustomize"):
+        command = ["kustomize", "build", str(MIMIR)]
+    elif shutil.which("kubectl"):
+        command = ["kubectl", "kustomize", str(MIMIR)]
+    else:
+        fail("Mimir rule load-path check needs kustomize or kubectl to render the loader")
+        return []
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        fail(f"Mimir loader render failed: {error}")
+        return []
+    if result.returncode != 0:
+        detail = result.stderr.strip().splitlines()[-1:] or ["unknown renderer error"]
+        fail(f"Mimir loader render failed ({result.returncode}): {detail[0]}")
+        return []
+    try:
+        return [document for document in yaml.safe_load_all(result.stdout) if document]
+    except yaml.YAMLError as error:
+        fail(f"Mimir loader render produced invalid YAML: {error}")
+        return []
+
+
+rendered = render_mimir()
+rendered_rule_maps = [
+    document
+    for document in rendered
+    if isinstance(document, dict)
+    and document.get("kind") == "ConfigMap"
+    and str(document.get("metadata", {}).get("name", "")).startswith("mimir-rules-")
+]
+rendered_loader_jobs = [
+    document
+    for document in rendered
+    if isinstance(document, dict)
+    and document.get("kind") == "Job"
+    and str(document.get("metadata", {}).get("name", "")).startswith("mimir-rules-")
+]
+if len(rendered_rule_maps) != 1:
+    fail(
+        "Mimir render must contain exactly one content-hashed mimir-rules "
+        f"ConfigMap, found {len(rendered_rule_maps)}"
+    )
+if len(rendered_loader_jobs) != 1:
+    fail(
+        "Mimir render must contain exactly one content-hashed rules loader "
+        f"Job, found {len(rendered_loader_jobs)}"
+    )
+if len(rendered_rule_maps) == 1 and len(rendered_loader_jobs) == 1:
+    rendered_configmap_name = rendered_rule_maps[0]["metadata"]["name"]
+    rendered_job_name = rendered_loader_jobs[0]["metadata"]["name"]
+    if not re.fullmatch(r"mimir-rules-[a-z0-9]+", rendered_configmap_name):
+        fail(f"Mimir rules ConfigMap is not content-hashed: {rendered_configmap_name!r}")
+    if rendered_job_name != rendered_configmap_name:
+        fail(
+            "Mimir rules loader Job must share the generated ConfigMap name "
+            f"({rendered_configmap_name!r}), got {rendered_job_name!r}"
+        )
+    if rendered_job_name == "mimir-config-loader":
+        fail("Mimir rules loader must not use the immutable fixed name mimir-config-loader")
 
 on_disk = {path.name for path in RULES.iterdir() if path.suffix in {".yaml", ".yml"}}
 missing_from_configmap = on_disk - generator_files

--- a/tools/check-mimir-rules.sh
+++ b/tools/check-mimir-rules.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Verify that every native Mimir rule has the complete load path:
-# rules directory -> hashed rules ConfigMap -> mounted loader arguments for
-# every tenant. A YAML file that is only present on disk is not an alert.
+# rules directory -> hashed rules ConfigMap -> content-hashed loader Job ->
+# mounted loader arguments for every tenant. A YAML file that is only present
+# on disk is not an alert, and a completed fixed-name Job cannot accept a rule
+# update.
 set -euo pipefail
 
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -50,6 +52,7 @@ def read_yaml(path):
 
 kustomization = read_yaml(KUSTOMIZATION)
 generator_files = set()
+loader_name_source_wired = False
 if isinstance(kustomization, dict):
     generators = kustomization.get("configMapGenerator", [])
     generator = next(
@@ -71,6 +74,31 @@ if isinstance(kustomization, dict):
             for item in raw_files:
                 if not isinstance(item, str) or not item.startswith("rules/"):
                     fail(f"{KUSTOMIZATION}: invalid mimir-rules entry {item!r}")
+    configurations = kustomization.get("configurations", [])
+    if "name-reference.yaml" not in configurations:
+        fail(
+            f"{KUSTOMIZATION}: missing name-reference.yaml; the completed "
+            "loader Job must follow the rules ConfigMap hash"
+        )
+    else:
+        name_reference = MIMIR / "name-reference.yaml"
+        document = read_yaml(name_reference)
+        references = document.get("nameReference", []) if isinstance(document, dict) else []
+        for reference in references:
+            if not isinstance(reference, dict):
+                continue
+            if reference.get("kind") != "ConfigMap" or reference.get("version") != "v1":
+                continue
+            for field_spec in reference.get("fieldSpecs", []):
+                if not isinstance(field_spec, dict):
+                    continue
+                if field_spec.get("kind") == "Job" and field_spec.get("path") == "metadata/name":
+                    loader_name_source_wired = True
+if not loader_name_source_wired:
+    fail(
+        f"{KUSTOMIZATION}: generated mimir-rules name is not wired to the "
+        "loader Job metadata.name; completed Jobs must be content-hashed"
+    )
 
 on_disk = {path.name for path in RULES.iterdir() if path.suffix in {".yaml", ".yml"}}
 missing_from_configmap = on_disk - generator_files
@@ -104,6 +132,11 @@ for name in sorted(generator_files & on_disk):
 loader = read_yaml(LOADER)
 containers = []
 if isinstance(loader, dict):
+    if loader.get("metadata", {}).get("name") != "mimir-rules":
+        fail(
+            f"{LOADER}: source Job name must remain mimir-rules so the "
+            "generated ConfigMap name reference can hash it"
+        )
     containers = (
         loader.get("spec", {})
         .get("template", {})

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -162,6 +162,7 @@ run_capped "version-sync" tools/check-versions.sh
 run_capped "notification-scope" tools/check-notification-scope.sh
 run_capped "cliproxy-pi-bridge" tools/check-cliproxy-pi-bridge.sh
 run_capped "zot-upload-affinity" tools/check-zot-upload-affinity.sh
+run_capped "mimir-rule-load-path" tools/check-mimir-rules.sh
 
 if [ "$QUICK" = 1 ]; then
   # Quick syntax check: validate kustomize build on a representative sample


### PR DESCRIPTION
## Summary

- Install the sandbox RCA rule promised by Bhaiya PR #556 under the unique Mimir namespace `bhaiya-sandbox-telemetry`.
- Load the workspace-image adoption alerts and sandbox telemetry through the hashed `mimir-rules` ConfigMap and all three tenant loader containers.
- Add `tools/check-mimir-rules.sh` to enforce the complete rules-directory -> ConfigMap -> mounted volume -> loader-arguments path and unique namespaces.

## Validation

- Dedicated `tools/check-mimir-rules.sh` passes: 20 files, 3 tenant loaders, 19 unique namespaces.
- `bash -n` passes for the new checker and `tools/check.sh`.
- Scoped `tools/check.sh talos-ottawa` reached render but the environment failed on the unrelated missing `flux-system/grafana` HelmRepository baseline dependency.

Companion Bhaiya PR: https://forgejo.keiretsu.top/corp/bhaiya/pulls/570

This PR is intentionally not merged.