### PR TITLE
fix(velero): alert on persisted backup failures

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -39,4 +39,5 @@ configMapGenerator:
       - rules/payments.yaml
       - rules/smartctl.yaml
       - rules/velero.yaml
+      - rules/velero-integrity.yaml
       - rules/zot.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -50,6 +50,7 @@ spec:
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
+            - /rules/velero-integrity.yaml
             - /rules/zot.yaml
           volumeMounts: &rulesmount
             - { name: rules, mountPath: /rules }
@@ -83,6 +84,7 @@ spec:
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
+            - /rules/velero-integrity.yaml
             - /rules/zot.yaml
           volumeMounts: *rulesmount
           securityContext: *sc
@@ -112,6 +114,7 @@ spec:
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
+            - /rules/velero-integrity.yaml
             - /rules/zot.yaml
           volumeMounts: *rulesmount
           securityContext: *sc

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -1,0 +1,84 @@
+# Velero Backup and PodVolumeBackup CR state is exported by the shared
+# kube-state-metrics custom-resource configuration. The Velero server counters
+# are useful for newly observed events, but do not represent the persisted
+# phase of an individual Backup (a real Failed Backup kept last_status=1).
+#
+# Keep this namespace separate from rules/velero.yaml. Both files are synced by
+# the same mimirtool Job and a repeated namespace aborts every tenant sync.
+namespace: velero-integrity
+groups:
+  - name: velero-integrity.rules
+    rules:
+      - alert: VeleroBackupInFailureState
+        expr: |
+          max by (cluster, namespace, backup, schedule, phase) (
+            velero_cr_backup_info{
+              namespace="velero-system",
+              schedule!="",
+              phase=~"Failed|PartiallyFailed"
+            }
+          ) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} has a {{ $labels.phase }} backup
+          description: >-
+            Backup {{ $labels.backup }} for schedule {{ $labels.schedule }} has
+            remained in {{ $labels.phase }} for at least five minutes. Inspect
+            the Backup failureReason/message, its PodVolumeBackup children,
+            Velero server and node-agent logs, and the Garage backup location.
+
+      - alert: VeleroPodVolumeBackupFailed
+        expr: |
+          max by (cluster, namespace, pod_volume_backup, backup, node, phase) (
+            velero_cr_podvolumebackup_info{
+              namespace="velero-system",
+              phase=~"Failed|Canceled"
+            }
+          ) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero PodVolumeBackup {{ $labels.phase }} for {{ $labels.backup }}
+          description: >-
+            PodVolumeBackup {{ $labels.pod_volume_backup }} for Backup
+            {{ $labels.backup }} on node {{ $labels.node }} has remained
+            {{ $labels.phase }} for at least five minutes. Inspect the PVB
+            status message, the parent Backup, node-agent logs, and the storage
+            path before treating the parent Backup as restorable.
+
+      - alert: VeleroPodVolumeBackupBytesMismatch
+        expr: |
+          (
+            max by (cluster, namespace, pod_volume_backup, backup, node) (
+              velero_cr_podvolumebackup_bytes_done{
+                namespace="velero-system"
+              }
+            )
+            != on (cluster, namespace, pod_volume_backup, backup, node)
+            max by (cluster, namespace, pod_volume_backup, backup, node) (
+              velero_cr_podvolumebackup_bytes_total{
+                namespace="velero-system"
+              }
+            )
+          )
+          and on (cluster, namespace, pod_volume_backup, backup, node)
+          max by (cluster, namespace, pod_volume_backup, backup, node) (
+            velero_cr_podvolumebackup_info{
+              namespace="velero-system",
+              phase="Completed"
+            }
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero completed PVB {{ $labels.pod_volume_backup }} has incomplete bytes
+          description: >-
+            Completed PodVolumeBackup {{ $labels.pod_volume_backup }} for
+            Backup {{ $labels.backup }} reports bytesDone different from
+            totalBytes on node {{ $labels.node }}. Inspect the PVB status and
+            node-agent/Kopia logs; matching item counts do not establish volume
+            integrity.

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -54,6 +54,12 @@ kube-state-metrics:
           - imagepolicies
           - imageupdateautomations
         verbs: [ "list", "watch" ]
+      - apiGroups:
+          - velero.io
+        resources:
+          - backups
+          - podvolumebackups
+        verbs: [ "list", "watch" ]
   customResourceState:
     enabled: true
     config:
@@ -247,3 +253,52 @@ kube-state-metrics:
                   ready: [ status, conditions, "[type=Ready]", status ]
                   suspended: [ spec, suspend ]
                   webhook_path: [ status, webhookPath ]
+          - groupVersionKind:
+              group: velero.io
+              version: v1
+              kind: Backup
+            metricNamePrefix: velero_cr
+            labelsFromPath:
+              namespace: [ metadata, namespace ]
+              backup: [ metadata, name ]
+              schedule: [ metadata, labels, velero.io/schedule-name ]
+            metrics:
+              - name: "backup_info"
+                help: "The current phase of a Velero Backup custom resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      phase: [ status, phase ]
+          - groupVersionKind:
+              group: velero.io
+              version: v1
+              kind: PodVolumeBackup
+            metricNamePrefix: velero_cr
+            labelsFromPath:
+              namespace: [ metadata, namespace ]
+              pod_volume_backup: [ metadata, name ]
+              backup: [ metadata, labels, velero.io/backup-name ]
+              node: [ spec, node ]
+            metrics:
+              - name: "podvolumebackup_info"
+                help: "The current phase of a Velero PodVolumeBackup custom resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      phase: [ status, phase ]
+              - name: "podvolumebackup_bytes_done"
+                help: "Bytes reported as uploaded by a Velero PodVolumeBackup."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ status, progress ]
+                    valueFrom: [ bytesDone ]
+              - name: "podvolumebackup_bytes_total"
+                help: "Total bytes reported for a Velero PodVolumeBackup."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ status, progress ]
+                    valueFrom: [ totalBytes ]


### PR DESCRIPTION
## Summary

- Export Velero Backup and PodVolumeBackup phase/progress state through the existing kube-state-metrics remote-write path.
- Add native Mimir alerts for scheduled Failed/PartiallyFailed Backups, Failed/Canceled PVBs, and byte mismatches on Completed PVBs.
- Load the unique velero-integrity rule namespace from the active Ottawa base overlay in all three tenant loader containers.

Closes #572

## Validation

- Live Ottawa API-proxy probes confirmed the persisted Failed bhaiya-backup object, Failed/PartiallyFailed Backups, Failed/Canceled PVBs, and a Completed equal-byte control.
- Mimir query API accepted all three new PromQL expressions.
- YAML parsing, git diff --check, and tools/orphans.sh passed.
- tools/check.sh was retried after the documented Flate timeout; the retry and scoped Ottawa check were blocked by unrelated chart-source discovery failures for grafana and tailscale-k8s-operator-helper-charts. No live resources were mutated.