### PR TITLE
fix(monitoring): make tailscale egress source render-local

### DIFF
--- a/kubernetes/apps/base/monitoring/monitoring-common/app/egress.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/egress.yaml
@@ -5,15 +5,9 @@ metadata:
   name: tailscale-egress
 spec:
   interval: 1m
-  chart:
-    spec:
-      chart: tailscale-egress
-      version: 0.0.0-latest
-      sourceRef:
-        kind: HelmRepository
-        name: tailscale-k8s-operator-helper-charts
-        namespace: flux-system 
-      interval: 1m
+  chartRef:
+    kind: OCIRepository
+    name: tailscale-egress
   releaseName: tailscale-egress
   values:
     proxyGroup: "common-egress"

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ocirepository-tailscale-egress.yaml
   - ocirepository.yaml
   - helmrelease-kube-prometheus-stack.yaml
   - egress.yaml

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/ocirepository-tailscale-egress.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/ocirepository-tailscale-egress.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tailscale-egress
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.0.0-latest
+  url: oci://ghcr.io/rajsinghtech/tailscale-k8s-operator-helper-charts/tailscale-egress


### PR DESCRIPTION
## Summary

Flate source discovery for the changed `kubernetes/apps/<location>` tree does not load the shared `clusters/common/flux/repositories/helm` objects. The original reference and shared source do match:

- `egress.yaml`: `HelmRepository/tailscale-k8s-operator-helper-charts`, namespace `flux-system`
- `tailscale-helper-charts.yaml`: `metadata.name: tailscale-k8s-operator-helper-charts`, `metadata.namespace: flux-system`

The full cluster render resolves that shared source, but the app-tree render reports it as a missing dependency. This change keeps the shared HelmRepository unchanged and adds an app-local `OCIRepository` for the same public chart artifact (`.../tailscale-egress:0.0.0-latest`), then points only `monitoring/tailscale-egress` at that local source. The shared HelmRepository remains needed by the Tailscale examples app.

## Validation

- `git diff --check` passes.
- Baseline-aware Flate app-tree renders pass for Ottawa (`6 passed, 127 skipped`), Robbinsdale (`6 passed, 89 skipped`), and St. Petersburg (`6 passed, 79 skipped`); each includes passing `monitoring/tailscale-egress` and `OCIRepository monitoring/tailscale-egress`.
- `tools/check.sh` currently stops before render on the unrelated out-of-scope `cliproxy-pi-bridge` preflight: `Qwen must rewrite every developer message to system before its OpenAI route`. Therefore this PR is not being reported as green.

No live cluster resources were mutated.