### PR TITLE
fix(cliproxy): restore Qwen developer-role payload override

### DIFF
--- a/kubernetes/apps/base/cliproxy/cliproxy/app/deployment.yaml
+++ b/kubernetes/apps/base/cliproxy/cliproxy/app/deployment.yaml
@@ -178,6 +178,16 @@ spec:
               # Allow a bounded wait for a cooling credential before starting
               # another round; 0 forbade every positive cooldown wait.
               max-retry-interval: 30
+              # St. Petersburg's Qwen SGLang endpoint accepts system messages
+              # but rejects OpenAI's developer role, which Pi sends by default.
+              # Keep this compatibility translation scoped to the Qwen alias.
+              payload:
+                override:
+                  - models:
+                      - name: "vllm/Qwen3.8-Flash-Next"
+                        protocol: "openai"
+                    params:
+                      'messages.#(role=="developer")#.role': system
               EOF
               cat /provider/providers.yaml >> /config/config.yaml
           env:


### PR DESCRIPTION
## What

Restores the `payload.override` block that translates OpenAI's `developer` role to `system` for the `vllm/Qwen3.8-Flash-Next` alias.

## Why this is urgent

**Every open PR in this repo is currently failing CI on a check its diff cannot possibly affect.** `#2698`, `#2700` and `#2702` all fail `cliproxy-pi-bridge` with:

```
Qwen must rewrite every developer message to system before its OpenAI route
```

## Root cause

- `24949a215` (Aug 31, *"adapt Qwen developer messages for SGLang"*) added the override. St. Petersburg's Qwen SGLang endpoint accepts `system` messages but rejects OpenAI's `developer` role, which Pi sends by default.
- `5e8aeb33c` (Sep 5, *"restore Vision-Exp DSpark inference"*) removed the entire `payload:` block as collateral damage. `payload.override` has been empty on `main` ever since.

Verified there is no replacement handling elsewhere in the rendered config — the translation is simply gone, so this is a live regression on the Qwen route, not only a CI failure.

## Why nobody noticed

`tools/check-cliproxy-pi-bridge.sh` exists precisely to prevent this, and it **does** fail against `main`'s content — I ran it directly on a pristine `origin/main` tree to confirm. But it only runs on `pull_request`, so pushes to `main` never execute it. `main` reported green for over a day while the guard was failing, and the cost landed on every unrelated PR.

That CI gap is worth its own fix (a guard that cannot run on the branch it protects is not a guard); filing separately rather than widening this PR.

## Verification

```
$ bash tools/check-cliproxy-pi-bridge.sh
✓ cliproxy Pi bridge metadata and Qwen payload contract   # EXIT=0

$ bash tools/check.sh talos-robbinsdale
✓ render OK: talos-robbinsdale                            # EXIT=0
```

The restored block carries the `protocol: "openai"` qualifier that the contract asserts (the pre-removal version predated it).
