### PR TITLE
feat(auth): allow staging member-shell subject through TinyAuth

### DIFF
--- a/kubernetes/apps/base/auth/tinyauth/tinyauth.env
+++ b/kubernetes/apps/base/auth/tinyauth/tinyauth.env
@@ -23,7 +23,7 @@ TINYAUTH_OAUTH_AUTOREDIRECT=google
 # session/OIDC token, so downstream apps can safely auto-provision on first
 # login (any non-listed account never reaches them). Comma-separated; matched
 # against the full email. Add a person here (one commit) to grant access.
-TINYAUTH_OAUTH_WHITELIST=kartikbharath@gmail.com,rajsinghcpre@gmail.com
+TINYAUTH_OAUTH_WHITELIST=kartikbharath@gmail.com,rajsinghcpre@gmail.com,kingraj360@gmail.com
 TINYAUTH_AUTH_TRUSTEDPROXIES=10.0.0.0/8,192.168.0.0/16
 TINYAUTH_ANALYTICS_ENABLED=false
 # UI / branding (customer-facing). background.svg is served from /resources


### PR DESCRIPTION
## Deliberately a draft — this needs Raj's decision, not mine

This is an **access-control change**: it grants a new identity the ability to authenticate to the platform. I verified the facts and prepared the change so it is one click away, but I am not merging an auth whitelist edit autonomously. Mark ready and merge if you want it.

## What

Adds `kingraj360@gmail.com` to `TINYAUTH_OAUTH_WHITELIST`.

## Why

Per corp/bhaiya #612, this is **gate 1 of 2** blocking the staging subject named in the automanaged product design. While the whitelist excludes that account, Google OAuth never completes a TinyAuth session, so it never presents `Remote-Email` to Bhaiya — meaning the member shell cannot be exercised at all, and #610/#609 cannot be worked on behind it.

## Verified before proposing

The original #612 analysis was done against a checkout that was 36 commits stale, so I re-verified both gates against `origin/main` and the live cluster:

- **`origin/main`** `kubernetes/apps/base/auth/tinyauth/tinyauth.env`:
  `TINYAUTH_OAUTH_WHITELIST=kartikbharath@gmail.com,rajsinghcpre@gmail.com`
- **Live** ConfigMap `tinyauth/tinyauth-config-gtmkgb2mk5`: identical pair.
- **Gate 2** still present at `internal/ui/handler.go:632` — fails closed with "Invitation required".

So #612's analysis is accurate and current.

```
$ bash tools/check.sh talos-ottawa
✓ render OK: talos-ottawa        # EXIT=0
```

## This clears gate 1 only

**Gate 2 is not addressed here and cannot be.** Bhaiya fails closed unless the email exists in its users table:

> "Your identity is valid, but it has not been invited to this Bhaiya control plane."

That is a runtime admin invite, not a GitOps change. Merging this alone moves the failure from "OAuth never completes" to "Invitation required" — visible progress, but still not a working login until the invite is issued.

## Scope note

This grants login capability only. It does not grant admin, does not set any entitlement flag, and does not create a workspace (#610). Per the standing design, that subject must not be charged.
