### PR TITLE
fix(ci): render baseline with complete cluster context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,13 @@ test: ## Render-test all clusters with flate
 test-%: ## Render-test one cluster, e.g. make test-talos-ottawa
 	@$(FLATE) test all --path clusters/$*/flux/config $(FLATE_FLAGS)
 # Application manifests live in two trees while the migration is completed.
-# Both trees sit outside the cluster-config scan root, but must still be able
-# to fail the bounded gate when an application manifest changes. Some clusters
-# have no legacy app tree, so skip a missing path.
+# A standalone location-tree scan is incomplete: shared bootstrap sources live
+# under clusters/common, so Flate aliases both the self GitRepository and any
+# foreign source (for example csi-addons) to this working tree. In baseline
+# mode, scan the complete cluster root instead. Its bootstrap follows common
+# and the location app tree, while the root walk also covers legacy apps.
 ifneq ($(strip $(FLATE_BASE)),)
-	@for path in \
-		clusters/$*/apps \
-		kubernetes/apps/$(patsubst talos-%,%,$*); do \
-		if [ -d "$$path" ]; then \
-			$(FLATE) test all --path "$$path" $(FLATE_FLAGS) || exit 1; \
-		fi; \
-	done
+	@$(FLATE) test all --path clusters/$* $(FLATE_FLAGS)
 endif
 
 diff: ## Show rendered diff vs origin/main for all clusters

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -336,23 +336,18 @@ assert "full make gate -> three renders" test "$(wc -l <"$flate_calls" | tr -d '
 : >"$flate_calls"
 KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" FLATE_BASE=baseline \
   make -s -C "$ROOT" test
-assert "baseline make gate -> eight renders" test "$(wc -l <"$flate_calls" | tr -d ' ')" = 8
+assert "baseline make gate -> six renders" test "$(wc -l <"$flate_calls" | tr -d ' ')" = 6
 for cluster in talos-ottawa talos-robbinsdale talos-stpetersburg; do
   assert "full make gate -> $cluster" grep -q -- "--path clusters/$cluster/flux/config" "$flate_calls"
-  location="${cluster#talos-}"
-  assert "baseline make gate -> $location app tree" \
-    grep -q -- "--path kubernetes/apps/$location" "$flate_calls"
+  assert "baseline make gate -> $cluster complete context" \
+    grep -q -- "--path clusters/$cluster" "$flate_calls"
 done
-assert "baseline make gate -> Ottawa legacy app tree" \
-  grep -q -- '--path clusters/talos-ottawa/apps' "$flate_calls"
-assert "baseline make gate -> St Petersburg legacy app tree" \
-  grep -q -- '--path clusters/talos-stpetersburg/apps' "$flate_calls"
-refute "baseline make gate -> skips missing Robbinsdale legacy tree" \
-  grep -q -- '--path clusters/talos-robbinsdale/apps' "$flate_calls"
+refute "baseline make gate -> no incomplete location-only scan" \
+  grep -q -- '--path kubernetes/apps/' "$flate_calls"
 
-# A renderer failure from a legacy app tree must propagate through the loop;
-# this is the control for malformed YAML in that path (the real Flate parser is
-# exercised by the integration gate, while this offline test stays networkless).
+# A renderer failure from the complete context render must propagate through
+# make. The real Flate parser is exercised by the integration gate, while this
+# offline test stays networkless.
 cat >"$fstub/flate" <<EOF
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
@@ -360,14 +355,14 @@ if [ "\${1:-}" = "--version" ]; then
   exit 0
 fi
 case "\$*" in
-  *'--path clusters/talos-ottawa/apps'*) exit 1 ;;
+  *'--path clusters/talos-ottawa --no-progress'*) exit 1 ;;
 esac
 printf '%s\\n' "\$*" >>"\$FLATE_CALLS"
 EOF
 chmod +x "$fstub/flate"
 KMAN_FLATE_BIN="$fstub/flate" FLATE_CALLS="$flate_calls" FLATE_BASE=baseline \
-  make -s -C "$ROOT" test-talos-ottawa >/dev/null 2>&1; legacy_ec=$?
-assert "legacy app render failure -> make fails" test "$legacy_ec" != 0
+  make -s -C "$ROOT" test-talos-ottawa >/dev/null 2>&1; context_ec=$?
+assert "complete context render failure -> make fails" test "$context_ec" != 0
 rm -rf "$fstub"
 
 # ---------------------------------------------------------------- check.sh (stubbed make; no real render)


### PR DESCRIPTION
## Summary

- Render Flate baseline mode from the complete `clusters/<cluster>` context so shared bootstrap resources and foreign sources resolve correctly.
- Remove the incomplete location-only scan that aliases multiple bootstrap sources to the working tree (`count=2`).
- Update the offline Makefile coverage for the six expected baseline renders and failure propagation.

This fixes #2699 and covers the same root cause behind the #2698 Grafana source symptom and #2707 Ottawa `common-settings` symptom.

## Verification

- `tools/check.sh`
- `tools/check-diagram.sh`
- `tools/tests/run.sh` — 185 passed, 0 failed

No live cluster resources were changed.

Fixes #2699