### PR TITLE
fix(velero): alert on latest backup integrity

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-velero-coverage.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-velero-coverage.yaml
@@ -2,6 +2,9 @@
 # that it can prove belongs to a labelled Bhaiya Backup. These counters are
 # process-lifetime signals with an explicit first-observation baseline, so old
 # unlabelled PVBs do not become a permanent new-object alert after a rollout.
+# The workspace missing-home signal below is deliberately a separate Bhaiya
+# aggregate: Velero's Backup phase and item counters cannot distinguish a
+# successful metadata-only Backup from one that captured the durable home PVC.
 #
 # Keep this namespace separate from rules/velero.yaml. A repeated namespace
 # aborts the complete mimirtool sync for every tenant.
@@ -101,3 +104,38 @@ groups:
             PodVolumeBackups for coverage", then check API reachability and
             RBAC. A successful observation with zero eligible objects is valid
             data and does not fire this alert.
+
+      - alert: BhaiyaVeleroWorkspaceBackupMissingHomePVB
+        expr: |
+          max by (cluster) (
+            (
+              bhaiya_velero_workspace_backups_missing_home_pod_volume_backups{
+                job="bhaiya",
+                container="bhaiya"
+              } > 0
+            )
+            and on (cluster, job, container, instance)
+            (
+              bhaiya_velero_pod_volume_backups_observation_success{
+                job="bhaiya",
+                container="bhaiya"
+              } == 1
+            )
+          )
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Workspace Velero Backup is missing its home PodVolumeBackup
+          description: >-
+            Bhaiya's successful Velero observation counted at least one
+            workspace-labelled Completed Backup without a completed home
+            PodVolumeBackup for at least five minutes. A workspace always has
+            a durable home PVC, so this is an invalid volume-less completion;
+            a completed PVB with zero logical bytes remains legitimate. This
+            alert is intentionally gated on
+            bhaiya_velero_pod_volume_backups_observation_success=1 and does
+            not infer volume health from velero_backup_last_status or matching
+            item counts. It remains inactive until Bhaiya exports the
+            missing-home aggregate metric; unlabelled/platform Backups are
+            outside this assertion.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -20,7 +20,7 @@ groups:
           ) > 0
         for: 5m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: Velero schedule {{ $labels.schedule }} has a {{ $labels.phase }} backup
           description: >-
@@ -39,7 +39,7 @@ groups:
           ) > 0
         for: 5m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: Velero PodVolumeBackup {{ $labels.phase }} for {{ $labels.backup }}
           description: >-
@@ -82,3 +82,44 @@ groups:
             totalBytes on node {{ $labels.node }}. Inspect the PVB status and
             node-agent/Kopia logs; matching item counts do not establish volume
             integrity.
+
+      - alert: VeleroScheduleLastBackupFailed
+        expr: |
+          (
+            max by (cluster, namespace, schedule, backup, phase) (
+              velero_cr_backup_info{
+                namespace="velero-system",
+                schedule!="",
+                phase=~"Failed|PartiallyFailed"
+              }
+            ) > 0
+          )
+          and on (cluster, namespace, schedule, backup)
+          (
+            velero_cr_backup_created_timestamp{
+              namespace="velero-system",
+              schedule!=""
+            }
+            == on (cluster, namespace, schedule) group_left
+            max by (cluster, namespace, schedule) (
+              velero_cr_backup_created_timestamp{
+                namespace="velero-system",
+                schedule!=""
+              }
+            )
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} has no successful latest backup
+          description: >-
+            The newest persisted Backup attempt for schedule
+            {{ $labels.schedule }} is {{ $labels.backup }} and has remained in
+            {{ $labels.phase }} for at least five minutes. This is the paging
+            signal: inspect the Backup failureReason/message, its PodVolumeBackup
+            children, Velero server and node-agent logs, and the Garage backup
+            location. Older failed Backup objects are intentionally ignored
+            when a newer attempt exists. The creation timestamp is used for
+            ordering; velero_backup_last_status is not authoritative for this
+            condition.

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -270,6 +270,12 @@ kube-state-metrics:
                   info:
                     labelsFromPath:
                       phase: [ status, phase ]
+              - name: "backup_created_timestamp"
+                help: "Unix creation timestamp of a Velero Backup custom resource."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ metadata, creationTimestamp ]
           - groupVersionKind:
               group: velero.io
               version: v1


### PR DESCRIPTION
## Summary

- retain persisted Backup/PVB phase coverage from #2700 as warning signals
- add a creation-timestamp join so only the latest failed or partially-failed scheduled Backup pages
- add completed-PVB byte mismatch coverage without treating zero-byte captured volumes as failures
- add the #574 contract-based workspace missing-home-PVB warning, gated by the successful observation gauge

The missing-home aggregate metric is not exposed yet in the current Bhaiya checkout or live Mimir. The rule is intentionally written against the velerocapture contract and does not substitute velero_backup_last_status, item counts, or byte counts.

## Verification

- `tools/check-mimir-rules.sh` passes: 22 files, 3 tenant loaders, 21 unique namespaces
- isolated negative guard tests catch both a missing ConfigMap entry and all three missing loader arguments
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh talos-ottawa` passes
- Prometheus 2.55.1 rule syntax and synthetic positive/negative tests pass
- `tools/orphans.sh kubernetes/apps/base/mimir` and `git diff --check` pass

Related operational findings and retained-data limits are in `/workspace/.agent-recovery/findings-envoylogs.md`.