### PR TITLE
feat(observability): retain Kata runtime exit evidence

### DIFF
--- a/kubernetes/apps/base/kata-containers/kata-containers/app/kustomization.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/kustomization.yaml
@@ -3,6 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./canary.yaml
+  - ./tracee-config.yaml
+  - ./tracee-daemonset.yaml
+  - ./tracee-networkpolicy.yaml
+  - ./tracee-service.yaml
+  - ./tracee-servicemonitor.yaml
   - ./runtimeclass.yaml
   - ./runtimeclass-workspace.yaml
   - ./runtimeclass-tailscale.yaml

--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-config.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-config.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kata-runtime-observer-config
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kata-runtime-observer
+    app.kubernetes.io/component: runtime-observer
+data:
+  config.yaml: |
+    # Keep the observer deliberately small: the command line below selects one
+    # lifecycle tracepoint and two host-side runtime processes.
+    cache:
+        type: mem
+        size: 512
+    perf-buffer-size: 256
+    healthz: true
+    metrics: true
+    pprof: false
+    pyroscope: false
+    listen-addr: :3366
+    log:
+        level: info
+    output:
+        json:
+            files:
+                - stdout
+        options:
+            parse-arguments: true
+            stack-addresses: false
+            exec-env: false
+            exec-hash: dev-inode
+            sort-events: false

--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-daemonset.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-daemonset.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-runtime-observer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kata-runtime-observer
+    app.kubernetes.io/component: runtime-observer
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kata-runtime-observer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kata-runtime-observer
+        app.kubernetes.io/component: runtime-observer
+    spec:
+      serviceAccountName: kata-runtime-observer
+      automountServiceAccountToken: false
+      priorityClassName: system-node-critical
+      hostPID: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values: [linux]
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      containers:
+        - name: tracee
+          # The digest is the multi-architecture manifest for Tracee 0.24.1.
+          image: docker.io/aquasec/tracee:0.24.1@sha256:cfbbfee972e64a644f6b1bac74ee26998e6e12442697be4c797ae563553a2a5b
+          imagePullPolicy: IfNotPresent
+          command:
+            - /tracee/tracee
+          args:
+            - --config
+            - /tracee/config.yaml
+            - --events
+            - sched_process_exit
+            # Linux TASK_COMM_LEN truncates cloud-hypervisor to
+            # cloud-hyperviso; the prefix catches both that and any future
+            # suffix without tracing unrelated processes.
+            - --scope
+            - comm=cloud-hyperviso*,virtiofsd
+            # Containerd enrichment supplies the sandbox/container and, when
+            # available, Kubernetes identity in the structured log. It is not
+            # copied into metric labels.
+            - --containers
+            - enrich=true
+            - --containers
+            - sockets.containerd=/var/run/containerd/containerd.sock
+          securityContext:
+            privileged: true
+          ports:
+            - name: metrics
+              containerPort: 3366
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            periodSeconds: 10
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: tracee-tmp
+              mountPath: /tmp/tracee
+            - name: os-release
+              mountPath: /etc/os-release-host
+              readOnly: true
+            - name: containerd-socket
+              mountPath: /var/run/containerd/containerd.sock
+              readOnly: true
+            - name: tracee-config
+              mountPath: /tracee/config.yaml
+              subPath: config.yaml
+              readOnly: true
+      volumes:
+        - name: tracee-tmp
+          hostPath:
+            path: /tmp/tracee
+            type: DirectoryOrCreate
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
+            type: File
+        - name: containerd-socket
+          hostPath:
+            path: /var/run/containerd/containerd.sock
+            type: Socket
+        - name: tracee-config
+          configMap:
+            name: kata-runtime-observer-config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kata-runtime-observer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kata-runtime-observer
+    app.kubernetes.io/component: runtime-observer

--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-networkpolicy.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-networkpolicy.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kata-runtime-observer-metrics
+  namespace: kube-system
+spec:
+  description: Allow Prometheus to scrape the bounded Kata runtime-exit counter and kubelet to check health.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kata-runtime-observer
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus-agent
+            app.kubernetes.io/instance: kube-prometheus-stack
+            operator.prometheus.io/name: kube-prometheus-stack
+      toPorts:
+        - ports:
+            - port: "3366"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: /metrics$
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "3366"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: /healthz$

--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-service.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kata-runtime-observer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kata-runtime-observer
+    app.kubernetes.io/component: metrics
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: kata-runtime-observer
+    app.kubernetes.io/component: runtime-observer
+  ports:
+    - name: metrics
+      port: 3366
+      targetPort: metrics
+      protocol: TCP

--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-servicemonitor.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-servicemonitor.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kata-runtime-observer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kata-runtime-observer
+    app.kubernetes.io/component: metrics
+spec:
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kata-runtime-observer
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+      metricRelabelings:
+        # Tracee exposes several process-health metrics. Only its event count
+        # is this observer's contract; keeping it here also prevents a future
+        # Tracee metric from acquiring the event label accidentally.
+        - action: keep
+          sourceLabels:
+            - __name__
+          regex: tracee_ebpf_events_total
+        - targetLabel: cluster
+          replacement: ${CLUSTER_NAME}
+        - targetLabel: event
+          replacement: kata_process_exit


### PR DESCRIPTION
Closes #2641

## What changed

- Deploy a pinned Tracee 0.24.1 DaemonSet with host PID visibility and the containerd socket.
- Select only `sched_process_exit` for the host-side `cloud-hypervisor` and `virtiofsd` processes.
- Send structured JSON to the existing Kubernetes log path, retaining event time, process start time, process/executable, exit code, signal code, process-group state, node UTS name, and container/Kubernetes enrichment when available.
- Expose only Tracee's `tracee_ebpf_events_total` through a ServiceMonitor, with static `cluster`, `node`, and `event="kata_process_exit"` labels. No pod UID, sandbox ID, PID, or process name is a metric label.

## Verification

- `tools/check.sh talos-ottawa` passes after rebasing onto current `origin/main`.
- Strict Kubernetes schema validation passes for all five new manifests.
- The current live baseline has no observer DaemonSet and no `tracee_ebpf_events_total` series, as expected before this PR is merged and reconciled.
- I did not terminate or disrupt a human-owned Kata workspace to manufacture an exit. A post-merge canary or naturally occurring runtime exit must still verify that the structured record appears in VictoriaLogs and that the node/event counter is scraped into Mimir. Query the log body in `content` where it is a Talos syslog record, and query Kubernetes data by field (for example, `kubernetes.namespace_name`), not by a stream namespace selector.
