### PR TITLE
feat(observability): retain RBD device-to-PVC mappings

### DIFF
--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-config.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-config.yaml
@@ -15,11 +15,8 @@ data:
         type: mem
         size: 512
     perf-buffer-size: 256
-    healthz: true
-    metrics: true
     pprof: false
     pyroscope: false
-    listen-addr: :3366
     log:
         level: info
     output:

--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-daemonset.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-daemonset.yaml
@@ -58,6 +58,14 @@ spec:
             - enrich=true
             - --containers
             - sockets.containerd=/var/run/containerd/containerd.sock
+            # Tracee 0.24 serves health and Prometheus endpoints through the
+            # server subcommands; the old config keys are not listeners.
+            - --server
+            - http-address=:3366
+            - --server
+            - metrics
+            - --server
+            - healthz
           securityContext:
             privileged: true
           ports:

--- a/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-servicemonitor.yaml
+++ b/kubernetes/apps/base/kata-containers/kata-containers/app/tracee-servicemonitor.yaml
@@ -13,7 +13,8 @@ spec:
       - kube-system
   selector:
     matchLabels:
-      app.kubernetes.io/name: kata-runtime-observer
+      # Flux commonMetadata overwrites the name label on Services. The
+      # component label is the stable selector for this metrics Service.
       app.kubernetes.io/component: metrics
   endpoints:
     - port: metrics

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - csi-rbac.yaml
+  - rbd-device-observer-config.yaml
+  - rbd-device-observer-rbac.yaml
+  - rbd-device-observer-daemonset.yaml

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-config.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-config.yaml
@@ -1,0 +1,226 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rbd-device-observer
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/name: rbd-device-observer
+    app.kubernetes.io/component: observability
+data:
+  observe.sh: |
+    #!/bin/sh
+    set -eu
+
+    # This is intentionally a small host observer, not a second CSI driver.
+    # It records the join between the kernel RBD device, kubelet's mount
+    # namespace, and the PV metadata already held by the Kubernetes API.
+    API_SERVER="https://$${KUBERNETES_SERVICE_HOST}:$${KUBERNETES_SERVICE_PORT}"
+    SERVICE_ACCOUNT_DIR=/var/run/secrets/kubernetes.io/serviceaccount
+    TOKEN_FILE="$${SERVICE_ACCOUNT_DIR}/token"
+    CA_FILE="$${SERVICE_ACCOUNT_DIR}/ca.crt"
+    STATE_FILE=/var/lib/rbd-device-observer/state.tsv
+    CURRENT_FILE=/tmp/current.tsv
+    PV_JSON=/tmp/persistent-volumes.json
+    PV_MAP=/tmp/persistent-volumes.tsv
+    PV_DRIVER=rook-ceph.rbd.csi.ceph.com
+    NODE="$${NODE_NAME}"
+    CLUSTER="$${CLUSTER_NAME}"
+
+    mkdir -p "$$(dirname "$${STATE_FILE}")"
+    touch "$${STATE_FILE}"
+
+    api_get() {
+      curl -fsS --cacert "$${CA_FILE}" \
+        -H "Authorization: Bearer $$(cat "$${TOKEN_FILE}")" \
+        "$${API_SERVER}$${1}"
+    }
+
+    emit_error() {
+      now=$$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      jq -cn \
+        --arg observed_at "$${now}" \
+        --arg cluster "$${CLUSTER}" \
+        --arg node "$${NODE}" \
+        --arg error "$${1}" \
+        '{schema:"keiretsu.csi_rbd_device_map/v1", observed_at:$$observed_at,
+          cluster:$$cluster, node:$$node, source:"rbd-device-observer",
+          operation:"snapshot", result:"error", error:$$error}'
+    }
+
+    read_attr() {
+      if [ -r "$${1}" ]; then
+        value=$$(cat "$${1}" 2>/dev/null || true)
+        if [ -n "$${value}" ]; then
+          printf '%s' "$${value}"
+          return
+        fi
+      fi
+      printf '%s' '-'
+    }
+
+    lookup_pv_field() {
+      # The TSV deliberately uses '-' for absent claim references so the
+      # shell's whitespace IFS cannot collapse an empty column while parsing.
+      awk -F '\t' -v image="$${IMAGE}" -v field="$${1}" '
+        $$4 == image {
+          value = $$field
+          if (value == "") value = "-"
+          print value
+          found = 1
+          exit
+        }
+        END {
+          if (!found) print "-"
+        }
+      ' "$${PV_MAP}"
+    }
+
+    emit_record() {
+      line="$${1}"
+      operation="$${2}"
+      result="$${3}"
+      IFS="$$(printf '\t')" read -r device major minor pool image handle pv pv_uid pvc_ns pvc_name pvc_uid pod_uid phase error <<EOF
+    $${line}
+    EOF
+      now=$$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      jq -cn \
+        --arg observed_at "$${now}" \
+        --arg cluster "$${CLUSTER}" \
+        --arg node "$${NODE}" \
+        --arg device "$${device}" \
+        --arg major "$${major}" \
+        --arg minor "$${minor}" \
+        --arg pool "$${pool}" \
+        --arg image "$${image}" \
+        --arg handle "$${handle}" \
+        --arg pv "$${pv}" \
+        --arg pv_uid "$${pv_uid}" \
+        --arg pvc_ns "$${pvc_ns}" \
+        --arg pvc_name "$${pvc_name}" \
+        --arg pvc_uid "$${pvc_uid}" \
+        --arg pod_uid "$${pod_uid}" \
+        --arg phase "$${phase}" \
+        --arg operation "$${operation}" \
+        --arg result "$${result}" \
+        --arg error "$${error}" \
+        '{schema:"keiretsu.csi_rbd_device_map/v1", observed_at:$$observed_at,
+          cluster:$$cluster, node:$$node, source:"rbd-device-observer",
+          device:{path:$$device, major:$$major, minor:$$minor},
+          rbd:{pool:$$pool, image:$$image},
+          csi:{volume_handle:(if $$handle == "-" then null else $$handle end)},
+          pv:{name:(if $$pv == "-" then null else $$pv end),
+              uid:(if $$pv_uid == "-" then null else $$pv_uid end)},
+          pvc:{namespace:(if $$pvc_ns == "-" then null else $$pvc_ns end),
+               name:(if $$pvc_name == "-" then null else $$pvc_name end),
+               uid:(if $$pvc_uid == "-" then null else $$pvc_uid end)},
+          pod_uid:(if $$pod_uid == "-" then null else $$pod_uid end),
+          phase:$$phase, operation:$$operation, result:$$result,
+          error:(if $$error == "-" then null else $$error end)}'
+    }
+
+    append_device() {
+      phase="$${1}"
+      pod_uid="$${2}"
+      error="$${3}"
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$${DEVICE}" "$${MAJOR}" "$${MINOR}" "$${POOL}" "$${IMAGE}" \
+        "$${HANDLE}" "$${PV}" "$${PV_UID}" "$${PVC_NS}" "$${PVC_NAME}" \
+        "$${PVC_UID}" "$${pod_uid}" "$${phase}" "$${error}" >> "$${CURRENT_FILE}"
+    }
+
+    refresh_pv_map() {
+      if ! api_get /api/v1/persistentvolumes > "$${PV_JSON}"; then
+        emit_error persistent_volume_list_failed
+        return 1
+      fi
+      if ! jq -er --arg driver "$${PV_DRIVER}" '
+          .items[]
+          | select(.spec.csi.driver == $$driver)
+          | [(.metadata.name // "-"),
+             (.metadata.uid // "-"),
+             (.spec.csi.volumeHandle // "-"),
+             (.spec.csi.volumeAttributes.imageName // "-"),
+             (.spec.csi.volumeAttributes.pool // "-"),
+             (.spec.claimRef.namespace // "-"),
+             (.spec.claimRef.name // "-"),
+             (.spec.claimRef.uid // "-")]
+          | @tsv
+        ' "$${PV_JSON}" > "$${PV_MAP}"; then
+        emit_error persistent_volume_parse_failed
+        return 1
+      fi
+      return 0
+    }
+
+    snapshot_devices() {
+      : > "$${CURRENT_FILE}"
+      for device_dir in /sys/bus/rbd/devices/*; do
+        [ -d "$${device_dir}" ] || continue
+        id=$$(basename "$${device_dir}")
+        DEVICE="/dev/rbd$${id}"
+        MAJOR=$$(read_attr "$${device_dir}/major")
+        MINOR=$$(read_attr "$${device_dir}/minor")
+        POOL=$$(read_attr "$${device_dir}/pool")
+        IMAGE=$$(read_attr "$${device_dir}/name")
+        HANDLE=$$(lookup_pv_field 3)
+        PV=$$(lookup_pv_field 1)
+        PV_UID=$$(lookup_pv_field 2)
+        PVC_NS=$$(lookup_pv_field 6)
+        PVC_NAME=$$(lookup_pv_field 7)
+        PVC_UID=$$(lookup_pv_field 8)
+        ERROR=-
+        if [ "$${HANDLE}" = '-' ]; then
+          ERROR=persistent_volume_not_found_for_image
+        fi
+
+        mounts=$$(awk -v device="$${MAJOR}:$${MINOR}" '
+          $$3 == device && index($$0, "/var/lib/kubelet/pods/") {
+            print "publish\t" $$0
+            next
+          }
+          $$3 == device && index($$0, "/var/lib/kubelet/plugins/kubernetes.io/csi/rook-ceph.rbd.csi.ceph.com/") {
+            print "stage\t" $$0
+          }
+        ' /proc/1/mountinfo 2>/dev/null || true)
+
+        if [ -n "$${mounts}" ]; then
+          while IFS="$$(printf '\t')" read -r phase mount_line; do
+            [ -n "$${mount_line}" ] || continue
+            pod_uid=$$(printf '%s\n' "$${mount_line}" \
+              | sed -n 's#.* /var/lib/kubelet/pods/\([^/]*\)/.*#\1#p')
+            [ -n "$${pod_uid}" ] || pod_uid=-
+            append_device "$${phase}" "$${pod_uid}" "$${ERROR}"
+          done <<EOF
+    $${mounts}
+    EOF
+        else
+          append_device mapped - "$${ERROR}"
+        fi
+      done
+    }
+
+    while :; do
+      if refresh_pv_map; then
+        snapshot_devices
+
+        # A new line means a map, a changed device/PVC/phase is represented as
+        # an unmap plus map, and a line disappearing is an unmap. The state is
+        # bounded by the devices currently known on this node; the history is
+        # the JSON emitted to stdout and retained by the normal log pipeline.
+        while IFS= read -r line; do
+          [ -n "$${line}" ] || continue
+          if ! grep -F -x -- "$${line}" "$${STATE_FILE}" >/dev/null 2>&1; then
+            emit_record "$${line}" map present
+          fi
+        done < "$${CURRENT_FILE}"
+        while IFS= read -r line; do
+          [ -n "$${line}" ] || continue
+          if ! grep -F -x -- "$${line}" "$${CURRENT_FILE}" >/dev/null 2>&1; then
+            emit_record "$${line}" unmap absent
+          fi
+        done < "$${STATE_FILE}"
+        cp "$${CURRENT_FILE}" "$${STATE_FILE}"
+      fi
+      sleep 60
+    done

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-config.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-config.yaml
@@ -31,7 +31,7 @@ data:
     touch "$${STATE_FILE}"
 
     api_get() {
-      curl -fsS --cacert "$${CA_FILE}" \
+      curl -fsS --connect-timeout 5 --max-time 30 --cacert "$${CA_FILE}" \
         -H "Authorization: Bearer $$(cat "$${TOKEN_FILE}")" \
         "$${API_SERVER}$${1}"
     }

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-daemonset.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-daemonset.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rbd-device-observer
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/name: rbd-device-observer
+    app.kubernetes.io/component: observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rbd-device-observer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rbd-device-observer
+        app.kubernetes.io/component: observability
+    spec:
+      serviceAccountName: rbd-device-observer
+      priorityClassName: system-node-critical
+      hostPID: true
+      automountServiceAccountToken: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values: [linux]
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      containers:
+        - name: observer
+          # This is the already deployed Ceph-CSI image. It is used only for
+          # its small shell/curl/jq runtime; it does not start the CSI driver.
+          image: quay.io/cephcsi/cephcsi:v3.17.0@sha256:886e6d2416d62dd7c8fbe659b6306b6c9451d6918e35ad5d1ac774520e11ef87
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/config/observe.sh"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CLUSTER_NAME
+              value: ${CLUSTER_NAME}
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: host-dev
+              mountPath: /dev
+              readOnly: true
+            - name: host-sys
+              mountPath: /sys
+              readOnly: true
+            - name: host-kubelet
+              mountPath: /var/lib/kubelet
+              readOnly: true
+            - name: state
+              mountPath: /var/lib/rbd-device-observer
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: rbd-device-observer
+            defaultMode: 0555
+        - name: host-dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: host-sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: host-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: state
+          hostPath:
+            path: /var/lib/rbd-device-observer
+            type: DirectoryOrCreate
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-rbac.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph-ottawa/app/rbd-device-observer-rbac.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-device-observer
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/name: rbd-device-observer
+    app.kubernetes.io/component: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbd-device-observer
+  labels:
+    app.kubernetes.io/name: rbd-device-observer
+    app.kubernetes.io/component: observability
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbd-device-observer
+  labels:
+    app.kubernetes.io/name: rbd-device-observer
+    app.kubernetes.io/component: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbd-device-observer
+subjects:
+  - kind: ServiceAccount
+    name: rbd-device-observer
+    namespace: rook-ceph


### PR DESCRIPTION
Closes #2636

## What changed

- Follow up the merged #2717 observer with the Tracee 0.24 `--server` arguments and a ServiceMonitor selector that survives Flux commonMetadata.
- Add an Ottawa-only, system-node-critical RBD device observer using the already deployed pinned Ceph-CSI image's shell/curl/jq runtime.
- On each node, join `/sys/bus/rbd/devices`, host mountinfo, and read-only PersistentVolume metadata from the Kubernetes API.
- Emit structured `keiretsu.csi_rbd_device_map/v1` JSON to stdout for map and unmap transitions, including device major/minor, pool/image, CSI handle, PV/PVC identity, pod UID, operation, phase, result, and error.
- Keep all device, volume, PVC, pod, and sandbox-like identities as JSON fields. No unbounded identity is a metric or stream label.
- Persist only the bounded current snapshot per node so a device-number reuse or unmap produces an explicit transition record; VictoriaLogs retains the emitted history through the normal Fluent Bit path.

## Verification

- `tools/check.sh talos-ottawa` passes.
- The post-Flux-substitution observer script passes `sh -n`.
- Existing live baseline: RBD node plugins are 4/4 Ready; `/dev/rbd0` and kubelet mountinfo are visible, while retained CSI records contain no durable device-to-PVC join.
- I did not terminate or disrupt a human-owned workspace or mutate any PVC. After review/merge and Flux reconciliation, verify the new DaemonSet on all Ottawa nodes and query VictoriaLogs by field (for example `kubernetes.namespace_name:rook-ceph`) for `schema:keiretsu.csi_rbd_device_map`; verify a record contains a real `device.path`, `csi.volume_handle`, `pvc`, and `pod_uid`. A naturally occurring map/unmap should verify the transition fields; no artificial failure is warranted.
- The current merged #2717 pods are not yet ready/scraping until this follow-up is reconciled; no `tracee_ebpf_events_total` exit sample was observed, and no workspace was killed to manufacture one.
