### PR TITLE
feat(monitoring): alert on Mimir recent query window

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -36,6 +36,7 @@ configMapGenerator:
       - rules/k8gb-dns.yaml
       - rules/media.yaml
       - rules/mimir-loader.yaml
+      - rules/mimir-queryable-window.yaml
       - rules/monitoring.yaml
       - rules/node-health.yaml
       - rules/payments.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -46,6 +46,7 @@ spec:
             - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
+            - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
             - /rules/payments.yaml
@@ -81,6 +82,7 @@ spec:
             - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
+            - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
             - /rules/payments.yaml
@@ -112,6 +114,7 @@ spec:
             - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
+            - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
             - /rules/payments.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-queryable-window.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-queryable-window.yaml
@@ -1,0 +1,41 @@
+namespace: mimir-queryable-window
+groups:
+  - name: mimir.queryable-window
+    rules:
+      - record: mimir_query_canary
+        expr: vector(1)
+        labels:
+          source: ruler
+
+      - alert: MimirRecentQueryWindowUnavailable
+        expr: |
+          absent_over_time(
+            mimir_query_canary{source="ruler"}[5m] offset 6h
+          )
+          and on ()
+          (
+            sum(
+              count_over_time(
+                mimir_query_canary{source="ruler"}[5m] offset 13h
+              )
+            ) > 0
+          )
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Mimir's recent query window is unavailable
+          description: >-
+            The dedicated Mimir query canary has no readable sample at the
+            six-hour offset for ten minutes, while the older thirteen-hour
+            canary remains readable from the store. This indicates that the
+            recent ingester-served window is not queryable. It does not prove
+            that every metric series is missing or that the data is permanently
+            lost. The six-hour offset must remain inside
+            querier.query_store_after (currently 12h); update this rule with
+            any query_store_after change or it can silently stop testing the
+            protected recent window.
+            This alert shares the Mimir ruler/query path it observes and is
+            not protection against a ruler, gateway, querier, or complete
+            query-path outage; pair it with an independent external query
+            check.


### PR DESCRIPTION
## Summary

- add a dedicated ruler-recorded `mimir_query_canary` and a recent-window availability alert
- require an older store-served canary control and keep the protected offset inside the current `query_store_after=12h` window
- wire the rule through the generated rules ConfigMap and all three tenant loader containers

## Alert behavior

`MimirRecentQueryWindowUnavailable` is pending for 10 minutes when the canary is unreadable at `offset 6h` while it remains readable at `offset 13h`. The dedicated canary avoids treating `up`'s changing membership and cardinality as the health contract.

This is a ruler/query-path diagnostic, not complete data-loss protection. It does not cover a complete Mimir gateway, querier, ruler, or query-path outage because the alert shares the path it observes; it does not prove every metric series is present or that absent recent data is permanently lost. An independent external query check is still required.

The 6h offset is intentionally inside the current 12h protected recent window. If `query_store_after` changes, this rule's offset must change with it or it can silently stop testing the intended window.

## Investigation result

The discriminating same-path range measurement showed the last non-empty sample move from `04:37Z` at approximately `15:41Z` to `06:42Z` at approximately `16:16Z`, with no restore, republish, or reconciliation. The edge moves with `now`; the morning data was hidden by `query_store_after`, not established as lost. The earlier 6h/13h offset result was non-discriminating because those offsets straddled the edge. The recovered series counts are degraded and need a later completeness check, but do not block this alert.

The instant/raw/Grafana query-path discrepancy remains unexplained and is explicitly not resolved by this PR.

## Deliberately not changed

- no replica count or `replication_factor` change
- no `query_store_after` change
- no post-renderer/PVC redesign; the fixed ingester claim must be redesigned before any replica/RF=2 cost decision

## Validation

- `tools/check.sh talos-ottawa`
- `tools/check-mimir-rules.sh`
- Prometheus rule syntax check with `promtool`
- exact generator and all-three-loader wiring audit
