### PR TITLE
feat(backup): cover unprotected database and Forgejo volumes

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -887,7 +887,7 @@ All *pools* live under `/var/local-path-provisioner/garage-node-local/…` with
 
 ### Garage buckets and access
 
-Ten `GarageBucket` CRs:
+`GarageBucket` CRs include:
 
 | Bucket | Contents |
 |---|---|
@@ -896,7 +896,7 @@ Ten `GarageBucket` CRs:
 | `mimir` | long-term metrics blocks |
 | `tailscale-logs` | tailnet audit log stream |
 | `forgejo` | Forgejo attachments and LFS objects |
-| `bhaiya-postgres`, `immich-postgres`, `tracearr-postgres`, `omnibus-postgres`, `bookorbit-postgres` | CNPG barman-cloud WAL and base backups — one bucket per database, prefix `${LOCATION}`, so federated sites never share a Barman catalog |
+| `bhaiya-postgres`, `firefly-postgres`, `forgejo-postgres`, `woodpecker-postgres`, `suwayomi-postgres`, `teslamate-postgres`, `immich-postgres`, `tracearr-postgres`, `omnibus-postgres`, `bookorbit-postgres` | CNPG barman-cloud WAL and base backups — one bucket per database, prefix `${LOCATION}`, so federated sites never share a Barman catalog |
 
 One footnote on that last row, because it breaks the pattern it states:
 
@@ -1028,7 +1028,7 @@ except `lobby-postgres` (1):
 | `woodpecker-postgres` | `ceph-block-replicated` 10Gi | |
 | `lobby-postgres` | `ceph-block-replicated` 5Gi | database conference; 1 instance |
 | `teslamate-postgres` | default class 8Gi | `postgresql:18` |
-| `suwayomi-postgres` | default class 10Gi | no backup wired |
+| `suwayomi-postgres` | default class 10Gi | |
 | `immich-postgres` | 16Gi Ottawa / 40Gi Robbinsdale | vectorchord image; the larger volume is the Robbinsdale one |
 | `tracearr-postgres` | 40Gi Ottawa / 20Gi Robbinsdale | |
 | `omnibus-postgres` | 10Gi | |

--- a/kubernetes/apps/base/forgejo/forgejo/app/pg.yaml
+++ b/kubernetes/apps/base/forgejo/forgejo/app/pg.yaml
@@ -18,3 +18,57 @@ spec:
     storageClass: ceph-block-replicated
   monitoring:
     enablePodMonitor: true
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: forgejo-postgres-s3-store
+        serverName: forgejo-postgres
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: forgejo-postgres-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: forgejo-postgres-s3-store
+          serverName: forgejo-postgres
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: forgejo-postgres-s3-store
+  namespace: forgejo
+spec:
+  configuration:
+    destinationPath: s3://forgejo-postgres/${LOCATION}/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: forgejo-postgres-s3
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: forgejo-postgres-s3
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      maxParallel: 8
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: forgejo-postgres-s3
+  namespace: forgejo
+spec:
+  schedule: "0 15 2 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: forgejo-postgres

--- a/kubernetes/apps/base/garage/garage-bucket-ottawa/forgejo-postgres.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket-ottawa/forgejo-postgres.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: forgejo-postgres
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: forgejo-postgres
+  quotas:
+    maxSize: 100Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: forgejo-postgres-key
+        namespace: forgejo
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-bucket-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket-ottawa/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
   - ../garage-bucket
   - bucket.yaml
   - firefly-postgres.yaml
+  - forgejo-postgres.yaml
+  - woodpecker-postgres.yaml
+  - suwayomi-postgres.yaml
+  - teslamate-postgres.yaml

--- a/kubernetes/apps/base/garage/garage-bucket-ottawa/suwayomi-postgres.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket-ottawa/suwayomi-postgres.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: suwayomi-postgres
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: suwayomi-postgres
+  quotas:
+    maxSize: 100Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: suwayomi-postgres-key
+        namespace: media
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-bucket-ottawa/teslamate-postgres.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket-ottawa/teslamate-postgres.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: teslamate-postgres
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: teslamate-postgres
+  quotas:
+    maxSize: 100Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: teslamate-postgres-key
+        namespace: teslamate
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-bucket-ottawa/woodpecker-postgres.yaml
+++ b/kubernetes/apps/base/garage/garage-bucket-ottawa/woodpecker-postgres.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: woodpecker-postgres
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+  globalAlias: woodpecker-postgres
+  quotas:
+    maxSize: 100Gi
+    maxObjects: 1000000
+  keyPermissions:
+    - keyRef:
+        name: woodpecker-postgres-key
+        namespace: woodpecker
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys-ottawa/forgejo-postgres-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys-ottawa/forgejo-postgres-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: forgejo-postgres-key
+  namespace: forgejo
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Forgejo PostgreSQL Backup Key"
+  secretTemplate:
+    name: forgejo-postgres-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: forgejo-postgres
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-keys-ottawa/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
   - ../garage-keys
   - bhaiya-postgres-key.yaml
   - firefly-postgres-key.yaml
+  - forgejo-postgres-key.yaml
+  - woodpecker-postgres-key.yaml
+  - suwayomi-postgres-key.yaml
+  - teslamate-postgres-key.yaml

--- a/kubernetes/apps/base/garage/garage-keys-ottawa/suwayomi-postgres-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys-ottawa/suwayomi-postgres-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: suwayomi-postgres-key
+  namespace: media
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Suwayomi PostgreSQL Backup Key"
+  secretTemplate:
+    name: suwayomi-postgres-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: suwayomi-postgres
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys-ottawa/teslamate-postgres-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys-ottawa/teslamate-postgres-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: teslamate-postgres-key
+  namespace: teslamate
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "TeslaMate PostgreSQL Backup Key"
+  secretTemplate:
+    name: teslamate-postgres-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: teslamate-postgres
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-keys-ottawa/woodpecker-postgres-key.yaml
+++ b/kubernetes/apps/base/garage/garage-keys-ottawa/woodpecker-postgres-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: woodpecker-postgres-key
+  namespace: woodpecker
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Woodpecker PostgreSQL Backup Key"
+  secretTemplate:
+    name: woodpecker-postgres-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  bucketPermissions:
+    - bucketRef:
+        name: woodpecker-postgres
+        namespace: garage
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/forgejo-reference-grant.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/forgejo-reference-grant.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-forgejo-postgres-key
+  namespace: forgejo
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: forgejo-postgres-key

--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - reference-grants.yaml
   - firefly-reference-grant.yaml
+  - forgejo-reference-grant.yaml
+  - woodpecker-reference-grant.yaml
+  - teslamate-reference-grant.yaml

--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/teslamate-reference-grant.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/teslamate-reference-grant.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-teslamate-postgres-key
+  namespace: teslamate
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: teslamate-postgres-key

--- a/kubernetes/apps/base/garage/garage-reference-grants-ottawa/woodpecker-reference-grant.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-ottawa/woodpecker-reference-grant.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-woodpecker-postgres-key
+  namespace: woodpecker
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: woodpecker-postgres-key

--- a/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
@@ -27,6 +27,8 @@ spec:
     - kind: GarageKey
       name: omnibus-postgres-key
     - kind: GarageKey
+      name: suwayomi-postgres-key
+    - kind: GarageKey
       name: tracearr-postgres-key
 ---
 apiVersion: garage.rajsingh.info/v1beta1

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -45,6 +45,10 @@ spec:
     - kind: GarageBucket
       namespace: bhaiya
     - kind: GarageKey
+      namespace: woodpecker
+    - kind: GarageKey
+      namespace: teslamate
+    - kind: GarageKey
       namespace: velero-system
     - kind: GarageKey
       namespace: firefly

--- a/kubernetes/apps/base/media/media-ottawa/suwayomi/postgres.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/suwayomi/postgres.yaml
@@ -23,3 +23,57 @@ spec:
     size: 10Gi
   monitoring:
     enablePodMonitor: true
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: suwayomi-postgres-s3-store
+        serverName: suwayomi-postgres
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: suwayomi-postgres-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: suwayomi-postgres-s3-store
+          serverName: suwayomi-postgres
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: suwayomi-postgres-s3-store
+  namespace: media
+spec:
+  configuration:
+    destinationPath: s3://suwayomi-postgres/${LOCATION}/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: suwayomi-postgres-s3
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: suwayomi-postgres-s3
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      maxParallel: 8
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: suwayomi-postgres-s3
+  namespace: media
+spec:
+  schedule: "0 15 1 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: suwayomi-postgres

--- a/kubernetes/apps/base/teslamate/teslamate/app/pg.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/pg.yaml
@@ -17,3 +17,57 @@ spec:
     enablePodMonitor: true
   storage:
     size: 8Gi
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: teslamate-postgres-s3-store
+        serverName: teslamate-postgres
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: teslamate-postgres-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: teslamate-postgres-s3-store
+          serverName: teslamate-postgres
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: teslamate-postgres-s3-store
+  namespace: teslamate
+spec:
+  configuration:
+    destinationPath: s3://teslamate-postgres/${LOCATION}/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: teslamate-postgres-s3
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: teslamate-postgres-s3
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      maxParallel: 8
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: teslamate-postgres-s3
+  namespace: teslamate
+spec:
+  schedule: "0 30 1 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: teslamate-postgres

--- a/kubernetes/apps/base/woodpecker/woodpecker/app/pg.yaml
+++ b/kubernetes/apps/base/woodpecker/woodpecker/app/pg.yaml
@@ -18,3 +18,57 @@ spec:
     storageClass: ceph-block-replicated
   monitoring:
     enablePodMonitor: true
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: woodpecker-postgres-s3-store
+        serverName: woodpecker-postgres
+  backup:
+    retentionPolicy: "30d"
+  externalClusters:
+    - name: woodpecker-postgres-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: woodpecker-postgres-s3-store
+          serverName: woodpecker-postgres
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: woodpecker-postgres-s3-store
+  namespace: woodpecker
+spec:
+  configuration:
+    destinationPath: s3://woodpecker-postgres/${LOCATION}/
+    endpointURL: http://${COMMON_S3_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: woodpecker-postgres-s3
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: woodpecker-postgres-s3
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      maxParallel: 8
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  retentionPolicy: "30d"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: woodpecker-postgres-s3
+  namespace: woodpecker
+spec:
+  schedule: "0 45 2 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: woodpecker-postgres

--- a/kubernetes/apps/ottawa/forgejo/forgejo.yaml
+++ b/kubernetes/apps/ottawa/forgejo/forgejo.yaml
@@ -11,6 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: garage
+    - name: garage-keys
     - name: cnpg-system
   path: ./kubernetes/apps/base/forgejo/forgejo/app
   prune: true

--- a/kubernetes/apps/ottawa/media/media-apps.yaml
+++ b/kubernetes/apps/ottawa/media/media-apps.yaml
@@ -13,6 +13,7 @@ spec:
     - name: rook-ceph-cluster-config
     - name: cnpg-system
     - name: dragonfly-operator-system
+    - name: garage-keys
   path: ./kubernetes/apps/base/media/media-ottawa
   prune: true
   sourceRef:

--- a/kubernetes/apps/ottawa/teslamate/teslamate.yaml
+++ b/kubernetes/apps/ottawa/teslamate/teslamate.yaml
@@ -9,6 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: garage-keys
     - name: cnpg-system
     - name: home-local-gateway
   path: ./kubernetes/apps/base/teslamate/teslamate/app

--- a/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: forgejo-backup
+  namespace: velero-system
+spec:
+  schedule: "0 10 * * *"
+  template:
+    ttl: 720h
+    storageLocation: garage
+    includedNamespaces:
+      - forgejo
+    defaultVolumesToFsBackup: true

--- a/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./home-backup.yaml
   - ./bhaiya-backup.yaml
   - ./cliproxy-backup.yaml
+  - ./forgejo-backup.yaml

--- a/kubernetes/apps/ottawa/woodpecker/woodpecker.yaml
+++ b/kubernetes/apps/ottawa/woodpecker/woodpecker.yaml
@@ -10,6 +10,8 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: garage
+    - name: garage-keys
     - name: cnpg-system
   path: ./kubernetes/apps/base/woodpecker/woodpecker/app
   prune: true


### PR DESCRIPTION
## Summary

- Add CNPG Barman Cloud WAL/base backups for `forgejo-postgres`, `woodpecker-postgres`, `suwayomi-postgres`, and `teslamate-postgres`.
- Provision one least-scope Garage bucket/key pair per database, with the required Ottawa reference grants and Flux dependency ordering.
- Add a daily Velero filesystem-backup schedule for the `forgejo` namespace so `gitea-shared-storage` (repositories) is covered in addition to the database backup.
- Update the architecture reference to describe the new backup buckets and remove the stale Suwayomi “no backup wired” note.

## Verification

- `tools/check.sh ot` passes: `✓ render OK: talos-ottawa`.
- `tools/check-diagram.sh` passes.
- `git diff --check` passes.
- Existing `bhaiya-postgres` reference path was verified live with Barman: `Status: DONE`, `Estimated Cluster Size: 56.6 MiB`, backup `20260906T023000`.
- `tools/orphans.sh` reports only the two pre-existing unrelated AI inference files.

## Operational boundary

This PR is declarative only. It does not create live buckets/keys, mutate existing Velero/Kopia repositories or schedules, restore anything, or delete anything. After merge and Flux reconciliation, first-run evidence must be collected before calling this covered: Ready Garage CRs/secrets, completed CNPG Backup objects, `barman-cloud-backup-show` with `Status: DONE` and a plausible `Estimated Cluster Size`, and a Forgejo Velero Backup with non-zero filesystem/PVC work including `gitea-shared-storage`.

All new backups intentionally land in the existing Garage failure domain (`s3://…` via the in-cluster Garage endpoint). That is a deliberate improvement over no protection, not independent recovery. Ottawa Ceph is currently `HEALTH_WARN` with eight slow BlueStore OSDs; slow first backups should be measured and distinguished from failure rather than judged by duration alone.
