### PR TITLE
feat(monitoring): alert on CNPG backup coverage

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -30,6 +30,7 @@ configMapGenerator:
       - rules/bhaiya-workspace-image.yaml
       - rules/blackbox.yaml
       - rules/ceph.yaml
+      - rules/cnpg-backup-coverage.yaml
       - rules/flux.yaml
       - rules/garage.yaml
       - rules/k8gb.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -40,6 +40,7 @@ spec:
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
+            - /rules/cnpg-backup-coverage.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
@@ -76,6 +77,7 @@ spec:
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
+            - /rules/cnpg-backup-coverage.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
@@ -108,6 +110,7 @@ spec:
             - /rules/bhaiya-workspace-image.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
+            - /rules/cnpg-backup-coverage.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/cnpg-backup-coverage.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/cnpg-backup-coverage.yaml
@@ -1,0 +1,58 @@
+namespace: cnpg-backup-coverage
+groups:
+  - name: cnpg-backup-coverage.rules
+    rules:
+      - alert: CNPGBackupStale
+        expr: |
+          (
+            time()
+            - max by (cluster, namespace, cnpg_cluster) (
+                cnpg_cr_backup_completed_timestamp
+                and on (cluster, namespace, backup, cnpg_cluster)
+                cnpg_cr_backup_info{phase="completed"}
+              )
+          ) > 172800
+          and on (cluster, namespace, cnpg_cluster)
+          max by (cluster, namespace, cnpg_cluster) (
+            cnpg_cr_cluster_info
+          )
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: CNPG cluster {{ $labels.namespace }}/{{ $labels.cnpg_cluster }} has a stale backup
+          description: >-
+            The newest completed CloudNativePG Backup custom resource for
+            {{ $labels.namespace }}/{{ $labels.cnpg_cluster }} is more than 48
+            hours old. Inspect the Backup phase and completion details, the
+            barman-cloud plugin, and the object-store path. This proves CR
+            freshness only; it does not prove that the object-store backup is
+            complete, restorable, or contains every database object. This rule
+            also shares the Mimir ruler and kube-state-metrics query path, so it
+            is not protection against a complete observation-path outage.
+
+      - alert: CNPGBackupMissing
+        expr: |
+          cnpg_cr_cluster_info
+          unless on (cluster, namespace, cnpg_cluster)
+          (
+            max by (cluster, namespace, cnpg_cluster) (
+              cnpg_cr_backup_completed_timestamp
+              and on (cluster, namespace, backup, cnpg_cluster)
+              cnpg_cr_backup_info{phase="completed"}
+            )
+          )
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: CNPG cluster {{ $labels.namespace }}/{{ $labels.cnpg_cluster }} has no completed backup
+          description: >-
+            No completed CloudNativePG Backup custom resource is observed for
+            {{ $labels.namespace }}/{{ $labels.cnpg_cluster }}. This catches a
+            cluster with no ScheduledBackup or Backup at all instead of treating
+            the missing series as healthy. Inspect the Cluster, Backup and
+            ScheduledBackup resources and configure the intended backup path.
+            This proves CR coverage only; it does not prove object-store
+            contents or restore capability, and it is not protection against a
+            complete Mimir or kube-state-metrics observation-path outage.

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -60,6 +60,12 @@ kube-state-metrics:
           - backups
           - podvolumebackups
         verbs: [ "list", "watch" ]
+      - apiGroups:
+          - postgresql.cnpg.io
+        resources:
+          - clusters
+          - backups
+        verbs: [ "list", "watch" ]
   customResourceState:
     enabled: true
     config:
@@ -276,6 +282,45 @@ kube-state-metrics:
                   type: Gauge
                   gauge:
                     path: [ metadata, creationTimestamp ]
+          - groupVersionKind:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            metricNamePrefix: cnpg_cr
+            labelsFromPath:
+              namespace: [ metadata, namespace ]
+              cnpg_cluster: [ metadata, name ]
+            metrics:
+              - name: "cluster_info"
+                help: "Information about a CloudNativePG Cluster custom resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [ metadata, name ]
+          - groupVersionKind:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Backup
+            metricNamePrefix: cnpg_cr
+            labelsFromPath:
+              namespace: [ metadata, namespace ]
+              backup: [ metadata, name ]
+              cnpg_cluster: [ spec, cluster, name ]
+            metrics:
+              - name: "backup_info"
+                help: "The current phase of a CloudNativePG Backup custom resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      phase: [ status, phase ]
+              - name: "backup_completed_timestamp"
+                help: "Unix completion timestamp of a CloudNativePG Backup custom resource."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ status, stoppedAt ]
           - groupVersionKind:
               group: velero.io
               version: v1


### PR DESCRIPTION
## Summary

- add KSM custom-resource-state metrics for CNPG `Cluster` and `Backup` CRs
- add `CNPGBackupStale` (newest completed Backup older than 48h)
- add `CNPGBackupMissing` (cluster inventory `unless` completed Backup inventory)
- wire the rule through the ConfigMap generator and all three Mimir tenant loaders

## Why this signal

The rule does not use `cnpg_collector_last_available_backup_timestamp` or
`cnpg_collector_first_recoverability_point`: both read zero in the live Ottawa
cluster even though healthy plugin-backed backups exist. It uses
`Backup.status.phase` plus `Backup.status.stoppedAt`, and joins against the
CNPG Cluster CR inventory. The inventory join is the important missing-series
guard: Forgejo has no `Backup` or `ScheduledBackup`, so a stale-only max would
never match it.

The Mimir namespace is `cnpg-backup-coverage`, unique across every loaded rule
file. `cluster` is reserved for the scrape-site label, so the CR identity label
is `cnpg_cluster`.

## Live baseline and verification

Captured before delivery:

- `bhaiya/bhaiya-postgres`: completed plugin backup stopped at
  `2026-09-06T02:30:02Z`; neither alert in the live-shaped fixture.
- `woodpecker/woodpecker-postgres`: only completed Backup stopped at
  `2026-02-24T08:47:23Z` (~194 days old); `CNPGBackupStale` fires.
- `forgejo/forgejo-postgres`: zero Backup and ScheduledBackup CRs;
  `CNPGBackupMissing` fires.

The positive/negative checks use promtool fixtures derived from those live CRs;
the new metric families cannot exist in the current cluster until this GitOps
change is delivered and KSM rolls. No live write or reconcile was performed.

Passed:

- `promtool test rules` positive fixture and bhaiya-only negative fixture
- `tools/check-mimir-rules.sh`
- `tools/check.sh talos-ottawa`
- full `tools/check.sh`

This alerts on CR freshness/coverage only. It does not prove object-store
contents, completeness, recoverability, LSN/data integrity, or restore success.
It also shares the KSM/Mimir query path and is not protection against a
complete observation-path outage; an independent external check remains needed.

Related: #2728
