### PR TITLE
fix(ai): restore MiaAI Qwen image and rehome vllm-ts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
     "**/*.sops.*",
     "**/clusterplex.yaml"
   ],
-  "ignoreDeps": ["go.temporal.io/api", "code.forgejo.org/forgejo-helm/forgejo"],
+  "ignoreDeps": ["go.temporal.io/api", "code.forgejo.org/forgejo-helm/forgejo", "vllm/vllm-openai"],
   "flux": {
     "managerFilePatterns": ["/clusters/.+\\.ya?ml$/", "/kubernetes/.+\\.ya?ml$/"]
   },

--- a/kubernetes/apps/base/ai/ai/inference/README.md
+++ b/kubernetes/apps/base/ai/ai/inference/README.md
@@ -192,9 +192,14 @@ For Bhaiya-managed workspaces, the generated config lives at
 ```
 
 Tailscale MagicDNS hostnames:
-- `stpetersburg-vllm` → active SGLang Qwen3.8 server (port 80 → 8000)
+- `stpetersburg-vllm` → active vLLM Qwen3.8 head via Service `vllm-ts` (port 80 → 8000)
 - There is no current `stpetersburg-llama-cpp` Service; the llama.cpp route
   described above is historical reference material only.
+
+The `vllm/vllm-openai` digest in `qwen38.yaml` is the MiaAI-Lab recipe image
+and must not be Renovate-bumped to stock Docker Hub digests: those lack the
+`qwen3_8_flash_next` package the startup patches expect. Renovate ignores
+`vllm/vllm-openai` for that reason.
 
 ## References
 

--- a/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
@@ -129,7 +129,7 @@ spec:
             requests: { memory: "64Mi", cpu: "100m" }
             limits: { memory: "256Mi", cpu: "500m" }
         - name: download-models
-          image: vllm/vllm-openai@sha256:2a7cde230b59f3ce6cab33dd245ba6bee41aa87b38c9fe84f966ff24016813ce
+          image: vllm/vllm-openai@sha256:3b0e188ffceb3d07e09c3cb5215433a0020eacf02d7f882ed3a8bfd15454477e
           command: [/bin/bash]
           args: [/scripts/download-and-validate.sh]
           env:
@@ -156,7 +156,7 @@ spec:
             requests: { memory: "64Mi", cpu: "100m" }
             limits: { memory: "256Mi", cpu: "500m" }
         - name: vllm
-          image: vllm/vllm-openai@sha256:2a7cde230b59f3ce6cab33dd245ba6bee41aa87b38c9fe84f966ff24016813ce
+          image: vllm/vllm-openai@sha256:3b0e188ffceb3d07e09c3cb5215433a0020eacf02d7f882ed3a8bfd15454477e
           # Upstream MiaAI-Lab arm64 image; patches below are applied at startup.
           command: [bash, -c]
           args:
@@ -304,7 +304,7 @@ spec:
             requests: { memory: "64Mi", cpu: "100m" }
             limits: { memory: "256Mi", cpu: "500m" }
         - name: download-models
-          image: vllm/vllm-openai@sha256:2a7cde230b59f3ce6cab33dd245ba6bee41aa87b38c9fe84f966ff24016813ce
+          image: vllm/vllm-openai@sha256:3b0e188ffceb3d07e09c3cb5215433a0020eacf02d7f882ed3a8bfd15454477e
           command: [/bin/bash]
           args: [/scripts/download-and-validate.sh]
           env:
@@ -331,7 +331,7 @@ spec:
             requests: { memory: "64Mi", cpu: "100m" }
             limits: { memory: "256Mi", cpu: "500m" }
         - name: vllm
-          image: vllm/vllm-openai@sha256:2a7cde230b59f3ce6cab33dd245ba6bee41aa87b38c9fe84f966ff24016813ce
+          image: vllm/vllm-openai@sha256:3b0e188ffceb3d07e09c3cb5215433a0020eacf02d7f882ed3a8bfd15454477e
           # Upstream MiaAI-Lab arm64 image; patches below are applied at startup.
           command: [bash, -c]
           args:
@@ -468,6 +468,29 @@ spec:
     role: head
   ports:
   - { name: http, port: 8000, protocol: TCP, targetPort: http }
+---
+# Tailscale ingress for CLIProxy's stpetersburg-vllm-upstream ExternalName.
+# This used to live in vllm.yaml; keep it with the active head so prune cannot
+# leave the Tailscale hostname pointing at a deleting Service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-ts
+  namespace: ai
+  labels:
+    app: qwen38
+  annotations:
+    tailscale.com/hostname: "${LOCATION}-vllm"
+    tailscale.com/proxy-group: common-ingress
+    tailscale.com/tags: "tag:k8s,tag:${LOCATION}"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+  - { name: http, port: 80, protocol: TCP, targetPort: 8000 }
+  selector:
+    app: qwen38
+    role: head
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
## Summary

`ai/qwen38` is on the live CLIProxy path for `vllm/Qwen3.8-Flash-Next`, and both LWS ranks have been CrashLooping (~71 restarts) with `probe_success=0` on `/health` and `/v1/models`.

**Root cause:** Renovate #2706 swapped the MiaAI recipe digest (`sha256:3b0e188…`) for stock `vllm/vllm-openai` (`sha256:2a7cde2…`). Stock images lack `vllm/models/qwen3_8_flash_next/.../ple_layer.py`, so the startup patch wrapper exits 1 before `vllm serve`. This is not OOM, GPU absence, or a download failure — same FileNotFound on spark-0 and spark-1.

**Also:** Service `ai/vllm-ts` (Tailscale hostname `stpetersburg-vllm`) has been stuck deleting since Feb with Tailscale finalizers after it left the active kustomization with `vllm.yaml`. CLIProxy still routes through that hostname.

## Changes

- Revert all four `qwen38` image refs to MiaAI digest `3b0e188…`
- Re-home Service `vllm-ts` into `qwen38.yaml` so Flux prune owns it again
- Add `vllm/vllm-openai` to Renovate `ignoreDeps` so stock digests cannot automerge over the recipe image
- Correct README MagicDNS wording (vLLM head, not SGLang)

## Post-merge ops (cannot do from this PR; read-only live)

1. If LWS does not roll on digest change (`restartPolicy: None`), delete the two pods / recreate the group once so they pull `3b0e188…`.
2. Clear stuck `vllm-ts` finalizers (or finish delete and let Flux recreate) so MagicDNS stops pointing at a deleting Service.

## Verification

- [x] `tools/check.sh sp` → `✓ render OK: talos-stpetersburg`
- [ ] After merge: pods `Ready 2/2`, image digest `3b0e188…`
- [ ] `probe_success=1` on both Probe targets
- [ ] `curl http://stpetersburg-vllm.keiretsu.ts.net/v1/models` returns the Qwen list
- [ ] CLIProxy `vllm/Qwen3.8-Flash-Next` completions succeed

Findings: `/workspace/.agent-recovery/findings-qwenup.md`

Do not self-merge.