### PR TITLE
fix(monitoring): describe adoption alert as template-only

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
@@ -82,18 +82,19 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Workspace image adoption is behind
+          summary: Workspace image template adoption is behind
           description: >-
             Bhaiya has reported that the newest queued workspace-image release
-            is not represented by the active template or every observed
-            ready/idle curated workspace for at least 75 minutes. Query
-            bhaiya_workspace_image_adoption_info for the queued version,
-            digest, template identity, and registry state. This catches a
-            stalled template adoption or workspace propagation even while the
-            control plane and Deployments remain healthy; a missing publication
-            is also a definitive delivery failure rather than an unknown probe
-            result. The alert identity is deliberately stable across newer
-            queued releases so continuous lag does not reset its timer.
+            is not represented by the active workspace template for at least
+            75 minutes. Query bhaiya_workspace_image_adoption_info for the
+            queued version, digest, template identity, and registry state.
+            This is template-adoption failure only: a definitive missing
+            publication or a template that never took the queued digest.
+            Ready/idle curated workspace lag is expected after adoption and
+            is reported by bhaiya_workspace_image_adoption_workspace_count,
+            not by this alert. The alert identity is deliberately stable
+            across newer queued releases so continuous lag does not reset
+            its timer.
 
       - alert: BhaiyaWorkspaceImageAdoptionUnknown
         expr: |
@@ -108,11 +109,13 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: Workspace image adoption cannot be evaluated
+          summary: Workspace image template adoption cannot be evaluated
           description: >-
-            Bhaiya cannot establish workspace-image adoption. Query
+            Bhaiya cannot establish workspace-image template adoption. Query
             bhaiya_workspace_image_adoption_info for the queued version,
             registry state, and template identity, then restore the Forgejo,
-            registry, or durable workspace observation path. Unknown is kept
-            separate from stale so this warning never claims a delivery failure
-            without evidence.
+            registry, or durable template observation path. Unknown is kept
+            separate from stale so this warning never claims a delivery
+            failure without evidence. Fleet drift remains on
+            bhaiya_workspace_image_adoption_workspace_count and does not
+            page through this alert.


### PR DESCRIPTION
## Summary

Pairs with corp/bhaiya#691. Bhaiya now drives `bhaiya_workspace_image_adoption_status` from **template adoption only**; ready/idle fleet digest lag stays on `bhaiya_workspace_image_adoption_workspace_count`.

This PR updates `BhaiyaWorkspaceImageAdoptionStale` / `Unknown` annotations so the critical page matches that split. The PromQL expression and alert name are unchanged on purpose: once #691 is deployed, `status="behind"` means template failure again, and expected post-adoption fleet drift stops paging.

## Why

Template adoption does not roll running sandboxes. The old annotation text claimed the queued digest must be represented by every ready/idle curated workspace, which made the normal steady state look like a delivery outage (#686 category b).

## Test plan

- [ ] Merge after corp/bhaiya#691 has deployed so the metric semantics match the annotations
- [ ] Confirm `BhaiyaWorkspaceImageAdoptionStale` clears once the control plane reports template-current with residual `workspace_count{behind}>0`
- [ ] Confirm a staged stale-template case would still fire the same alert