### PR TITLE
fix(monitoring): de-latch alerts that cannot clear; restore StP source-controller probe

### DIFF
--- a/kubernetes/apps/base/flux-system/flux-system-stpetersburg/app/networkpolicy-monitoring.yaml
+++ b/kubernetes/apps/base/flux-system/flux-system-stpetersburg/app/networkpolicy-monitoring.yaml
@@ -1,9 +1,11 @@
 ---
-# Allow Prometheus in the monitoring namespace to scrape Flux controller
-# metrics endpoints (port 8080). The common `allow-gatus` NP only opens
-# port 9090 from the gatus namespace, leaving Prometheus blocked which
-# trips PrometheusTargetDown on every flux controller. Robbinsdale and
-# Ottawa don't see this regression; add the policy explicitly on StP.
+# Keep this identical to the common flux-monitoring allow-monitoring policy.
+# St. Petersburg reconciles both Kustomizations against the same object; the
+# StP-only 8080 variant previously won on alternate intervals and stripped
+# port 9090. That broke the blackbox path to source-controller: Service port
+# 80 maps to container port 9090 (http), while Prometheus scrapes 8080
+# (http-prom). Without 9090, probe_success stays 0 for the full timeout and
+# ProbeSlowResponse fires as a consequence.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,4 +22,6 @@ spec:
               kubernetes.io/metadata.name: monitoring
       ports:
         - port: 8080
+          protocol: TCP
+        - port: 9090
           protocol: TCP

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/media.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/media.yaml
@@ -5,27 +5,50 @@ groups:
       # failed Job means a rotation happened. One is routine; a stream of them
       # means every server being drawn has an unusable forwarded port.
       #
-      # Count rotations in a window rather than testing a failed Job for presence:
+      # Answer "did the most recent run fail?", not "did any retained Job fail".
       # kube_job_status_failed stays >0 for as long as failedJobsHistoryLimit
-      # retains the Job, so `> 0` latches the alert on long after convergence.
+      # retains the Job, so max_over_time / any-failure windows latch after the
+      # CronJob has already converged. Compare the newest failed Job's start
+      # time with the newest Job overall; a later success clears the alert even
+      # while the old Failed object is still in the API. Restrict to
+      # kube-state-metrics so OpenCost's mirrored series cannot double-count.
       # kube-state-metrics carries no cronjob label, hence the label_replace.
+      # `for: 5m` plus the */5 schedule means a single routine rotation that
+      # succeeds on the next tick never waits long enough to fire.
       - alert: QbittorrentVpnRotated
         expr: >-
           count by (cronjob) (
-            label_replace(
-              max_over_time(
-                kube_job_status_failed{namespace="media", job_name=~"qbittorrent(-pvt)?-portforward-probe-.*"}[1h]
-              ) > 0,
-              "cronjob", "$$1", "job_name", "(qbittorrent(?:-pvt)?-portforward-probe)-.*"
+            (
+              max by (cronjob) (
+                label_replace(
+                  (
+                    kube_job_status_start_time{namespace="media", job="kube-state-metrics", job_name=~"qbittorrent(-pvt)?-portforward-probe-.*"}
+                    and on(job_name)
+                    (
+                      max without (reason) (
+                        kube_job_status_failed{namespace="media", job="kube-state-metrics", job_name=~"qbittorrent(-pvt)?-portforward-probe-.*"}
+                      ) > 0
+                    )
+                  ),
+                  "cronjob", "$$1", "job_name", "(qbittorrent(?:-pvt)?-portforward-probe)-.*"
+                )
+              )
+              ==
+              max by (cronjob) (
+                label_replace(
+                  kube_job_status_start_time{namespace="media", job="kube-state-metrics", job_name=~"qbittorrent(-pvt)?-portforward-probe-.*"},
+                  "cronjob", "$$1", "job_name", "(qbittorrent(?:-pvt)?-portforward-probe)-.*"
+                )
+              )
             )
-          ) > 2
+          ) > 0
         for: 5m
         annotations:
           summary: >-
             {{ $labels.cronjob }} reports port forwarding is not working
           description: >-
-            The port-forward probe failed more than twice in the last hour. Either it
-            found the forwarded port unreachable on two rounds a minute apart and rotated
+            The most recent port-forward probe run failed. Either it found the
+            forwarded port unreachable on two rounds a minute apart and rotated
             the VPN without converging on a usable exit address, or gluetun has no
             forwarded port at all — its NAT-PMP request is refused when the Proton
             wireguard key was generated without NAT-PMP (Port Forwarding), which no

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -9,34 +9,28 @@ namespace: velero-integrity
 groups:
   - name: velero-integrity.rules
     rules:
-      - alert: VeleroBackupInFailureState
-        expr: |
-          max by (cluster, namespace, backup, schedule, phase) (
-            velero_cr_backup_info{
-              namespace="velero-system",
-              schedule!="",
-              phase=~"Failed|PartiallyFailed"
-            }
-          ) > 0
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: Velero schedule {{ $labels.schedule }} has a {{ $labels.phase }} backup
-          description: >-
-            Backup {{ $labels.backup }} for schedule {{ $labels.schedule }} has
-            remained in {{ $labels.phase }} for at least five minutes. Inspect
-            the Backup failureReason/message, its PodVolumeBackup children,
-            Velero server and node-agent logs, and the Garage backup location.
-
+      # Failed/Canceled PVB CRs persist until TTL expiry. Matching every one
+      # latches for days after the parent Backup has already been superseded.
+      # Restrict to parents created in the last 24h so a recent failure still
+      # pages, while historical objects stop saturating the alert stream.
+      # Schedule-level paging for the newest Backup remains in
+      # VeleroScheduleLastBackupFailed below.
       - alert: VeleroPodVolumeBackupFailed
         expr: |
-          max by (cluster, namespace, pod_volume_backup, backup, node, phase) (
-            velero_cr_podvolumebackup_info{
-              namespace="velero-system",
-              phase=~"Failed|Canceled"
-            }
-          ) > 0
+          (
+            max by (cluster, namespace, pod_volume_backup, backup, node, phase) (
+              velero_cr_podvolumebackup_info{
+                namespace="velero-system",
+                phase=~"Failed|Canceled"
+              }
+            ) > 0
+          )
+          and on (cluster, namespace, backup)
+          (
+            velero_cr_backup_created_timestamp{
+              namespace="velero-system"
+            } > time() - 24 * 3600
+          )
         for: 5m
         labels:
           severity: warning
@@ -45,9 +39,12 @@ groups:
           description: >-
             PodVolumeBackup {{ $labels.pod_volume_backup }} for Backup
             {{ $labels.backup }} on node {{ $labels.node }} has remained
-            {{ $labels.phase }} for at least five minutes. Inspect the PVB
-            status message, the parent Backup, node-agent logs, and the storage
-            path before treating the parent Backup as restorable.
+            {{ $labels.phase }} for at least five minutes, and the parent
+            Backup was created within the last 24 hours. Older
+            Failed/Canceled PVB objects are intentionally ignored so a
+            recovered schedule stops paging. Inspect the PVB status message,
+            the parent Backup, node-agent logs, and the storage path before
+            treating the parent Backup as restorable.
 
       - alert: VeleroPodVolumeBackupBytesMismatch
         expr: |


### PR DESCRIPTION
Roughly half the continuously-firing alerts are latched expressions that cannot clear. That saturates the channel, and it is why the real Velero backup failures in #686 went unseen for days.

**The goal here is not quieter alerts — it is making a firing alert mean something again.** Nothing currently-true was silenced.

## Inventory

Live count was **46** firing instances across the three Mimir tenants, not the ~61 estimated in #686. Delivery is fine; saturation is real.

| Scope | Before | After (projected) |
|---|---|---|
| Ottawa | 25 | ~13–14 |
| Robbinsdale | 6 | ~4 |
| St. Petersburg | 15 | ~8–9 |
| **Total** | **46** | **~25–27** |

The after-count is a projection from re-evaluating the changed PromQL against live metrics. It cannot be observed without deploying.

## Changes

**`rules/velero-integrity.yaml`** — removed the latching `VeleroBackupInFailureState`, which duplicated the already-correct `VeleroScheduleLastBackupFailed` (that one only pages when the *newest* Backup per schedule failed). Rewrote `VeleroPodVolumeBackupFailed` to require the parent backup be within 24h, so historical Failed/Canceled PVBs stop paging while a fresh failure still does. Clears ~17 instances; the one PVB still inside 24h correctly stays.

**`rules/media.yaml`** — `QbittorrentVpnRotated` used `max_over_time(kube_job_status_failed[1h]) > 0`, which latches for as long as `failedJobsHistoryLimit` retains the Job. Replaced with a "newest Job is a failed Job" comparison so a later success clears it. Both CronJobs are currently succeeding.

**StP `networkpolicy-monitoring.yaml`** — the StP-only variant reconciled against the same object as the common allow-monitoring policy and stripped port 9090 on alternate intervals. Service port 80 maps to container port 9090, so the blackbox probe to source-controller broke and `ProbeSlowResponse` fired as a consequence. Made it identical to the common policy (8080 **and** 9090). Note main's current StP file still has 8080 only — `ddfd3a8ae` added the common policy but not this variant.

## Still firing, and should be — these need owners, not rule edits

CNPG backup coverage (`media/suwayomi-postgres` and `teslamate/teslamate-postgres` have zero completed Backups; `woodpecker/woodpecker-postgres` is >48h stale) · workspace-image adoption stale (critical) · Bhaiya p99 above the 2s threshold on `bhaiya` and `bhaiya-payments` · SSH session termination errors · SMART health (Ottawa NVMe 67°C, Robbinsdale NVMe 72°C, and `sda`/`sdb`/`sdc` on `10.1.0.24` reporting SMART status failed) · JetKVM probe · rook-ceph mgr memory · StP qwen38 crashloop (one incident, three alerts) · StP node memory.

## Refuted

- **Ceph `BLUESTORE_SLOW_OP_ALERT` as a current latch** — already handled upstream; `CephSlowOps` watches `ceph_healthcheck_slow_ops` and `CephHealthError` deliberately ignores HEALTH_WARN. Neither was firing.
- **`Watchdog` as noise** — it is an intentional always-firing dead-man's switch (`vector(1)`, severity `none`). Removing it would destroy pipeline liveness signal.
- **"Just silence Velero"** — the failures were real historically, but what was *firing* was almost entirely historical CR latch. Newest `bhaiya-backup` and `home-assistant-backup` are Completed. `VeleroScheduleLastBackupFailed` is kept so a true current failure still pages.

## Validation

`tools/check-mimir-rules.sh` → 24 files, 3 tenant loaders, 23 unique namespaces. `tools/check.sh` → render OK for talos-ottawa, talos-robbinsdale, talos-stpetersburg.

Supersedes `work/alertfix`, which carried the same StP NetworkPolicy and `media.yaml` fixes as a subset.
