### PR TITLE
fix(cnpg): establish base backups for suwayomi/teslamate/woodpecker — WAL success is not restore coverage

### DIFF
--- a/kubernetes/apps/base/media/media-ottawa/suwayomi/postgres.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/suwayomi/postgres.yaml
@@ -70,10 +70,30 @@ metadata:
   namespace: media
 spec:
   schedule: "0 15 1 * * *"
-  immediate: true
+  # Do not re-fire an immediate Backup on every Flux reconcile: the first
+  # enablement Backup raced plugin sidecar registration and failed with
+  # "requested plugin is not available". The one-shot verify Backup below
+  # establishes the first recoverable base backup; the schedule keeps it fresh.
+  immediate: false
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
   cluster:
     name: suwayomi-postgres
+---
+# One-shot base backup after plugin enablement. The initial ScheduledBackup
+# with immediate:true failed before the barman-cloud sidecar was registered on
+# the instance pods, so ObjectStore recovery windows stayed empty despite
+# healthy WAL archiving. Forgejo used the same verify pattern successfully.
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: suwayomi-postgres-verify-20260907
+  namespace: media
+spec:
+  cluster:
+    name: suwayomi-postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/base/teslamate/teslamate/app/pg.yaml
+++ b/kubernetes/apps/base/teslamate/teslamate/app/pg.yaml
@@ -64,10 +64,30 @@ metadata:
   namespace: teslamate
 spec:
   schedule: "0 30 1 * * *"
-  immediate: true
+  # Do not re-fire an immediate Backup on every Flux reconcile: the first
+  # enablement Backup raced plugin sidecar registration and failed with
+  # "requested plugin is not available". The one-shot verify Backup below
+  # establishes the first recoverable base backup; the schedule keeps it fresh.
+  immediate: false
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
   cluster:
     name: teslamate-postgres
+---
+# One-shot base backup after plugin enablement. The initial ScheduledBackup
+# with immediate:true failed before the barman-cloud sidecar was registered on
+# the instance pods, so ObjectStore recovery windows stayed empty despite
+# healthy WAL archiving. Forgejo used the same verify pattern successfully.
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: teslamate-postgres-verify-20260907
+  namespace: teslamate
+spec:
+  cluster:
+    name: teslamate-postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/base/woodpecker/woodpecker/app/pg.yaml
+++ b/kubernetes/apps/base/woodpecker/woodpecker/app/pg.yaml
@@ -65,10 +65,30 @@ metadata:
   namespace: woodpecker
 spec:
   schedule: "0 45 2 * * *"
-  immediate: true
+  # Do not re-fire an immediate Backup on every Flux reconcile: the first
+  # enablement Backup raced plugin sidecar registration and failed with
+  # "requested plugin is not available". The one-shot verify Backup below
+  # establishes the first recoverable base backup; the schedule keeps it fresh.
+  immediate: false
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
   cluster:
     name: woodpecker-postgres
+---
+# One-shot base backup after plugin enablement. The initial ScheduledBackup
+# with immediate:true failed before the barman-cloud sidecar was registered on
+# the instance pods, so ObjectStore recovery windows stayed empty despite
+# healthy WAL archiving. Forgejo used the same verify pattern successfully.
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: woodpecker-postgres-verify-20260907
+  namespace: woodpecker
+spec:
+  cluster:
+    name: woodpecker-postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io


### PR DESCRIPTION
`CNPGBackupMissing` and `CNPGBackupStale` are firing on three Ottawa Postgres clusters and they are **correct**. Investigating them found a failure shape worth naming: **WAL archiving is healthy, but there is no base backup — so nothing is restorable.**

Everything looks alive. WAL flows continuously, the plugin is loaded, sidecars are injected, the cluster is Healthy. And the ObjectStore recovery window is empty `{}`.

## Root cause

Not "schedules were never created" — all three ScheduledBackups, ObjectStores and secrets exist and were created ~108m ago by #2732. What failed was the **first immediate Backup at enablement**, which raced the sidecar registration:

```
requested plugin is not available: barman-cloud.cloudnative-pg.io
```

WAL archiving started working shortly after, so the plugin is fine now. But the one Backup that would have established a base was the one that raced, and nothing retried it.

## Per cluster

| Cluster | State |
|---|---|
| `media/suwayomi-postgres` | Only Backup is the failed enablement one. Recovery window empty. |
| `teslamate/teslamate-postgres` | Same. |
| `woodpecker/woodpecker-postgres` | **Worse than "stale".** Its only completed Backup is from **2026-02-24** against `s3://woodpecker/`, while live WAL now archives to `s3://woodpecker-postgres/ottawa/`. The alert said stale because kube-state-metrics still sees that February CR. Operationally, **CI's own database has no current recoverable base backup on the store it is archiving into.** |

`forgejo/forgejo-postgres` is the control: it hit the identical race, then a one-shot verify Backup completed and populated its recovery window. This PR copies that working pattern.

## Changes

One-shot verify Backups for the three clusters (`*-verify-20260907`), and `ScheduledBackup.spec.immediate: false` on all three so Flux reconcile stops re-creating raced immediate Backups.

No live `kubectl apply` or delete. No object-store content pruned. The failed enablement Backups and the old `woodpecker-postgres-initial` CR are deliberately **kept as evidence** — do not delete them without an operator decision.

## Verify after Flux reconciles

1. `Backup/*-verify-20260907` reaches `phase=completed` with `beginWal`/`endWal`
2. ObjectStore `status.serverRecoveryWindow.<cluster>` gains `firstRecoverabilityPoint` and `lastSuccessfulBackupTime`
3. Cluster condition `LastBackupSucceeded=True`
4. `CNPGBackupMissing` / `CNPGBackupStale` clear for these three

Until then the alerts stay correctly red.

## Relationship to corp/bhaiya#695

Same broad class — **backup reporting is not restore coverage** — but a different mechanism. #695 is a Backup that reports **Completed** while silently skipping the durable PVC. This is a Backup that honestly reports **failed**, with WAL success masking the absence of a base.

The shared lesson: **do not treat WAL archive success as backup coverage.**

## Refuted

- **"Schedules were never created."** False — all three exist, ~108m old.
- **"woodpecker is merely stale but covered."** False for the current store.
- **"The plugin is permanently broken."** False — only the first Backup raced registration.
- **"Silence the CNPG alerts."** No. They are correctly reporting missing base backups.

## Validation

`tools/check.sh` → render OK for talos-ottawa, talos-robbinsdale, talos-stpetersburg.
