### PR TITLE
fix(garage): consistent reads so Kopia maintenance stops false clock-skew refusals [NEEDS SIGN-OFF]

### DIFF
--- a/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-ottawa/flux/vars/cluster-settings.yaml
@@ -55,6 +55,9 @@ data:
   # Garage: storage layout hand-managed per-node in clusters/talos-ottawa/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.
+  # Required for Velero/Kopia maintenance (#575). See garagecluster.yaml.
+  GARAGE_CONSISTENCY_MODE: "consistent"
+
   GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
 
   # Operator-managed replacements for the four LocalPath GarageNodes. Each

--- a/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-robbinsdale/flux/vars/cluster-settings.yaml
@@ -44,6 +44,9 @@ data:
   # Garage: storage layout hand-managed per-node in clusters/talos-robbinsdale/apps/garage
   # (Manual) so the array can move off SMB to ceph/local-path per node. Gateway
   # tier stays operator-managed (Auto). Requires operator v0.6.11+.
+  # Required for Velero/Kopia maintenance (#575). See garagecluster.yaml.
+  GARAGE_CONSISTENCY_MODE: "consistent"
+
   GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
 
   # Operator-managed replacements for the three LocalPath GarageNodes. Each

--- a/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
@@ -48,6 +48,9 @@ data:
   # GATEWAY tier stays operator-managed (Auto). The cluster CR (federation,
   # gateway tier, replication) still comes from common. Requires operator
   # v0.6.11+ (spec.storage.layoutPolicy).
+  # Required for Velero/Kopia maintenance (#575). See garagecluster.yaml.
+  GARAGE_CONSISTENCY_MODE: "consistent"
+
   GARAGE_STORAGE_LAYOUT_POLICY: "Manual"
 
   # Operator-managed replacements for the three LocalPath GarageNodes. Each

--- a/docs/adr/0007-velero-backups-need-an-independent-object-store.md
+++ b/docs/adr/0007-velero-backups-need-an-independent-object-store.md
@@ -24,7 +24,7 @@ The live observations below were made on 2026-09-04 UTC.
 | S3 path | `http://garage-gateway.garage.svc.cluster.local:3900`; the `bhaiya-garage-kopia` repository is `Ready` on this BSL |
 | Bucket object | `GarageBucket/garage/velero`, `globalAlias: velero`, `maxSize: 1Ti` |
 | Current bucket usage | 30,760 objects and 308,047,420,448 bytes (286.9 GiB); usage is approximately 28% of the configured byte quota |
-| Garage topology | replication factor 3, `degraded` consistency, Ottawa/Robbinsdale/St. Petersburg federated zones; Ottawa currently has five storage nodes and two gateway replicas |
+| Garage topology | replication factor 3, `consistent` read-after-write (required by Kopia maintenance; see #575), Ottawa/Robbinsdale/St. Petersburg federated zones; Ottawa currently has five storage nodes and two gateway replicas |
 | Independent target | None. All three live `GarageBucket/velero` objects report the same global bucket ID, and all three BSLs use the same bucket and gateway service name with only the prefix changed |
 
 Garage's remote zones and replication protect against selected node or site

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -843,7 +843,7 @@ reason needs two patches because both halves of the mismatch have to move:
 One per site; together, one logical S3 estate.
 
 - image `dxflrs/garage` v2.3.0, zone `${LOCATION}`
-- replication factor 3, `consistencyMode: degraded`
+- replication factor 3, `consistencyMode: consistent` (Kopia/Velero need read-after-write; see #575)
 - `s3Api` rootDomain `.s3.keiretsu.top`; `webApi` rootDomain `.keiretsu.top`
 - `rpcPublicAddr ${LOCATION}-garage.keiretsu.ts.net:3901`
 - `remoteClusters` lists **all three** zones, each reached over the tailnet:
@@ -1507,22 +1507,23 @@ Ottawa's edge on their own.
 
 ### Garage: one zone is survivable, two are not
 
-Replication factor 3 across exactly three zones, `consistencyMode: degraded`,
-reads at quorum 1.
+Replication factor 3 across exactly three zones. The fleet default is
+`consistencyMode: consistent` (read-after-write) because Velero/Kopia
+maintenance depends on it: Kopia writes `_maintenance` then immediately HEADs
+that same object and treats Garage `Last-Modified` as the repository clock
+(#575). Under `degraded`, that HEAD can return a ~1h-stale replica and Kopia
+refuses prune as "clock skew" even when every node is NTP-synced.
 
-- **One zone down:** reads and writes continue. Apps talk to their local
-  gateway, which proxies reads to a surviving zone, so a site can lose its own
-  storage tier entirely and still serve objects.
+- **One zone down under consistent:** writes still need quorum; reads that
+  cannot gather quorum fail closed rather than serving a single stale replica.
+  Prefer temporary `GARAGE_CONSISTENCY_MODE=degraded` only for an explicit drain
+  or availability window, then restore `consistent`.
 - **Two zones down:** you are below write quorum. Treat it as an outage of the
   object store, not a degradation.
 
-The reason this is tolerable rather than reckless is what is stored in it: OCI
-blobs and kopia backups are content-addressed, and Barman WAL is append-only,
-so none of the current consumers depend on read-after-write consistency. That
-argument is written down beside the setting in the `GarageCluster` manifest,
-`garagecluster.yaml` under `kubernetes/apps/base/garage/garage/` — check it
-before adding a consumer that *does* need read-after-write, because the
-reasoning, not the replication factor, is what makes `degraded` safe here.
+OCI blobs and Barman WAL can tolerate eventual-consistent reads. Kopia's
+maintenance schedule blob cannot. That argument is written beside the setting
+in `garagecluster.yaml` under `kubernetes/apps/base/garage/garage/`.
 
 Note also that the storage tier is `Manual` at all three sites while the gateway
 tier is operator-managed, and that retirement of a node with positive capacity

--- a/kubernetes/apps/base/garage/garage/garagecluster.yaml
+++ b/kubernetes/apps/base/garage/garage/garagecluster.yaml
@@ -22,15 +22,18 @@ spec:
 
   replication:
     factor: 3
-    # degraded: reads fall back to a single (local) replica when cross-WAN quorum
-    # is slow/unavailable, instead of returning 503/504. Writes still require
-    # quorum. This fixes the read-path 503s that broke zot (boot-time getAllRepos
-    # list + blob HEAD checks) and CI image pushes. Safe now that restic/volsync
-    # is decommissioned (2026-07-04) — it was the only read-after-write-sensitive
-    # consumer; the rest are content-addressed (OCI/zot, Kopia/velero) or
-    # append-only (logs, barman/CNPG backups), which tolerate eventual-consistent
-    # reads (a stale/absent read is a transient retry, not corruption).
-    consistencyMode: "${GARAGE_CONSISTENCY_MODE:=degraded}"
+    # consistent: Garage serves read-after-write for object metadata. Required by
+    # Velero/Kopia maintenance (#575): Kopia PUTs `_maintenance` then immediately
+    # HEADs it and treats Garage's Last-Modified as the "repository timestamp".
+    # Under degraded, that HEAD can hit a replica still carrying the previous
+    # hour's stamp (~1h5m behind local), and Kopia refuses prune as "clock skew"
+    # even though every Talos node is NTP-synced to microseconds.
+    #
+    # degraded remains available via GARAGE_CONSISTENCY_MODE for drain windows
+    # or if a site must prefer availability over read-after-write (zot historically
+    # preferred it for cross-WAN 503 avoidance). Do not return the fleet default
+    # to degraded while Kopia still owns the Velero volume repositories here.
+    consistencyMode: "${GARAGE_CONSISTENCY_MODE:=consistent}"
 
   s3Api:
     rootDomain: ".s3.${COMMON_DOMAIN}"


### PR DESCRIPTION
> **This changes failure behaviour across all three clusters. It needs Raj's sign-off before merge, not just a green check.**

## The "clock skew" is not a clock problem

Kopia maintenance has been refusing to prune with `clock skew detected … skew 1h5m12s`. Every node clock is fine — Ottawa Talos nodes are synchronised to **microseconds** (`node_timex_sync_status == 1`, `|offset|` ≤ ~0.3 ms; well under 10 ms across the whole failure window, including on `asuka` where the failed job ran).

What Kopia actually compares, from `kopia/repo/maintenance/maintenance_run.go`:

1. `updateSchedule()` **PUTs** the `_maintenance` blob
2. `GetMetadata(_maintenance)` reads `bm.Timestamp`
3. `checkClockSkewBounds` compares the local process clock to **that stored object timestamp**, refusing if `|Δ| > 5m`

So "repository: …" in the error is **Garage's S3 `Last-Modified` on a blob Kopia just wrote** — not a remote wall clock, not NTP.

## The arithmetic proves it

| Local | Repository | Skew | Skew − 1h |
|---|---|---|---|
| 2026-08-29T12:06:44Z | 2026-08-29T11:01:26Z | 1h5m18s | 5m18s |
| 2026-09-03T14:41:27Z | 2026-09-03T13:36:28Z | 1h4m59s | 4m59s |
| 2026-09-06T22:12:13Z | 2026-09-06T21:07:01Z | 1h5m12s | 5m12s |

Every event is **exactly one maintenance interval (~1h) plus ~5m**. That is the signature of reading the *previous cycle's* metadata — not a drifting oscillator, and not a timezone (all stamps are explicit `+0000 UTC`).

Live `GarageCluster/garage` is `{"consistencyMode":"degraded","factor":3}`. Under degraded reads, the HEAD immediately following Kopia's own PUT can land on a replica still carrying the previous hour's stamp. That is precisely the observed shape.

It also explains why retries work: the same repo Failed at 22:12 and **Succeeded at 22:16 on the same node with the same clock**. The only variable is which replica answered.

## Changes

Fleet default `consistencyMode` → `consistent`, set explicitly in all three sites' `cluster-settings` (they must agree for federation drain policy), plus corrected docs. The old comment in `garagecluster.yaml` claimed Kopia and Velero "tolerate eventual-consistent reads" — **that is wrong** for the maintenance schedule blob, which requires read-after-write.

## The tradeoff Raj needs to accept

Garage reads that previously fell back to a single local replica under a WAN blip will now **fail closed instead of serving stale data**. That is the intended behaviour, but it is a real availability change across Ottawa, Robbinsdale and St Petersburg.

For a deliberate drain window, set `GARAGE_CONSISTENCY_MODE=degraded` temporarily and restore `consistent` before relying on Kopia maintenance again.

## Not claimed

That `consistent` repairs the `BLOB not found` pack/index errors (corp/bhaiya#686 family), or that a Ready BackupRepository equals a successful prune. Acceptance is a later hourly maintenance that does **not** refuse for skew. An independent off-cluster Velero target (ADR 0007 / #571) remains the real durability answer.

No prune, delete, or forced BackupRepository job was run. `tools/check.sh` renders OK for all three clusters.
