### PR TITLE
feat(monitoring): alert when the newest backup Completed with warnings (the #695 silent-skip case)

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -3,6 +3,11 @@
 # are useful for newly observed events, but do not represent the persisted
 # phase of an individual Backup (a real Failed Backup kept last_status=1).
 #
+# #572 acceptance (Failed/PartiallyFailed latest Backup, Failed/Canceled PVB,
+# bytesDone!=totalBytes) is covered by the rules below after #2743. The
+# warnings gauge + VeleroScheduleLatestBackupHasWarnings close the #695 gap
+# (Completed Backup that silently skipped a durable hostPath volume).
+#
 # Keep this namespace separate from rules/velero.yaml. Both files are synced by
 # the same mimirtool Job and a repeated namespace aborts every tenant sync.
 namespace: velero-integrity
@@ -120,3 +125,47 @@ groups:
             when a newer attempt exists. The creation timestamp is used for
             ordering; velero_backup_last_status is not authoritative for this
             condition.
+
+      # Completed + warnings is how Velero reports hostPath volume skips while
+      # still leaving phase=Completed (StP home-assistant-config / #695). Bound
+      # to the newest Backup per schedule so a later clean run clears the alert;
+      # do not match historical warning-bearing objects.
+      - alert: VeleroScheduleLatestBackupHasWarnings
+        expr: |
+          (
+            max by (cluster, namespace, schedule, backup) (
+              velero_cr_backup_warnings{
+                namespace="velero-system",
+                schedule!=""
+              }
+            ) > 0
+          )
+          and on (cluster, namespace, schedule, backup)
+          (
+            velero_cr_backup_created_timestamp{
+              namespace="velero-system",
+              schedule!=""
+            }
+            == on (cluster, namespace, schedule) group_left
+            max by (cluster, namespace, schedule) (
+              velero_cr_backup_created_timestamp{
+                namespace="velero-system",
+                schedule!=""
+              }
+            )
+          )
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} latest backup has warnings
+          description: >-
+            The newest Backup for schedule {{ $labels.schedule }} is
+            {{ $labels.backup }} and reports status.warnings > 0. Velero uses
+            warnings for soft failures such as skipping a hostPath / local-path
+            volume while still marking the Backup Completed, so phase alone is
+            not enough. Inspect the Backup log for "hostPath volume which is not
+            supported" (or other skip reasons), confirm every durable PVC has a
+            Completed PodVolumeBackup, and do not treat this Backup as a volume
+            restore source until the warning is gone. A later Backup with
+            warnings=0 clears this alert.

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -282,6 +282,20 @@ kube-state-metrics:
                   type: Gauge
                   gauge:
                     path: [ metadata, creationTimestamp ]
+              # status.warnings is how Velero records hostPath volume skips and
+              # similar soft failures while still leaving phase=Completed (#695).
+              - name: "backup_warnings"
+                help: "Warning count on a Velero Backup custom resource (status.warnings)."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ status, warnings ]
+              - name: "backup_errors"
+                help: "Error count on a Velero Backup custom resource (status.errors)."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ status, errors ]
           - groupVersionKind:
               group: postgresql.cnpg.io
               version: v1


### PR DESCRIPTION
Two findings from investigating corp/bhaiya#572.

## #572 is already satisfied — propose closing it

All three of its acceptance criteria are met on `main` after #2743:

| #572 requirement | Rule on main today | Clears on recovery? |
|---|---|---|
| Named-schedule Backup Failed/PartiallyFailed | `VeleroScheduleLastBackupFailed` — newest Backup per schedule only | **Yes** — a later Completed Backup is newer by `velero_cr_backup_created_timestamp` |
| Consequential PVB Failed/Canceled | `VeleroPodVolumeBackupFailed` — with the #2743 24h parent bound | **Yes** |
| Completed PVB with `bytesDone != totalBytes` | `VeleroPodVolumeBackupBytesMismatch` | **Yes** |

Both rule files are in the mimirtool loader for all three clusters.

**What #572 asked for that we should keep refusing:** reintroducing "any Failed/PartiallyFailed Backup object → alert". Those CRs persist until TTL (~7d), so that pattern **cannot clear after recovery** while old objects exist. That is exactly the latch #2743 removed, and re-adding it would undo that work.

Verified live on Ottawa: joining `velero_cr_backup_info` to the max `velero_cr_backup_created_timestamp` per schedule returns `bhaiya-backup-20260906080000` / `Completed`, so the rule correctly does not fire — while three historical PartiallyFailed objects still sit in the API.

## The real gap: a Completed backup that silently skipped a durable volume

Adds `VeleroScheduleLatestBackupHasWarnings`, keyed on `velero_cr_backup_warnings > 0` for the **newest** backup per schedule.

This is the corp/bhaiya#695 failure mode, and it had **no detection at all**: Velero downgrades an unsupported volume (a `local-path` hostPath PV) to a *skip*, marks the Backup **Completed**, and emits a warning nobody was watching. That is how St Petersburg's Home Assistant config went from day one to never having a single PodVolumeBackup while its schedule reported success.

It is deliberately **non-latching** — scoped to the newest backup per schedule, so it clears when a subsequent backup is clean, exactly like the rules #2743 established.

Also extends `kube-state-metrics-config.yaml` so the warnings series is available.

## Why this matters more than the rest

Every other Velero rule detects a backup that *says* it failed. This is the only one that detects a backup that **says it succeeded and did not**. Given the night's finding that "Completed" was the dangerous state, that asymmetry is worth closing.

## Validation

`tools/check-mimir-rules.sh` and `tools/check.sh` — render OK for talos-ottawa, talos-robbinsdale, talos-stpetersburg.
