### PR TITLE
feat(monitoring): alert when WAL is healthy but no base backup exists on the current store

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/cnpg-backup-coverage.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/cnpg-backup-coverage.yaml
@@ -56,3 +56,70 @@ groups:
             This proves CR coverage only; it does not prove object-store
             contents or restore capability, and it is not protection against a
             complete Mimir or kube-state-metrics observation-path outage.
+
+      # Woodpecker failure mode (#2745 / cnpgmismatch): a Completed Backup CR can
+      # exist on an old barmanObjectStore destination (deliberately retained
+      # evidence: woodpecker-postgres-initial → s3://woodpecker/) while the
+      # cluster's current ObjectStore (s3://woodpecker-postgres/ottawa/) has an
+      # empty recovery window and only WAL. CR-only Missing/Stale are blind to
+      # that, and joining Backup.status.destinationPath would permanently latch
+      # on that kept historical CR. Same discipline as
+      # VeleroScheduleLatestBackupHasWarnings: page the *current* condition, not
+      # every retained object. barman-cloud's last-available timestamp is the
+      # current ObjectStore recovery window, so it clears once a verify/base
+      # backup lands on the live store. Require recent WAL archival so a brand-
+      # new cluster before its first archive does not page, and so a total scrape
+      # outage remains distinct.
+      - alert: CNPGCurrentStoreBackupMissing
+        expr: |
+          (
+            max by (cluster, namespace, pod) (
+              cnpg_pg_stat_archiver_seconds_since_last_archival < 3600
+            )
+            unless on (cluster, namespace, pod)
+            (
+              max by (cluster, namespace, pod) (
+                barman_cloud_cloudnative_pg_io_last_available_backup_timestamp > 0
+              )
+            )
+          )
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: CNPG {{ $labels.namespace }}/{{ $labels.pod }} archives WAL but has no current-store base backup
+          description: >-
+            {{ $labels.namespace }}/{{ $labels.pod }} has archived WAL within the
+            last hour, but barman-cloud reports no last-available backup on the
+            current ObjectStore. This is the woodpecker-shaped gap: a Completed
+            Backup CR may still exist on a previous destination while the live
+            store has only WAL. Inspect ObjectStore status.serverRecoveryWindow,
+            the Cluster plugin barmanObjectName destinationPath, and create a
+            verify Backup against the current store. Do not treat WAL success as
+            restore coverage.
+
+      - alert: CNPGCurrentStoreBackupStale
+        expr: |
+          (
+            max by (cluster, namespace, pod) (
+              time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp
+            ) > 172800
+          )
+          and on (cluster, namespace, pod)
+          (
+            max by (cluster, namespace, pod) (
+              cnpg_pg_stat_archiver_seconds_since_last_archival < 3600
+            )
+          )
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: CNPG {{ $labels.namespace }}/{{ $labels.pod }} current-store base backup is stale
+          description: >-
+            The current ObjectStore last-available backup for
+            {{ $labels.namespace }}/{{ $labels.pod }} is older than 48 hours while
+            WAL archival is still succeeding. A Completed Backup CR on a different
+            destination does not clear this. Inspect ScheduledBackup, the verify
+            Backup path, and ObjectStore status.serverRecoveryWindow before
+            treating the database as restorable.


### PR DESCRIPTION
Adds detection for the failure mode found in km#2745: **WAL archiving healthy, no base backup on the store it archives into.** A cluster in that state looks fine on every existing signal and is unrecoverable.

## The gap

`woodpecker-postgres` — CI's own database — had its only completed Backup from **2026-02-24** against `s3://woodpecker/`, while live WAL archived to `s3://woodpecker-postgres/ottawa/`. Existing alerts only catch *missing* or *stale*, and kube-state-metrics still saw that February record, so it read as merely "stale". Operationally it had **no recoverable base backup at all** on the store in use.

Nothing alerted on that, because every signal was individually healthy.

## Fleet audit first

Audited every CNPG cluster across all three sites before writing a rule:

| Site | Clusters | Completed CRs whose `destinationPath` ≠ current ObjectStore | **Active** gaps (empty recovery window) |
|---|---|---|---|
| Ottawa | 10 | 1 historical only (`woodpecker-postgres-initial`) | **0** |
| Robbinsdale | 2 | 0 | 0 |
| St. Petersburg | 0 | n/a | n/a |

So this is not a widespread problem — it was a one-off, already fixed by km#2745. The rule exists so the next one is caught rather than stumbled upon.

## The rules

`CNPGCurrentStoreBackupMissing` fires when WAL archiving is healthy (`cnpg_pg_stat_archiver_seconds_since_last_archival < 3600`) **and** there is no available backup on the current store. `CNPGCurrentStoreBackupStale` covers the aged equivalent.

Two properties that matter:

- **Keyed on the current store's own metrics**, so a retained Backup CR pointing at an old destination cannot satisfy it. That is what makes it catch the woodpecker case rather than being fooled by it.
- **Non-latching.** It clears when a base backup lands. `woodpecker-postgres-initial` is deliberately kept as evidence and this rule does **not** fire on it — that was an explicit design constraint, since we spent real effort removing rules that could not clear.

## Relationship to the other two

Three different mechanisms, same underlying lesson — **backup reporting is not restore coverage**:

- **corp/bhaiya#695 / km#2748** — Backup reports **Completed** while silently skipping a durable hostPath PVC.
- **km#2745** — Backup honestly reports **failed**, but WAL success masks the absent base.
- **This** — everything reports healthy, and the base backup is on a store nobody writes to any more.

## Validation

`tools/check-mimir-rules.sh` → 24 files, 3 tenant loaders, 23 unique namespaces. `tools/check.sh` → render OK for all three clusters. No backup or object-store content deleted or pruned.
