### PR TITLE
feat(monitoring): detect schedules that never ran, stale repo maintenance, and unavailable BSLs

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
@@ -72,3 +72,106 @@ groups:
             server, and node-agent pods. This is a freshness/reporting guard;
             it cannot detect a backup that completes while silently missing
             data, and it also needs the Velero metric to remain scrapeable.
+
+      # VeleroBackupStale requires a last_successful_timestamp series. A Schedule
+      # that is Enabled but has never produced a Backup (forgejo-backup after
+      # #2732 had status.lastBackup unset) creates no such series and stays
+      # invisible. Page from the Schedule CR once it is older than 36h without
+      # lastBackup. Clears when lastBackup is set; does not latch on history.
+      - alert: VeleroScheduleNeverBackedUp
+        expr: |
+          (
+            max by (cluster, namespace, schedule) (
+              velero_cr_schedule_info{
+                namespace="velero-system",
+                phase="Enabled",
+                paused!="true"
+              }
+            )
+            and on (cluster, namespace, schedule)
+            (
+              time()
+              - max by (cluster, namespace, schedule) (
+                  velero_cr_schedule_created_timestamp{
+                    namespace="velero-system"
+                  }
+                )
+              > 129600
+            )
+          )
+          unless on (cluster, namespace, schedule)
+          (
+            max by (cluster, namespace, schedule) (
+              velero_cr_schedule_last_backup_timestamp{
+                namespace="velero-system"
+              } > 0
+            )
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} has never produced a backup
+          description: >-
+            Schedule {{ $labels.schedule }} has been Enabled for more than 36
+            hours with no status.lastBackup. VeleroBackupStale cannot see this
+            because no velero_backup_last_successful_timestamp series exists
+            until the first success. Inspect the Schedule, its first cron
+            window, BackupStorageLocation, and Velero logs. The alert clears
+            when lastBackup is set.
+
+      # BackupRepository phase=Ready coexists with refused Kopia maintenance
+      # (#575 Garage degraded read-after-write on _maintenance). Prefer
+      # lastMaintenanceTime freshness over the failure counter so a historical
+      # refusal does not latch after later successes.
+      - alert: VeleroBackupRepositoryMaintenanceStale
+        expr: |
+          (
+            max by (cluster, namespace, repository, volume_namespace) (
+              velero_cr_backuprepository_info{
+                namespace="velero-system",
+                phase="Ready"
+              }
+            )
+            and on (cluster, namespace, repository)
+            (
+              time()
+              - max by (cluster, namespace, repository) (
+                  velero_cr_backuprepository_last_maintenance_timestamp{
+                    namespace="velero-system"
+                  }
+                )
+              > 21600
+            )
+          )
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: Velero BackupRepository {{ $labels.repository }} maintenance is stale
+          description: >-
+            BackupRepository {{ $labels.repository }} (volume namespace
+            {{ $labels.volume_namespace }}) is Ready but has not recorded
+            lastMaintenanceTime within 6 hours (maintenanceFrequency is 1h).
+            This is the #575-shaped gap: Ready does not mean prune/maintenance
+            is succeeding. Inspect recent maintain Jobs and Velero logs for
+            "clock skew" / refused maintenance. The alert clears when
+            lastMaintenanceTime advances; it does not latch on
+            velero_repo_maintenance_failure_total.
+
+      - alert: VeleroBackupStorageLocationUnavailable
+        expr: |
+          max by (cluster, backup_location_name) (
+            velero_backup_location_status_gauge == 0
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero BackupStorageLocation {{ $labels.backup_location_name }} is unavailable
+          description: >-
+            BackupStorageLocation {{ $labels.backup_location_name }} is not
+            Available. New backups cannot be written even while old objects
+            remain readable in Garage. Inspect BSL status, credentials, and
+            the garage-gateway path. Clears when the location becomes Available
+            again.

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -335,6 +335,66 @@ kube-state-metrics:
                   type: Gauge
                   gauge:
                     path: [ status, stoppedAt ]
+          # Schedule CRs are required to catch schedules that never produce a
+          # successful Backup (no velero_backup_last_successful_timestamp series).
+          # VeleroBackupStale alone is blind to that case: forgejo-backup was
+          # Enabled with lastBackup unset and would stay invisible until after
+          # its first success created a timestamp series.
+          - groupVersionKind:
+              group: velero.io
+              version: v1
+              kind: Schedule
+            metricNamePrefix: velero_cr
+            labelsFromPath:
+              namespace: [ metadata, namespace ]
+              schedule: [ metadata, name ]
+            metrics:
+              - name: "schedule_info"
+                help: "Phase and pause state of a Velero Schedule custom resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      phase: [ status, phase ]
+                      paused: [ spec, paused ]
+              - name: "schedule_created_timestamp"
+                help: "Unix creation timestamp of a Velero Schedule custom resource."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ metadata, creationTimestamp ]
+              - name: "schedule_last_backup_timestamp"
+                help: "Unix timestamp of Schedule.status.lastBackup when set."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ status, lastBackup ]
+          # BackupRepository phase=Ready can coexist with refused Kopia prune
+          # (#575). Export lastMaintenanceTime so Ready-but-unmaintained is
+          # observable without latching on a historical failure counter.
+          - groupVersionKind:
+              group: velero.io
+              version: v1
+              kind: BackupRepository
+            metricNamePrefix: velero_cr
+            labelsFromPath:
+              namespace: [ metadata, namespace ]
+              repository: [ metadata, name ]
+              volume_namespace: [ spec, volumeNamespace ]
+            metrics:
+              - name: "backuprepository_info"
+                help: "Phase of a Velero BackupRepository custom resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      phase: [ status, phase ]
+              - name: "backuprepository_last_maintenance_timestamp"
+                help: "Unix timestamp of BackupRepository.status.lastMaintenanceTime."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ status, lastMaintenanceTime ]
           - groupVersionKind:
               group: velero.io
               version: v1


### PR DESCRIPTION
Three more ways a backup can be silently absent, each now detectable. This closes gaps found by *enumerating* failure modes rather than waiting to trip over them — every previous one tonight was discovered by accident.

## The rules

**`VeleroScheduleNeverBackedUp`** — a Schedule that is Enabled, not paused, created more than 36h ago, and has **no `lastBackup` at all**. This is the Forgejo shape from corp/bhaiya#703: the schedule exists and looks configured, and has never produced a single Backup. Nothing detected that.

**`VeleroBackupRepositoryMaintenanceStale`** — a repository that is **Ready** but whose `lastMaintenanceTime` is more than 6h old (`for: 30m`). This is exactly the #575 case: Kopia refused prunes for weeks while the BackupRepository reported Ready, so *Ready was not evidence of maintenance running*. Retention and repo growth silently degrade behind a green status.

**`VeleroBackupStorageLocationUnavailable`** — the location gauge sitting at 0 for 15m. A BSL that has gone unavailable makes every subsequent backup fail at the storage layer.

Plus the kube-state-metrics exports these need: `velero_cr_schedule_info` / `_created_timestamp` / `_last_backup_timestamp`, and `velero_cr_backuprepository_info` / `_last_maintenance_timestamp`.

## Why the "Ready repo" one matters most

It generalises the lesson from #575. We spent weeks with maintenance refusing to run — the clock-skew symptom — while every dashboard showed a Ready repository. **A component reporting Ready is not the same as that component doing its job**, and the only way to tell the difference is to watch the timestamp of the work itself.

## Design discipline

All three are non-latching and clear when the underlying condition resolves, consistent with km#2743, #2748 and #2752. None of them fires on a historical object that has been deliberately retained as evidence.

## Validation

`tools/check-mimir-rules.sh` → 24 files, 3 tenant loaders, 23 unique namespaces. `tools/check.sh` → render OK for talos-ottawa, talos-robbinsdale, talos-stpetersburg.
