### PR TITLE
fix(monitoring): retain apiserver LIST/watch-cache counters (~4k series)

### DIFF
--- a/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/helmrelease-kube-prometheus-stack.yaml
@@ -151,14 +151,26 @@ spec:
           - action: drop
             sourceLabels: [__name__]
             regex: (apiserver_request_duration_seconds|apiserver_request_sli_duration_seconds|apiserver_request_body_size_bytes|apiserver_response_sizes|apiserver_watch_cache_read_wait_seconds|apiserver_watch_list_duration_seconds|apiserver_watch_events_sizes|etcd_request_duration_seconds|rpc_duration_seconds|rpc_duration)_bucket
-          # Second pass: the _sum/_count of those histograms plus apiserver/etcd
-          # internal bookkeeping series — verified referenced by zero dashboards,
-          # alerts, or badges. apiserver_request_total and
-          # apiserver_request_duration_seconds_{sum,count} are deliberately NOT
-          # matched here (the API dashboards use them).
+          # Second pass: drop unused latency companions / bookkeeping, but do
+          # NOT blank the watch-cache LIST attribution counters.
+          #
+          # Measured on live /metrics (2026-09-07), per apiserver endpoint:
+          #   StP  restore set ≈ 3840 series (cache_list_* + storage_list_* +
+          #        longrunning_requests + watch_cache_capacity +
+          #        non-bucket apiserver_watch_cache_* including read-wait
+          #        _sum/_count). Ottawa ≈ 4476.
+          #   Still dropped watch latency _bucket ≈ 12311 (StP) / 14289
+          #        (Ottawa) — the class that drove the ~470k-series agent OOM.
+          #   apiserver_request_total already kept (≈1801 StP / 2241 Ottawa;
+          #        labels: verb/resource/code/scope — no username/client on
+          #        v1.36, so SA attribution still needs audit logs).
+          #   apiserver_watch_list_duration_seconds_{sum,count} already kept
+          #        (only its _bucket is in the first drop rule).
+          # Recording rules are unnecessary: the useful counters are separable
+          # from the expensive buckets.
           - action: drop
             sourceLabels: [__name__]
-            regex: (apiserver_request_sli_duration_seconds|apiserver_response_sizes|apiserver_watch_events_sizes|etcd_request_duration_seconds|apiserver_admission_controller_admission_duration_seconds|apiserver_admission_step_admission_duration_seconds|apiserver_admission_webhook_admission_duration_seconds)_(sum|count)|apiserver_watch_events_total|apiserver_watch_cache_.*|apiserver_storage_list_.*|apiserver_cache_list_.*|apiserver_longrunning_requests|apiextensions_openapi_v3?_regeneration_count|etcd_requests_total|etcd_bookmark_total|watch_cache_capacity
+            regex: (apiserver_request_sli_duration_seconds|apiserver_response_sizes|apiserver_watch_events_sizes|etcd_request_duration_seconds|apiserver_admission_controller_admission_duration_seconds|apiserver_admission_step_admission_duration_seconds|apiserver_admission_webhook_admission_duration_seconds)_(sum|count)|apiserver_watch_events_total|apiextensions_openapi_v3?_regeneration_count|etcd_requests_total|etcd_bookmark_total
 
     kubelet:
       serviceMonitor:


### PR DESCRIPTION
## Summary

The second `kubeApiServer` metricRelabel drop blanketed `apiserver_cache_list_*`, `apiserver_storage_list_*`, `apiserver_watch_cache_*`, `apiserver_longrunning_requests`, and `watch_cache_capacity` after the histogram-bucket Prometheus-agent OOM. Those families are the signal that made the St Petersburg LIST storm in corp/bhaiya#700 attributable from raw `/metrics`, but Mimir never saw them.

**Useful counters are separable from the expensive buckets.** This PR restores the resource-keyed LIST/watch-cache families and keeps dropping `_bucket`.

## Added series count (safety number)

Measured from live apiserver `/metrics` (2026-09-07), **per endpoint**:

| Set | StP orin-0 | Ottawa CP sample |
| --- | ---: | ---: |
| **Restored by this PR** | **≈ 3840** | **≈ 4476** |
| Watch latency `_bucket` still dropped | ≈ 12311 | ≈ 14289 |
| `apiserver_request_total` (already kept) | ≈ 1801 | ≈ 2241 |

≈ 4k series/endpoint is ~1% of the ~470k histogram-bucket class that OOMed the agent. No recording rule needed.

`apiserver_request_total` stays as-is (verb/resource/code/scope). On v1.36 it has **no username/client label**, so SA attribution still needs audit logs; this change gives continuous **resource**-level LIST pressure in Mimir (`rate(apiserver_cache_list_total[5m])` by `resource`).

## Validation

- `yq` parse OK; `git diff --check` OK
- `./tools/check.sh --quick` and `talos-ottawa` hit **pre-existing** local render flakes (missing agent-sandbox kustomization; kube-prometheus-stack OCIRepository “dependency not found”) — same class noted on km#2634; YAML change itself is comment + regex narrowing only

## Test plan

- [ ] After Flux reconciles kube-prometheus-stack, confirm Mimir has `apiserver_cache_list_total` / `apiserver_cache_list_fetched_objects_total` for `job="apiserver"`
- [ ] Confirm agent RSS stays near current filtered steady state (buckets still dropped)
- [ ] Chart StP `rate(apiserver_cache_list_total{resource=~"pods|daemonsets|garagenodes|garageclusters"}[5m])` for #700 follow-up

Findings: `/workspace/agent-briefs/out/watchcache2-FINDINGS.md`