### PR TITLE
docs(auth): stop tinyauth.env contradicting itself about the OAuth whitelist

### DIFF
--- a/kubernetes/apps/base/auth/README.md
+++ b/kubernetes/apps/base/auth/README.md
@@ -38,11 +38,23 @@ dashboards) and `teaspoon/securitypolicy.yaml`.
 
 ## onboarding a new user
 
-Add their google email to the `authorization` allow-list of each route they
-should reach. Tinyauth accepts valid Google identities; route-level Envoy
-authorization is the application access boundary.
+Two gates, in order:
 
-Removing a user means removing them from the relevant route allow-lists.
+1. **TinyAuth authN** — add their Google email to `TINYAUTH_OAUTH_WHITELIST` in
+   `tinyauth/tinyauth.env` (and `tinyauth-killinit/tinyauth.env` if they need
+   `*.killinit.cc`). Without this, Google login never yields a session and no
+   downstream app ever sees `Remote-Email`. This is a GitOps commit.
+2. **Per-app authZ** — then grant them the app:
+   - most routes: add the email to that route's SecurityPolicy `Remote-Email`
+     allow-list;
+   - Bhaiya: invite via the Bhaiya admin / workspace collaborators UI (Bhaiya
+     does authZ in-process; a Bhaiya invite is not Google sign-in);
+   - Audiobookshelf: whitelist alone is enough (no SecurityPolicy; ABS
+     auto-registers — see `docs/adr/0002-reading-stack-access-model.md`).
+
+Removing a user means removing them from the whitelist (blocks new logins) and
+from the relevant route allow-lists / app accounts (see ADR 0002 for credential
+revocation caveats).
 
 ## applications that trust identity headers
 

--- a/kubernetes/apps/base/auth/tinyauth/tinyauth.env
+++ b/kubernetes/apps/base/auth/tinyauth/tinyauth.env
@@ -35,11 +35,18 @@ TINYAUTH_UI_BACKGROUNDIMAGE=/resources/background.svg
 # redirect to is an https *.keiretsu.top subdomain (already validated against
 # the cookie domain), so the warnings are just friction in the login flow.
 TINYAUTH_UI_WARNINGSENABLED=false
-# authN gate: tinyauth lets any valid Google account authenticate. Per-app
-# authZ (who may use bhaiya, role=admin/member) lives in bhaiya's own users
-# table, managed via the bhaiya admin UI — no manifest edits needed to invite
-# people. Each app that needs per-user gating has its own SecurityPolicy with
-# extAuth pointing here; bhaiya does its own authorization in-process.
+# Layers (do not confuse them):
+#   1. TINYAUTH_OAUTH_WHITELIST above is the shared authN gate. Only listed
+#      Google accounts get a session / OIDC token. Inviting someone to Bhaiya
+#      (or any app) is NOT enough — add their email here too, or OAuth never
+#      completes and they never present Remote-Email downstream.
+#   2. Per-app authZ is separate: Bhaiya checks its users table / workspace
+#      allowed_emails in-process; most other routes use an Envoy SecurityPolicy
+#      Remote-Email allow-list. Those layers never run for a non-whitelisted
+#      Google account.
+#   3. Some apps (notably Audiobookshelf) have NO SecurityPolicy and rely on
+#      this whitelist as their only authN gate — see adr/0002. Do not remove
+#      the whitelist casually; that is a platform access-policy change.
 # OIDC server mode — acts as an identity provider for downstream apps (e.g. Forgejo)
 # Keys are stored on the persistent volume (/data) — auto-created on first start
 TINYAUTH_OIDC_PRIVATEKEYPATH=/data/oidc/private.pem


### PR DESCRIPTION
`tinyauth.env` contradicted itself, and the false half is exactly the sentence someone would act on.

One comment correctly explains that `TINYAUTH_OAUTH_WHITELIST` means only listed emails get a session. A later comment in the **same file** claims "tinyauth lets any valid Google account authenticate … no manifest edits needed to invite people."

That second claim is false, and it is the one that reads like an instruction. It is how the next person concludes a Bhaiya workspace invite is sufficient and then cannot explain why the invitee is bounced at Google login.

Comments and README only — **no behaviour change, and the whitelist itself is untouched.**

## The two gates, for the record

- **AuthN**, before Bhaiya ever sees the user: `TINYAUTH_OAUTH_WHITELIST`. A collaborator not on that list fails at Google login, never receives a session cookie, and therefore never presents `Remote-Email`.
- **AuthZ**, only reached after authN succeeds: the workspace SecurityPolicy allow-lists `Remote-Email` for owner + `allowed_emails`. That gate never runs for someone rejected upstream.

## On whether the whitelist should exist at all

**Keep it for now.** Bhaiya does its own per-workspace authorization on `Remote-Email`, so the whitelist is arguably redundant *for Bhaiya* — but it is not Bhaiya-only. Other consumers sit behind the same tinyauth, and removing it would silently widen access for those before they have been re-gated deliberately.

Any change to whitelist membership or its existence is an access decision, not a docs cleanup, and should be its own ticket.

## Closes out corp/bhaiya#568

The Bhaiya half landed in #675 — create and settings copy now say plainly that an invite grants workspace access but **not** Google sign-in, and names the allowlist as a separate operator step, with tests pinning that wording. This is the manifests half. Between them, the product no longer lies about what an invite does, and neither does the config.

`tools/check.sh` renders OK for all three clusters.
