### PR TITLE
fix(velero): actually include media config volumes under opt-in mode

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1014,8 +1014,11 @@ Schedules, all TTL 168h:
 | Robbinsdale | `home` 09:00 · `media-config` 06:00 (config only) |
 | St. Petersburg | `home-assistant` 09:00 |
 
-`media-config` deliberately sets `defaultVolumesToFsBackup: false` — the bulk
-data lives on Ceph/SMB and relies on storage-layer durability.
+`media-config` deliberately sets `defaultVolumesToFsBackup: false` (opt-IN) so
+the bulk Ceph/SMB media shares are never selected. App pods must set
+`backup.velero.io/backup-volumes` to their config volume (`config` /
+`config-volume` / `backup`); `backup-volumes-excludes` alone does not opt
+anything in. Postgres in `media` is covered by CNPG/Barman, not this schedule.
 
 ### CloudNativePG
 

--- a/kubernetes/apps/base/media/media-ottawa/audiobookshelf/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/audiobookshelf/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: audiobookshelf

--- a/kubernetes/apps/base/media/media-ottawa/autobrr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/autobrr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: autobrr

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-1080p/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-1080p

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-4k/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-4k

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-4kremux/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-4kremux/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-4kremux

--- a/kubernetes/apps/base/media/media-ottawa/bazarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bazarr-anime/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-anime

--- a/kubernetes/apps/base/media/media-ottawa/bookorbit/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/bookorbit/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bookorbit

--- a/kubernetes/apps/base/media/media-ottawa/kometa/cronjob.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/kometa/cronjob.yaml
@@ -10,6 +10,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            # media-config-backup uses opt-in fs-backup; include the config PVC.
+            backup.velero.io/backup-volumes: config
         spec:
           initContainers:
             - name: download-fonts

--- a/kubernetes/apps/base/media/media-ottawa/komga/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/komga/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: komga

--- a/kubernetes/apps/base/media/media-ottawa/lidarr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/lidarr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: lidarr

--- a/kubernetes/apps/base/media/media-ottawa/maintainerr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/maintainerr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: config
       labels:
         app: maintainerr
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/omnibus/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/omnibus/app.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: omnibus

--- a/kubernetes/apps/base/media/media-ottawa/overseerr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/overseerr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: overseerr

--- a/kubernetes/apps/base/media/media-ottawa/plex/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/plex/app.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media-volume
       labels:
         app: plex

--- a/kubernetes/apps/base/media/media-ottawa/prowlarr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/prowlarr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: prowlarr

--- a/kubernetes/apps/base/media/media-ottawa/qb-pvt/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/qb-pvt/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config-volume
         backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: qbittorrent-pvt

--- a/kubernetes/apps/base/media/media-ottawa/qb/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/qb/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config-volume
         backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: qbittorrent

--- a/kubernetes/apps/base/media/media-ottawa/radarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-1080p/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-1080p

--- a/kubernetes/apps/base/media/media-ottawa/radarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-4k/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-4k

--- a/kubernetes/apps/base/media/media-ottawa/radarr-4kremux/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-4kremux/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-4kremux

--- a/kubernetes/apps/base/media/media-ottawa/radarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/radarr-anime/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-anime

--- a/kubernetes/apps/base/media/media-ottawa/sabnzbd/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sabnzbd/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sabnzbd

--- a/kubernetes/apps/base/media/media-ottawa/shelfmark/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/shelfmark/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: shelfmark

--- a/kubernetes/apps/base/media/media-ottawa/sonarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sonarr-1080p/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-1080p

--- a/kubernetes/apps/base/media/media-ottawa/sonarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sonarr-4k/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-4k

--- a/kubernetes/apps/base/media/media-ottawa/sonarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/sonarr-anime/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-anime

--- a/kubernetes/apps/base/media/media-ottawa/suwayomi/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/suwayomi/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: suwayomi

--- a/kubernetes/apps/base/media/media-ottawa/tautulli/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/tautulli/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: tautulli

--- a/kubernetes/apps/base/media/media-ottawa/tracearr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/tracearr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: backup
       labels:
         app: tracearr
     spec:

--- a/kubernetes/apps/base/media/media-ottawa/wizarr/app.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/wizarr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: wizarr

--- a/kubernetes/apps/base/media/media-robbinsdale/autobrr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/autobrr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: autobrr

--- a/kubernetes/apps/base/media/media-robbinsdale/bazarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/bazarr-1080p/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-1080p

--- a/kubernetes/apps/base/media/media-robbinsdale/bazarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/bazarr-4k/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-4k

--- a/kubernetes/apps/base/media/media-robbinsdale/bazarr-4kremux/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/bazarr-4kremux/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-4kremux

--- a/kubernetes/apps/base/media/media-robbinsdale/bazarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/bazarr-anime/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: bazarr-anime

--- a/kubernetes/apps/base/media/media-robbinsdale/kometa/cronjob.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/kometa/cronjob.yaml
@@ -10,6 +10,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            # media-config-backup uses opt-in fs-backup; include the config PVC.
+            backup.velero.io/backup-volumes: config
         spec:
           initContainers:
             - name: download-fonts

--- a/kubernetes/apps/base/media/media-robbinsdale/lidarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/lidarr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: lidarr

--- a/kubernetes/apps/base/media/media-robbinsdale/maintainerr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/maintainerr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: config
       labels:
         app: maintainerr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/overseerr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/overseerr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: overseerr

--- a/kubernetes/apps/base/media/media-robbinsdale/plex/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/plex/app.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media-volume
       labels:
         app: plex

--- a/kubernetes/apps/base/media/media-robbinsdale/prowlarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/prowlarr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: prowlarr

--- a/kubernetes/apps/base/media/media-robbinsdale/qb-pvt/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/qb-pvt/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config-volume
         backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: qbittorrent-pvt

--- a/kubernetes/apps/base/media/media-robbinsdale/qb/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/qb/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config-volume
         backup.velero.io/backup-volumes-excludes: downloads-volume
       labels:
         app: qbittorrent

--- a/kubernetes/apps/base/media/media-robbinsdale/radarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/radarr-1080p/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-1080p

--- a/kubernetes/apps/base/media/media-robbinsdale/radarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/radarr-4k/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-4k

--- a/kubernetes/apps/base/media/media-robbinsdale/radarr-4kremux/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/radarr-4kremux/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-4kremux

--- a/kubernetes/apps/base/media/media-robbinsdale/radarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/radarr-anime/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: radarr-anime

--- a/kubernetes/apps/base/media/media-robbinsdale/sabnzbd/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/sabnzbd/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sabnzbd

--- a/kubernetes/apps/base/media/media-robbinsdale/sonarr-1080p/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/sonarr-1080p/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-1080p

--- a/kubernetes/apps/base/media/media-robbinsdale/sonarr-4k/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/sonarr-4k/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-4k

--- a/kubernetes/apps/base/media/media-robbinsdale/sonarr-anime/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/sonarr-anime/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: sonarr-anime

--- a/kubernetes/apps/base/media/media-robbinsdale/tautulli/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/tautulli/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: tautulli

--- a/kubernetes/apps/base/media/media-robbinsdale/tracearr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/tracearr/app.yaml
@@ -12,6 +12,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: backup
       labels:
         app: tracearr
     spec:

--- a/kubernetes/apps/base/media/media-robbinsdale/wizarr/app.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/wizarr/app.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        backup.velero.io/backup-volumes: config
         backup.velero.io/backup-volumes-excludes: media
       labels:
         app: wizarr

--- a/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
@@ -1,4 +1,8 @@
 ---
+# First successful run must capture gitea-shared-storage (pod volume `data`)
+# plus forgejo-postgres-*/pgdata. emptyDir scratch volumes are skipped by
+# fs-backup-resource-policy. Schedule is daily 10:00 UTC; if lastBackup is
+# empty the cron has not fired yet — that is not a capture failure.
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:

--- a/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
@@ -1,4 +1,13 @@
 ---
+# Back up media *app config* PVCs only. Bulk media/downloads live on Ceph/SMB
+# and rely on storage-layer durability — never opt those volumes in.
+#
+# IMPORTANT: defaultVolumesToFsBackup is false (opt-IN). Pods must set
+# backup.velero.io/backup-volumes to the config volume name (usually `config`
+# or `config-volume`). backup-volumes-excludes alone does NOT include anything
+# under opt-in mode; that mismatch previously left every config PVC with
+# schedule membership and zero PodVolumeBackups while the Backup still
+# reported Completed.
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:

--- a/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
@@ -1,4 +1,13 @@
 ---
+# Back up media *app config* PVCs only. Bulk media/downloads live on Ceph/SMB
+# and rely on storage-layer durability — never opt those volumes in.
+#
+# IMPORTANT: defaultVolumesToFsBackup is false (opt-IN). Pods must set
+# backup.velero.io/backup-volumes to the config volume name (usually `config`
+# or `config-volume`). backup-volumes-excludes alone does NOT include anything
+# under opt-in mode; that mismatch previously left every config PVC with
+# schedule membership and zero PodVolumeBackups while the Backup still
+# reported Completed.
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:


### PR DESCRIPTION
Two findings from corp/bhaiya#703. One is reassuring; the other is a real gap that dozens of PVCs were sitting in.

## Forgejo git data is fine — the audit row was a false alarm

`forgejo-backup` showed "Enabled, zero PVBs", which read as a capture failure. It is not: **the cron has not fired yet.** The schedule is `0 10 * * *` and was created at 2026-09-06T22:26Z — *after* that day's slot — so the first run is at 10:00Z.

Verified the first run will capture the right thing rather than assuming it:

| Pod | Volume | PVC | Under `fs=true` + emptyDir policy |
|---|---|---|---|
| `forgejo-*` | **`data`** | **`gitea-shared-storage`** (the repositories) | **Selected** |
| `forgejo-postgres-{1,2}` | `pgdata` | `forgejo-postgres-{1,2}` | Selected (also covered by CNPG) |
| both | `temp` / `scratch-data` / `shm` / `plugins` | emptyDir | Skipped by VolumePolicies |

No `backup.velero.io` annotations on the Forgejo pod, so opt-out mode takes all eligible volumes. **No manifest bug would omit the git data.** Added a comment on the schedule recording the expected volumes and that an empty `lastBackup` means "not due yet" — that ambiguity is what made this look alarming.

Deliberately did **not** force a one-shot Backup; that would mutate cluster backup state outside GitOps. Acceptance is simply the 10:00Z run.

## Media config: the intent was right, the wiring was not

`docs/reference/architecture.md` already stated the goal — *"media-config … 06:00 (config only), deliberately sets `defaultVolumesToFsBackup: false` — bulk data on Ceph/SMB"*. So backing up config PVCs **is** wanted and excluding the bulk shares **is** wanted. Intent was established before touching anything.

**The bug is that opt-in mode was only half-wired.** Under `defaultVolumesToFsBackup: false`:

- volumes in `backup.velero.io/backup-volumes` are backed up
- `backup-volumes-excludes` **alone does nothing useful** — "not excluded" is not "included"

Pods carried `backup-volumes-excludes: media` and **no** `backup-volumes`. Net result: schedule membership, Completed metadata-only Backups, and **zero media-config PVBs, ever** — confirmed against a live Ottawa dump.

That is the fourth distinct route to a green Backup that captured nothing, after the hostPath skip (#695), WAL-without-a-base, and a base backup on an abandoned store.

## Fix

Added `backup.velero.io/backup-volumes` naming the config volume on **every** Ottawa and Robbinsdale media app that mounts a config PVC — including maintainerr, tracearr and the kometa CronJobs. 54 files; zero remaining config PVCs without an include.

Excludes are **left in place** so that an accidental future flip to opt-out still skips the bulk shares. Comments on both `media-config-backup` schedules now state the opt-in contract explicitly, and the architecture blurb no longer implies excludes alone achieve "config only".

After Flux rolls the pods, the next `0 6 * * *` run should produce Completed PVBs for config volumes and still none for the media shares.

`tools/check.sh` renders OK for all three clusters.
