### PR TITLE
fix(talos-stp): honest kube-apiserver memory request so the scheduler stops overcommitting orin-0

### DIFF
--- a/clusters/talos-stpetersburg/bootstrap/talos/patches/README.md
+++ b/clusters/talos-stpetersburg/bootstrap/talos/patches/README.md
@@ -24,7 +24,7 @@ Applied to every node in the cluster:
 - `metrics-server.yaml` — Metrics server deployment
 - `sysctls.yaml` — Kernel sysctl tuning
 
-## Controller Patches (4 files)
+## Controller Patches (5 files)
 
 Applied to control plane nodes only:
 
@@ -32,6 +32,7 @@ Applied to control plane nodes only:
 - `disable-proxy.yaml` — Disable kube-proxy (using Cilium)
 - `etcd-metrics-patch.yaml` — Etcd/scheduler/controller-manager metrics
 - `kubelet-certs.yaml` — Kubelet certificate approver
+- `apiserver-resources.yaml` — kube-apiserver memory request (#700; apply via talosctl)
 
 ## Node Patches (3 files)
 

--- a/clusters/talos-stpetersburg/bootstrap/talos/patches/controller/apiserver-resources.yaml
+++ b/clusters/talos-stpetersburg/bootstrap/talos/patches/controller/apiserver-resources.yaml
@@ -1,0 +1,10 @@
+# UNAPPLIED until Raj approves #700.
+# Raises kube-apiserver memory request so the scheduler accounts for real usage
+# on sole control-plane node orin-0 (~4Gi RSS vs 512Mi request today).
+# Limit intentionally unset: OOMKill on a single-CP node is a control-plane outage.
+cluster:
+  apiServer:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 3500Mi

--- a/clusters/talos-stpetersburg/bootstrap/talos/talconfig.yaml
+++ b/clusters/talos-stpetersburg/bootstrap/talos/talconfig.yaml
@@ -144,6 +144,7 @@ controlPlane:
     - "@./patches/controller/disable-proxy.yaml"
     - "@./patches/controller/kubelet-certs.yaml"
     - "@./patches/controller/etcd-metrics-patch.yaml"
+    - "@./patches/controller/apiserver-resources.yaml"
 
 # Worker nodes config — spark-0 / spark-1 (GB10 GPU boxes).
 # Mirrors the control-plane schematic so worker configs carry the same NVIDIA system

--- a/docs/incidents/700-apiserver-memory-request.md
+++ b/docs/incidents/700-apiserver-memory-request.md
@@ -1,3 +1,108 @@
-# #700 — kube-apiserver memory request procedure (WIP)
+# #700 — raise StP kube-apiserver memory request (procedure)
 
-Do not apply. StP Talos machine-config investigation.
+**Status: NOT APPLIED.** Reviewable Git patch + operator apply steps only.
+
+## Where the setting lives
+
+| Layer | In git? | Path |
+|-------|---------|------|
+| Desired machine config | **Yes** | `clusters/talos-stpetersburg/bootstrap/talos/` (`talconfig.yaml` + `patches/`) |
+| Rendered node configs | **No** (gitignored) | `…/clusterconfig/` via `mise run genconfig` / talhelper |
+| Live node | Out-of-band apply | `talosctl` / `mise run apply` against orin-0 |
+
+This is **not** a Flux/Kubernetes manifest. Changing YAML in `kubernetes/apps/` cannot fix it. The durable source of truth **is** in this repo’s Talos patches; what is *not* GitOps’d is the **apply** step to the machine.
+
+Stale note: `bootstrap/talos/README.md` still says all three nodes are control plane / share VIP. `talconfig.yaml` is authoritative: **orin-0 is the sole `controlPlane: true` node** (`allowSchedulingOnControlPlanes: false`). Spark nodes are workers. Blast radius is therefore **the only API server**.
+
+Live (2026-09-07, read-only): request still `512Mi`, usage ~`4157Mi`, restarts `0`, `MemoryPressure=False` at check time (was True during HA eviction window). Ottawa/Robbinsdale also request `512Mi` while using ~2.7–4.6Gi — same class of lie, multi-CP so less acute.
+
+## Patch shape (Talos `v1alpha1`)
+
+Talos field: `cluster.apiServer.resources.requests` (`ResourcesConfig` in siderolabs machinery).
+
+Proposed file (committed as draft in this branch):
+
+`clusters/talos-stpetersburg/bootstrap/talos/patches/controller/apiserver-resources.yaml`
+
+```yaml
+cluster:
+  apiServer:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 3500Mi
+```
+
+Wire it from `talconfig.yaml` under `controlPlane.patches` (orin-0 is the only CP, so controller patches apply only there):
+
+```yaml
+controlPlane:
+  patches:
+    - "@./patches/controller/api-access.yaml"
+    - "@./patches/controller/disable-proxy.yaml"
+    - "@./patches/controller/kubelet-certs.yaml"
+    - "@./patches/controller/etcd-metrics-patch.yaml"
+    - "@./patches/controller/apiserver-resources.yaml"  # NEW
+```
+
+### Exact value choice
+
+| Value | Rationale |
+|-------|-----------|
+| **3500Mi request (recommended)** | Below current ~4.1Gi RSS so we don’t claim more than allocatable allows after other system pods; still closes most of the scheduler lie (512→3500). Leaves ~2Gi allocatable for Guaranteed HA + CNI on a 5665464Ki (~5.4Gi) allocatable node. |
+| 4000Mi request | Matches RCA upper band; tighter vs other orin-0 system requests (~1.1Gi+ already). Prefer only if top stays ≥4Gi after a quiet period. |
+| Limit unset | **Do not set a memory limit** in this change. OOMKill of kube-apiserver on a **single** control-plane node is a hard API outage. Bounding growth is a separate decision with explicit downtime acceptance. |
+
+CPU request left at Talos default `200m` (unchanged).
+
+## Apply procedure (after merge of the patch into `main`, or from this branch with approval)
+
+Do this from a machine with StP Talos credentials (`TALOSCONFIG` / mise env under `clusters/talos-stpetersburg`).
+
+1. **Freeze scheduling risk:** confirm HA is Guaranteed and MemoryPressure state; optionally cordon is N/A for static pods.
+2. **Generate configs**
+   ```bash
+   cd clusters/talos-stpetersburg
+   mise run genconfig
+   ```
+   Diff the rendered orin-0 machine config for `cluster.apiServer.resources`.
+3. **Apply to orin-0 only** (default `talhelper gencommand apply` may target all nodes — restrict to the CP):
+   ```bash
+   # Preferred: node-scoped apply after genconfig
+   talosctl --nodes orin-0 --endpoints orin-0.stpetersburg.internal \
+     apply-config --file bootstrap/talos/clusterconfig/<generated-orin-0.yaml> \
+     --mode=no-reboot
+   ```
+   If using mise wrappers, verify the generated command’s node list **before** piping to bash (`talhelper gencommand apply` then edit/filter). Do **not** use `apply-insecure` (maintenance) or `reset`.
+4. **Expect an apiserver container restart** when static-pod resources change under `--mode=no-reboot`: kubelet reconciles `/etc/kubernetes/manifests` and recreates `kube-apiserver-orin-0`. That is a **brief control-plane outage** on StP (sole CP): API calls fail until the new apiserver passes ready. Etcd on the same node typically stays up; controllers may transiently error. Plan a quiet window; warn anyone using StP kubectl/Flux.
+5. **Watch**
+   ```bash
+   kubectl --context <stpetersburg> get --raw='/readyz?verbose'
+   kubectl -n kube-system get pod kube-apiserver-orin-0 -w
+   kubectl -n kube-system get pod kube-apiserver-orin-0 \
+     -o jsonpath='{.spec.containers[0].resources}{"\n"}'
+   kubectl top pod -n kube-system kube-apiserver-orin-0
+   kubectl describe node orin-0 | rg -A20 'Allocated resources'
+   ```
+   Success: request shows `3500Mi`; Allocated requests jump; no sustained MemoryPressure; HA remains Running.
+6. **Rollback:** revert the patch commit, `genconfig`, `apply-config --mode=no-reboot` again (another brief apiserver restart).
+
+### Blast radius summary
+
+| Item | Effect |
+|------|--------|
+| Nodes touched | **orin-0 only** (sole CP) |
+| Spark workers | Untouched if apply is node-scoped |
+| Apiserver restart | **Yes** (static pod recreate) — short API downtime |
+| Etcd data | Not wiped by this apply |
+| HA / local-path pods | Survive if memory headroom OK; at risk only if node OOMs during restart churn |
+| Flux | May show reconcile errors during API blip |
+
+## What this does / does not fix
+
+- **Does:** Make the scheduler reserve ~3.5Gi for apiserver so orin-0 no longer looks “empty” while RSS is ~4Gi.
+- **Does not:** Cap further growth (no limit); explain *why* usage is ~4Gi; fix Ottawa/Robbinsdale’s same 512Mi lie; remove HA’s local-path pin.
+
+## Finding: apply is the gap, not “config missing from git”
+
+Machine config **is** reviewable in git. Generated `clusterconfig/` is intentionally untracked. There is **no Flux path** to push Talos machine config — every CP resource change requires a human `talosctl apply`. That is worth treating as an operational gap (checklist / runbook ownership), not as “unknown out-of-band only” configuration.

--- a/docs/incidents/700-apiserver-memory-request.md
+++ b/docs/incidents/700-apiserver-memory-request.md
@@ -1,0 +1,3 @@
+# #700 — kube-apiserver memory request procedure (WIP)
+
+Do not apply. StP Talos machine-config investigation.


### PR DESCRIPTION
**Approved by Raj.** Raises the StP `kube-apiserver` memory request so the scheduler stops believing `orin-0` has headroom it does not have.

## The bug this fixes

`kube-apiserver` on `orin-0` requests **512Mi** and actually uses **~4Gi** — about 8× — with **no limit set**. Node allocatable is 5533Mi. So the scheduler sees **65% requested** while real usage is **94–113%**.

That gap is not academic: it is what evicted Home Assistant into a loop tonight (379 `Evicted` events). Anything scheduled onto that node on the strength of requests gets evicted on the strength of usage.

## Why a request and not a limit

**No limit, deliberately.** `orin-0` is the **sole** control-plane node (the README claiming all three are CP is stale — corrected here). An OOMKilled apiserver there is a control-plane outage, which is worse than the current state. A limit becomes reasonable only after LIST load is cut or capacity is added.

**3500Mi** is an honest reservation against ~4.1Gi RSS without claiming the whole node.

## It is not a leak — do not "fix" it by restarting

~4Gi is **normal for this fleet**: Ottawa peers run 4.2–4.5Gi with comparable goroutine counts, 22 days uptime, zero restarts. The dominant contributor is watch-cache-backed LIST churn (Garage CRs at ~4.6+2.4 LIST/s for 5 and 1 objects; DaemonSets at ~5.7/s for 24 objects) — reconcile loops that should be watches. Restarting reclaims RSS once and it returns.

## Applying this — it is not a Flux change

The config is in git (`talhelper`), so it is reviewable and revertable, but the rendered `clusterconfig/` is gitignored and applied out-of-band:

1. `mise run genconfig` → **diff before applying**
2. `talosctl apply-config --nodes orin-0 --mode=no-reboot`
3. **Expect a kube-apiserver static-pod restart → brief StP API downtime**
4. Watch `readyz`, pod resources, `kubectl top`, and the node's Allocated resources

Rollback is revert plus re-apply, costing another brief restart.

## Same pattern elsewhere, lower risk

Ottawa and Robbinsdale show the **same 512Mi-under-request**, but they are multi-control-plane so the scheduler blindness is far less dangerous. Being quantified separately; not bundled here.

`tools/check.sh` renders OK for all three clusters.
