### PR TITLE
fix(ottawa): public Envoy externalTrafficPolicy Cluster (#677)

### DIFF
--- a/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
@@ -69,4 +69,12 @@ spec:
                 matchLabels:
                   gateway.envoyproxy.io/owning-gateway-name: public
       envoyService:
+        # Cluster (not Local): UniFi ECMP advertises 10.169.10.15/32 from both
+        # rei and kaji. With Local, a mid-flow hash flip lands packets on a node
+        # with no established tuple and that node RSTs (#661/#677). Cluster lets
+        # either node forward to either Envoy backend. Trade-off: backends see
+        # the node IP (SNAT), not the real client — observability only; authZ is
+        # Remote-Email / SSH key (see docs/incidents/677-*). Private and ts
+        # gateways stay Local.
+        externalTrafficPolicy: Cluster
         loadBalancerIP: ${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.10.15


### PR DESCRIPTION
## Summary

Implements **#677 option 3** for the **public** Envoy gateway only:

- `kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml`: set `envoyService.externalTrafficPolicy: Cluster`
- **Private** and **ts** EnvoyProxies are unchanged (Tailscale SSH hop stays Local)

### Why

UniFi ECMP advertises `10.169.10.15/32` from both rei and kaji. With `Local`, each node's frontend only has the local Envoy backend, so a mid-flow hash flip can RST. `Cluster` lets either node forward to either backend.

### Observability we lose (accepted)

- Envoy `downstream_remote_address` on public listeners becomes the **node IP** (SNAT), not the residential client IP
- HTTP `ClientTrafficPolicy` XFF / clientIPDetection for Gateways using this Service similarly see the node IP
- AuthZ is unaffected: SecurityPolicies use `Remote-Email`; SSH uses key fingerprints; UniFi/CF/fail2ban audit found no IP ban consumer on this path

### Acceptance test (required after merge/roll)

Re-run the #661 public-vs-Tailscale A/B on the **public** hop. Sustained high-volume sessions must be measured again. This change removes a fitting mechanism; **it is not proof until measured**.

### Verification already done

- `tools/check.sh` → `✓ render OK: talos-ottawa talos-robbinsdale talos-stpetersburg`
- Server-side dry-run: `envoyproxy.gateway.envoyproxy.io/public` **serverside-applied (server dry run)** OK
- Direct Service dry-run conflicts with `envoy-gateway` manager as expected — EG will reconcile the Service from the EnvoyProxy field

### Do not merge without review

Public ingress change.