### PR TITLE
fix(stpetersburg): right-size kube-apiserver memory request to 2400Mi

### DIFF
--- a/clusters/talos-stpetersburg/bootstrap/talos/patches/controller/apiserver-resources.yaml
+++ b/clusters/talos-stpetersburg/bootstrap/talos/patches/controller/apiserver-resources.yaml
@@ -1,10 +1,15 @@
-# UNAPPLIED until Raj approves #700.
+# Applied to orin-0 2026-09-07 (issue #700).
 # Raises kube-apiserver memory request so the scheduler accounts for real usage
-# on sole control-plane node orin-0 (~4Gi RSS vs 512Mi request today).
-# Limit intentionally unset: OOMKill on a single-CP node is a control-plane outage.
+# on sole control-plane node orin-0. Limit intentionally unset: OOMKill on a
+# single-CP node is a control-plane outage.
+#
+# 3500Mi was too high. orin-0 has only ~5532Mi allocatable, so a 3500Mi request
+# consumed 63% of the node and left 94Mi free, which made homeassistant-0
+# (1Gi + 32Mi, pinned to orin-0 by a local-path PVC) unschedulable and took
+# HomeKit down. Right-sized to observed usage (~2043Mi) plus headroom.
 cluster:
   apiServer:
     resources:
       requests:
         cpu: 200m
-        memory: 3500Mi
+        memory: 2400Mi


### PR DESCRIPTION
## P0 — HomeKit down

`homeassistant-0` has been `Pending` on orin-0 for 20+ minutes with insufficient memory. This is fallout from the #700 fix I applied earlier today.

## What happened

I set the apiserver memory request to **3500Mi** to make the scheduler account for its real usage. That number was too high for this node:

| | |
| --- | --- |
| orin-0 allocatable | 5532Mi |
| allocated requests | 5438Mi (98%) |
| **free** | **94Mi** |
| apiserver request | 3500Mi |
| apiserver *actual* usage | **2043Mi** |
| homeassistant-0 needs | 1024Mi + 32Mi = 1056Mi |

So the request over-reserved ~1.5Gi it never uses, and HA — which is pinned to orin-0 by a `local-path` PVC and therefore cannot reschedule to a spark node — had nowhere to fit. `MemoryPressure` stayed `False` and actual available memory was ~3.5Gi the whole time; this was purely a *request-accounting* starvation, which is exactly the mechanism #700 set out to fix, overcorrected.

## Change

`memory: 3500Mi` → `memory: 2400Mi`, freeing 1100Mi.

Sizing rationale, deliberately not just "enough to fit HA":

- 2400Mi sits **357Mi above observed usage** (2043Mi), so the scheduler still sees the apiserver honestly.
- It leaves HA **138Mi of margin** after its 1056Mi request, rather than the 38Mi that a 2500Mi request would have left. A margin that thin would be re-broken by the next small pod.
- The limit stays unset on purpose — an OOMKill on a single-control-plane node is a control-plane outage.

## Delivery

Talos machine config is not reconciled by Flux, so this lands via `talosctl patch machineconfig --mode=no-reboot --patch-file` against the live node, gated on `--dry-run` showing only this change. No `kubectl apply`.

## Follow-up worth considering separately

orin-0 is a 3-node cluster's only control-plane node, with ~5.5Gi allocatable, hosting a pinned stateful workload. The headroom here is thin enough that request changes are load-bearing. Not fixing that in a P0.
