### PR TITLE
fix(stpetersburg): reclaim orin-0 schedulable memory headroom

### DIFF
--- a/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
+++ b/clusters/talos-stpetersburg/flux/vars/cluster-settings.yaml
@@ -115,7 +115,7 @@ data:
             }
           ],
           "resources": {
-            "requests": {"cpu": "100m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "64Mi"},
             "limits": {"cpu": "3000m", "memory": "3Gi"}
           }
         }

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
@@ -32,9 +32,11 @@ spec:
       containers:
         - name: kube-multus
           resources:
+            # orin-0 usage ~28Mi; 200Mi request was pure schedulable waste on the
+            # sole control-plane node that also pins Home Assistant.
             requests:
-              cpu: "200m"
-              memory: "200Mi"
+              cpu: "50m"
+              memory: "64Mi"
             limits:
               cpu: "1000m"
               memory: "3000Mi"

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
@@ -49,3 +49,40 @@ groups:
             distinguishes host-level memory pressure from a Kata sandbox
             teardown; correlate it with the affected pod's termination reason
             and node memory metrics.
+
+      # Schedulable memory headroom, not RSS. orin-0 (StP sole control-plane)
+      # ran HomeKit Pending when requests filled the node while MemoryPressure
+      # stayed False (2026-09-07). Fire before the next Guaranteed pod cannot
+      # schedule — especially workloads pinned by local-path PVCs.
+      - alert: NodeSchedulableMemoryHeadroomLow
+        expr: |
+          (
+            sum by (cluster, node) (
+              kube_node_status_allocatable{resource="memory"}
+            )
+            -
+            sum by (cluster, node) (
+              kube_pod_container_resource_requests{resource="memory"}
+              * on (cluster, namespace, pod) group_left()
+              (kube_pod_status_phase{phase="Running"} == 1)
+            )
+          )
+          /
+          sum by (cluster, node) (
+            kube_node_status_allocatable{resource="memory"}
+          )
+          < 0.08
+          and on (cluster, node)
+          kube_node_status_condition{condition="Ready",status="true"} == 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Node {{ $labels.node }} has less than 8% schedulable memory headroom
+          description: >-
+            Free schedulable memory (allocatable minus Running pod requests) is
+            under 8% while the node is Ready. New pods and request increases
+            fail with Insufficient memory even when MemoryPressure is False.
+            StP orin-0 hit this on 2026-09-07 and parked homeassistant-0
+            (local-path PVC). Trim over-requests or free capacity before the
+            next control-plane change.

--- a/kubernetes/apps/base/velero/velero/helmrelease.yaml
+++ b/kubernetes/apps/base/velero/velero/helmrelease.yaml
@@ -79,9 +79,12 @@ spec:
       extraArgs:
         - --node-agent-configmap=node-agent-config
       resources:
+        # Observed RSS on StP/Ottawa node-agents is ~38–66Mi. 256Mi left orin-0
+        # with ~30Mi schedulable headroom after the apiserver right-size; 96Mi
+        # keeps a buffer for backup spikes without starving Home Assistant.
         requests:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 100m
+          memory: 96Mi
         limits:
           cpu: 1
           memory: 1Gi


### PR DESCRIPTION
## Context

After kube-apiserver → 2400Mi on sole CP node **orin-0**, allocatable requests sat at **~5502/5532Mi (~30Mi free)** while MemoryPressure stayed False. Home Assistant is pinned by `local-path` + `nodeSelector: orin-0`; the next request bump or Guaranteed pod will Pending again.

## Recommendation

1. **Trim over-requests now** (this PR) — largest safe GitOps win without moving HA.
2. **Alert on schedulable headroom** (this PR) — fires before Pending, unlike MemoryPressure.
3. **Move HA off local-path later** — needs LAN macvlan + PVC migration; not in this change.

### Request vs usage (orin-0)

| Workload | Was request | Usage | Now |
| --- | ---: | ---: | ---: |
| garage orin pool | 256Mi | ~6Mi | **64Mi** |
| velero node-agent | 256Mi | ~38–66Mi | **96Mi** |
| StP multus | 200Mi | ~28Mi | **64Mi** |

Expected reclaim ≈ **500Mi+** schedulable headroom.

## Alert

`NodeSchedulableMemoryHeadroomLow`: Running-pod memory requests leave &lt;8% of allocatable for 15m on a Ready node.

## Limits

No prod apply. Do not merge until reviewed.