### PR TITLE
fix(velero): page silent empty backups and bootstrap Forgejo git data

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -4,9 +4,14 @@
 # phase of an individual Backup (a real Failed Backup kept last_status=1).
 #
 # #572 acceptance (Failed/PartiallyFailed latest Backup, Failed/Canceled PVB,
-# bytesDone!=totalBytes) is covered by the rules below after #2743. The
-# warnings gauge + VeleroScheduleLatestBackupHasWarnings close the #695 gap
-# (Completed Backup that silently skipped a durable hostPath volume).
+# bytesDone!=totalBytes) is covered by the rules below after #2743.
+#
+# Silent-skip / green-empty coverage (corp/bhaiya#695, #703):
+# - VeleroScheduleLatestBackupHasWarnings: hostPath skips leave phase=Completed
+#   with status.warnings>0 (StP homeassistant-config).
+# - VeleroScheduleLatestBackupMissingVolumes: Completed latest Backup with zero
+#   PodVolumeBackup children (metadata-only / unmounted PVC / opt-in miss).
+# Both join on the newest Backup per schedule so they clear on recovery.
 #
 # Keep this namespace separate from rules/velero.yaml. Both files are synced by
 # the same mimirtool Job and a repeated namespace aborts every tenant sync.
@@ -129,7 +134,8 @@ groups:
       # Completed + warnings is how Velero reports hostPath volume skips while
       # still leaving phase=Completed (StP home-assistant-config / #695). Bound
       # to the newest Backup per schedule so a later clean run clears the alert;
-      # do not match historical warning-bearing objects.
+      # do not match historical warning-bearing objects. Critical: a "Completed"
+      # Backup with warnings is the dangerous signal, not a soft FYI.
       - alert: VeleroScheduleLatestBackupHasWarnings
         expr: |
           (
@@ -156,16 +162,70 @@ groups:
           )
         for: 5m
         labels:
-          severity: warning
+          severity: critical
         annotations:
-          summary: Velero schedule {{ $labels.schedule }} latest backup has warnings
+          summary: Velero schedule {{ $labels.schedule }} latest Completed backup has warnings
           description: >-
             The newest Backup for schedule {{ $labels.schedule }} is
             {{ $labels.backup }} and reports status.warnings > 0. Velero uses
             warnings for soft failures such as skipping a hostPath / local-path
-            volume while still marking the Backup Completed, so phase alone is
-            not enough. Inspect the Backup log for "hostPath volume which is not
-            supported" (or other skip reasons), confirm every durable PVC has a
-            Completed PodVolumeBackup, and do not treat this Backup as a volume
-            restore source until the warning is gone. A later Backup with
-            warnings=0 clears this alert.
+            volume while still marking the Backup Completed (corp/bhaiya#695),
+            so phase alone is not enough. Inspect the Backup log for "hostPath
+            volume which is not supported" (or other skip reasons), confirm
+            every durable PVC has a Completed PodVolumeBackup for its pod+volume,
+            and do not treat this Backup as a volume restore source until the
+            warning is gone. A later Backup with warnings=0 clears this alert.
+
+      # Metadata-only Completed Backup: no PodVolumeBackup children at all.
+      # Covers opt-in miss (media-config before #2757), scaled-to-zero apps
+      # with orphan PVCs (hermes), and similar green-empty schedules (#703).
+      # Schedules that never create a Backup are VeleroScheduleNeverBackedUp.
+      # Require phase=Completed on the newest Backup so Failed attempts do not
+      # double-page with VeleroScheduleLastBackupFailed.
+      - alert: VeleroScheduleLatestBackupMissingVolumes
+        expr: |
+          (
+            max by (cluster, namespace, schedule, backup) (
+              velero_cr_backup_info{
+                namespace="velero-system",
+                schedule!="",
+                phase="Completed"
+              }
+            )
+            and on (cluster, namespace, schedule, backup)
+            (
+              velero_cr_backup_created_timestamp{
+                namespace="velero-system",
+                schedule!=""
+              }
+              == on (cluster, namespace, schedule) group_left
+              max by (cluster, namespace, schedule) (
+                velero_cr_backup_created_timestamp{
+                  namespace="velero-system",
+                  schedule!=""
+                }
+              )
+            )
+          )
+          unless on (cluster, namespace, backup)
+          (
+            count by (cluster, namespace, backup) (
+              velero_cr_podvolumebackup_info{
+                namespace="velero-system"
+              }
+            ) > 0
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} latest Completed backup has no volume snapshots
+          description: >-
+            The newest Backup for schedule {{ $labels.schedule }} is
+            {{ $labels.backup }}, phase=Completed, and has zero PodVolumeBackup
+            children. That is a metadata-only backup: Kubernetes objects may be
+            present while durable PVCs were never selected or never mounted
+            (corp/bhaiya#703). Confirm with
+            `kubectl -n velero-system get podvolumebackup -l velero.io/backup-name={{ $labels.backup }}`
+            and the live pod volume mounts — do not trust the Backup phase.
+            Clears when a later Backup has at least one PodVolumeBackup.

--- a/kubernetes/apps/ottawa/velero/schedules/forgejo-backup-bootstrap.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/forgejo-backup-bootstrap.yaml
@@ -1,0 +1,26 @@
+---
+# One-shot Backup so gitea-shared-storage is covered before the daily 10:00Z
+# Schedule tick (corp/bhaiya#703). Same template as forgejo-backup. Idempotent
+# name: re-applying is a no-op once the object exists. Delete only after a
+# Schedule-owned Backup has a Completed PVB for forgejo-*/data.
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: forgejo-backup-bootstrap
+  namespace: velero-system
+  labels:
+    keiretsu.top/bootstrap-for-schedule: forgejo-backup
+  annotations:
+    keiretsu.top/purpose: >-
+      Capture gitea-shared-storage (pod volume data) and forgejo-postgres
+      pgdata once; daily coverage remains forgejo-backup Schedule at 10:00 UTC.
+spec:
+  ttl: 720h0m0s
+  storageLocation: garage
+  includedNamespaces:
+    - forgejo
+  defaultVolumesToFsBackup: true
+  snapshotMoveData: false
+  resourcePolicy:
+    kind: configmap
+    name: fs-backup-resource-policy

--- a/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
@@ -3,6 +3,8 @@
 # plus forgejo-postgres-*/pgdata. emptyDir scratch volumes are skipped by
 # fs-backup-resource-policy. Schedule is daily 10:00 UTC; if lastBackup is
 # empty the cron has not fired yet — that is not a capture failure.
+# A one-shot Backup forgejo-backup-bootstrap covers git data until the
+# Schedule owns a Completed PVB for volume data (gitea-shared-storage).
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:

--- a/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./bhaiya-backup.yaml
   - ./cliproxy-backup.yaml
   - ./forgejo-backup.yaml
+  - ./forgejo-backup-bootstrap.yaml

--- a/kubernetes/apps/stpetersburg/velero/schedules/home-assistant-backup.yaml
+++ b/kubernetes/apps/stpetersburg/velero/schedules/home-assistant-backup.yaml
@@ -1,4 +1,9 @@
 ---
+# corp/bhaiya#695: homeassistant-config is local-path → hostPath. Velero fs-backup
+# skips it with a warning and still marks the Backup Completed. CSI snapshots are
+# unavailable (no VolumeSnapshotLocation on StP; only StorageClass is local-path).
+# Detection: VeleroScheduleLatestBackupHasWarnings (critical). Data fix needs a
+# non-hostPath volume or a non-Velero copy — not another Completed Backup.
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:
@@ -11,8 +16,7 @@ spec:
     includedNamespaces:
       - home-assistant
     defaultVolumesToFsBackup: true
-    # Skip AirConnect emptyDir noise. NOTE: homeassistant-config is still
-    # unprotected — Velero refuses local-path hostPath PVs (see findings).
+    # Skip AirConnect emptyDir so remaining warnings are hostPath skips only.
     resourcePolicy:
       kind: configmap
       name: fs-backup-resource-policy


### PR DESCRIPTION
## Summary

Addresses Forgejo `corp/bhaiya` **#695** and **#703** in GitOps (no prod apply).

### Priority 1 — make silent skip / green-empty loud
- Promote `VeleroScheduleLatestBackupHasWarnings` to **critical** (StP HA Completed + `warnings>0` while hostPath `homeassistant-config` is skipped).
- Add clearable `VeleroScheduleLatestBackupMissingVolumes`: newest **Completed** Backup per schedule with **zero** PodVolumeBackup children (hermes, pre-fix media-config, etc.).
- Live PromQL checks: StP HA warnings join matches `home-assistant-backup-20260906090023`; Ottawa missing-volumes join matches `hermes-backup-…` and `media-config-backup-…`.

### Priority 2 — cover Forgejo git data
- Add one-shot `Backup/forgejo-backup-bootstrap` (same template as the daily Schedule) so `gitea-shared-storage` (pod volume `data`) is selected before the first `0 10 * * *` tick.
- **Verify after Flux** with contents, not phase:
  `kubectl -n velero-system get podvolumebackup -l velero.io/backup-name=forgejo-backup-bootstrap` must show Completed for `forgejo-*/data`.

### Explicitly not in this PR
- Moving StP HA off local-path/hostPath (needs a storage decision; only StorageClass on StP is local-path).
- Waiting for media-config 06:00Z / forgejo 10:00Z cron proof (bootstrap covers forgejo; media already fixed in #2757 pending next cron).

## Test plan
- [x] `tools/check.sh` render OK (ottawa/robbinsdale/stpetersburg)
- [x] PromQL for warnings + missing-volumes against live Mimir
- [ ] After merge/Flux: bootstrap Backup exists; Completed PVB on `data`→`gitea-shared-storage`
- [ ] Alerts fire for current StP HA + hermes; clear when fixed

Do **not** merge without Raj.