### PR TITLE
fix(mimir): shrink RF=1 recent query blindness (#674)

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -105,6 +105,20 @@ spec:
             # The first rollout moves the ingester from emptyDir to RBD. Flush
             # and ship the current head before Kubernetes removes the old pod.
             flush_blocks_on_shutdown: true
+          bucket_store:
+            # Must stay strictly below querier.query_store_after. Leaving the
+            # default 10h with a 4h store-after boundary would open a 4h–10h
+            # hole where neither ingesters nor store-gateway answer.
+            ignore_blocks_within: 2h
+        querier:
+          # Defaults are query_store_after=12h / query_ingesters_within=13h.
+          # With a single RF=1 ingester that makes the last ~12h a SPOF
+          # (corp/bhaiya#674): any ingester replacement blinds the window
+          # until blocks age past the boundary. Shrink the ingester-only
+          # window without paying for a second ~4GiB RSS replica. Does not
+          # protect the unshipped head; RF/replica HA remains a capacity call.
+          query_store_after: 4h
+          query_ingesters_within: 5h
         limits:
           compactor_blocks_retention_period: 7d
           ingestion_rate: 500000

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-queryable-window.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-queryable-window.yaml
@@ -10,13 +10,13 @@ groups:
       - alert: MimirRecentQueryWindowUnavailable
         expr: |
           absent_over_time(
-            mimir_query_canary{source="ruler"}[5m] offset 6h
+            mimir_query_canary{source="ruler"}[5m] offset 2h
           )
           and on ()
           (
             sum(
               count_over_time(
-                mimir_query_canary{source="ruler"}[5m] offset 13h
+                mimir_query_canary{source="ruler"}[5m] offset 6h
               )
             ) > 0
           )
@@ -27,14 +27,14 @@ groups:
           summary: Mimir's recent query window is unavailable
           description: >-
             The dedicated Mimir query canary has no readable sample at the
-            six-hour offset for ten minutes, while the older thirteen-hour
-            canary remains readable from the store. This indicates that the
-            recent ingester-served window is not queryable. It does not prove
-            that every metric series is missing or that the data is permanently
-            lost. The six-hour offset must remain inside
-            querier.query_store_after (currently 12h); update this rule with
-            any query_store_after change or it can silently stop testing the
-            protected recent window.
+            two-hour offset for ten minutes, while the older six-hour canary
+            remains readable from the store. This indicates that the recent
+            ingester-served window is not queryable. It does not prove that
+            every metric series is missing or that the data is permanently
+            lost. The two-hour offset must remain inside
+            querier.query_store_after (currently 4h after #674); update this
+            rule with any query_store_after change or it can silently stop
+            testing the protected recent window.
             This alert shares the Mimir ruler/query path it observes and is
             not protection against a ruler, gateway, querier, or complete
             query-path outage; pair it with an independent external query


### PR DESCRIPTION
## Summary

Addresses Forgejo `corp/bhaiya#674` with the **smallest durable config-only** change after verifying live Ottawa state.

### Live evidence (read-only, 2026-09-07)

| Fact | Evidence |
| --- | --- |
| Ingester count | `sts/mimir-ingester` **replicas=1**, pod on `rei` since `2026-09-06T14:54:50Z` |
| RF | live `mimir-config` + CLI `--ingester.ring.replication-factor=1` |
| `query_store_after` | **absent** in live config (`querier` only has `max_concurrent`) → **default 12h** |
| companions | `ignore_blocks_within` / `query_ingesters_within` also unset → defaults **10h / 13h** |
| Memory | `mimir-ingester-0` **~4294Mi** RSS (requests still 512Mi) |
| Detection already present | `#2725` `mimir_query_canary` = 1; `MimirRecentQueryWindowUnavailable` not firing (6h currently readable) |

So the issue text is **still accurate**: single ingester + default 12h store-after remains a recent-window SPOF. The “nothing alerts” claim is only **partially** true — `#2725` already landed the ruler canary alert, but the blind window itself was unchanged.

## Change

- Explicitly set `query_store_after=4h`, `query_ingesters_within=5h`, `ignore_blocks_within=2h` (ordered so there is no 4h–10h hole).
- Retune `MimirRecentQueryWindowUnavailable` offsets **6h/13h → 2h/6h** so the probe stays inside the protected window.

## Non-goals (explicit)

- **No replica/RF increase.** Post-renderer still hard-codes `storage-mimir-ingester-0`; HA needs a capacity call (~4.3GiB RSS + 20Gi PVC per extra ingester).
- Ruler alert remains a **shared-path diagnostic**, not an independent blackbox (documented in the rule).

## Validation

- `tools/check-mimir-rules.sh` ✓
- `tools/check.sh talos-ottawa` ✓

## Test plan

- [ ] After Flux rolls queriers, confirm live `/config` shows the new triad
- [ ] Confirm `mimir_query_canary` still evaluates and the alert stays idle while 2h is readable
- [ ] On next ingester restart, expect a much shorter unreadable window (~4h max for shipped blocks) and alert coverage inside that window