### PR TITLE
fix(mimir): raise HelmRelease timeouts above ring-stability wait (#713)

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -5,6 +5,14 @@ metadata:
   name: mimir
 spec:
   interval: 30m
+  # Ring components (compactor/store-gateway/ingester) log
+  # "waiting until ring topology is stable" for min 1m / max 5m and also have
+  # readinessProbe.initialDelaySeconds=60 plus possible WAL replay. The Helm
+  # default 5m wait treats that healthy join as a stall, fails the upgrade,
+  # then fails the rollback for the same reason and burns remediation retries
+  # (corp/bhaiya#713). Keep the wait above the 5m ceiling so GitOps can land
+  # Mimir config (including #2765) without manual suspend/resume.
+  timeout: 15m
   chart:
     spec:
       chart: mimir-distributed
@@ -14,12 +22,17 @@ spec:
         name: grafana
         namespace: flux-system
   install:
+    timeout: 15m
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
+    timeout: 15m
     remediation:
-      retries: 3
+      # Retry the upgrade itself; do not dig a deeper hole by rolling back a
+      # merely-slow ring join into another 5m-default stall (#713).
+      retries: 2
+      strategy: retry
   postRenderers:
     - kustomize:
         patches:
@@ -105,6 +118,8 @@ spec:
             # The first rollout moves the ingester from emptyDir to RBD. Flush
             # and ship the current head before Kubernetes removes the old pod.
             flush_blocks_on_shutdown: true
+            # helm-release-epoch: 2026-09-07T05:55:00Z — bump with timeout
+            # delivery fixes so Flux performs a real upgrade after #713.
           bucket_store:
             # Must stay strictly below querier.query_store_after. Leaving the
             # default 10h with a 4h store-after boundary would open a 4h–10h


### PR DESCRIPTION
## Summary

Fixes Forgejo `corp/bhaiya#713`: Mimir Helm upgrades fail because ring components are *slow*, not broken. That made **every** Mimir HelmRelease change undeliverable (including already-merged km#2765).

### Live evidence before this PR

- `HelmRelease/mimir`: `Ready=False` `reason=RollbackFailed`, `Released=False` `reason=UpgradeFailed`, `upgradeFailures: 3`, message shows **timeout of 5m0s**
- Stalled object was `StatefulSet/mimir-compactor` during healthy ring wait
- Serving remained fine: `count(up)=259`, queriers/gateway ready (delivery failure ≠ outage)
- Live `mimir-config` still has **no** `query_store_after` override → #2765 never reached the cluster

## Change

- `spec.timeout: 15m`
- `spec.install.timeout: 15m`
- `spec.upgrade.timeout: 15m`
- `spec.upgrade.remediation.strategy: retry` with `retries: 2` (retry the upgrade; don’t dig deeper with failed rollbacks of a merely-slow join)
- Values epoch comment so Flux does a real upgrade after merge

## Non-goals

- No suspend/resume / manual helm surgery from this PR
- No replica/RF changes

## Validation

- `tools/check.sh talos-ottawa` ✓

## Test plan (required — do not verify by reading YAML)

After merge / Flux reconcile, without manual suspend/resume:

- [ ] `kubectl -n mimir get helmrelease mimir` → `Ready=True` (not RollbackFailed)
- [ ] `upgradeFailures` stops climbing / resets on success
- [ ] Live config shows #2765 triad (`query_store_after: 4h`, etc.)
- [ ] Mimir still serving (`count(up)` healthy)