### PR TITLE
docs(garage): keep degraded; document Kopia maintenance RAW exception

### DIFF
--- a/docs/adr/0007-velero-backups-need-an-independent-object-store.md
+++ b/docs/adr/0007-velero-backups-need-an-independent-object-store.md
@@ -24,7 +24,7 @@ The live observations below were made on 2026-09-04 UTC.
 | S3 path | `http://garage-gateway.garage.svc.cluster.local:3900`; the `bhaiya-garage-kopia` repository is `Ready` on this BSL |
 | Bucket object | `GarageBucket/garage/velero`, `globalAlias: velero`, `maxSize: 1Ti` |
 | Current bucket usage | 30,760 objects and 308,047,420,448 bytes (286.9 GiB); usage is approximately 28% of the configured byte quota |
-| Garage topology | replication factor 3, `degraded` consistency, Ottawa/Robbinsdale/St. Petersburg federated zones; Ottawa currently has five storage nodes and two gateway replicas |
+| Garage topology | replication factor 3, `degraded` consistency (kept for flap tolerance; Kopia `_maintenance` RAW is a known intermittent prune refusal under degraded — not a reason to raise fleet read quorum; see km#2746), Ottawa/Robbinsdale/St. Petersburg federated zones; Ottawa currently has five storage nodes and two gateway replicas |
 | Independent target | None. All three live `GarageBucket/velero` objects report the same global bucket ID, and all three BSLs use the same bucket and gateway service name with only the prefix changed |
 
 Garage's remote zones and replication protect against selected node or site

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1511,21 +1511,25 @@ Ottawa's edge on their own.
 ### Garage: one zone is survivable, two are not
 
 Replication factor 3 across exactly three zones, `consistencyMode: degraded`,
-reads at quorum 1.
+reads at quorum 1 / writes at quorum 2 (Garage upstream table).
 
-- **One zone down:** reads and writes continue. Apps talk to their local
-  gateway, which proxies reads to a surviving zone, so a site can lose its own
-  storage tier entirely and still serve objects.
+- **One zone hard-down, two healthy:** reads and writes continue (writes need
+  the two survivors; reads need any one replica under degraded).
+- **One zone flapping / high RTT:** degraded still serves reads from a local
+  replica; under `consistent` (read quorum 2) those reads fail closed with
+  503/504 — that is why the fleet default stays degraded (`89342b046`).
 - **Two zones down:** you are below write quorum. Treat it as an outage of the
   object store, not a degradation.
 
-The reason this is tolerable rather than reckless is what is stored in it: OCI
-blobs and kopia backups are content-addressed, and Barman WAL is append-only,
-so none of the current consumers depend on read-after-write consistency. That
-argument is written down beside the setting in the `GarageCluster` manifest,
-`garagecluster.yaml` under `kubernetes/apps/base/garage/garage/` — check it
-before adding a consumer that *does* need read-after-write, because the
-reasoning, not the replication factor, is what makes `degraded` safe here.
+Most consumers tolerate eventual-consistent reads: OCI/zot blobs and Kopia
+*pack* data are content-addressed; Barman WAL is append-only. **Kopia
+repository maintenance is the exception** — it requires read-after-write on
+the `_maintenance` schedule blob and can false-refuse prune as "clock skew"
+under degraded (corp/bhaiya#575). That is accepted intermittent pain, not a
+reason to raise fleet read quorum; Garage cannot scope consistency per bucket,
+and a maintenance-window flip still exposes Zot/CI to flap 503s. See the
+comment on `consistencyMode` in `garagecluster.yaml`. ADR 0007 (independent
+Velero object store) remains the durability/RAW endgame.
 
 Note also that the storage tier is `Manual` at all three sites while the gateway
 tier is operator-managed, and that retirement of a node with positive capacity

--- a/kubernetes/apps/base/garage/garage/garagecluster.yaml
+++ b/kubernetes/apps/base/garage/garage/garagecluster.yaml
@@ -26,14 +26,24 @@ spec:
 
   replication:
     factor: 3
-    # degraded: reads fall back to a single (local) replica when cross-WAN quorum
-    # is slow/unavailable, instead of returning 503/504. Writes still require
-    # quorum. This fixes the read-path 503s that broke zot (boot-time getAllRepos
-    # list + blob HEAD checks) and CI image pushes. Safe now that restic/volsync
-    # is decommissioned (2026-07-04) — it was the only read-after-write-sensitive
-    # consumer; the rest are content-addressed (OCI/zot, Kopia/velero) or
-    # append-only (logs, barman/CNPG backups), which tolerate eventual-consistent
-    # reads (a stale/absent read is a transient retry, not corruption).
+    # degraded: read quorum 1, write quorum 2 (RF=3). Reads fall back to a single
+    # replica when cross-WAN quorum is slow/unavailable instead of 503/504.
+    # Chosen deliberately in 89342b046 after consistent-mode Tailscale flaps
+    # broke Zot boot (getAllRepos) and CI blob HEADs.
+    #
+    # EXCEPTION — Kopia repository maintenance does NOT tolerate this. Velero
+    # spawns kopia maintenance which PUTs `_maintenance` then immediately HEADs
+    # it and treats Garage Last-Modified as the repo clock (max skew 5m). Under
+    # degraded that HEAD can return the previous hour's stamp → false "clock
+    # skew" prune refusal (#575 / km#2746). Content-addressed pack uploads still
+    # tolerate degraded (retry on stale/absent).
+    #
+    # Do NOT flip the fleet default to consistent to fix that. Garage has no
+    # per-bucket consistency mode; a windowed flip still puts R=2 on Zot/CI for
+    # the whole window and re-opens flap 503s. Keep degraded; track prune RAW
+    # via ADR 0007 / upstream Kopia, or accept intermittent maintenance retry.
+    # GARAGE_CONSISTENCY_MODE=consistent remains for explicit drain windows only
+    # (see docs/garage-node-local-v0.7.1-migration.md), then restore degraded.
     consistencyMode: "${GARAGE_CONSISTENCY_MODE:=degraded}"
 
   s3Api:


### PR DESCRIPTION
## Summary

Follow-on to the km#2746 sign-off: **do not** raise fleet read quorum. This PR only corrects docs/comments so we stop claiming Kopia tolerates `degraded`.

- Default remains `${GARAGE_CONSISTENCY_MODE:=degraded}` (unchanged).
- Documents why Kopia maintenance needs RAW (`_maintenance` PUT then HEAD / 5m skew) and why that is **not** a reason to flip the estate to `consistent`.
- States that Garage has no per-bucket consistency mode; a “windowed” flip still puts R=2 on Zot/CI for the whole window (same flap 503 failure mode as #2746).

## Why Kopia needs RAW (narrow)

Only **repository maintenance**, not pack backup I/O. Upstream `maintenance_run.go`: PUT `_maintenance` → immediate `GetMetadata` → refuse if `|Δ| > 5m`. Observed ~1h5m skew = stale prior-cycle Last-Modified under R=1.

## Test plan

- [x] No runtime/config value change (`:=degraded` stays)
- [ ] Review comment accuracy against Garage RF=3 quorum table + `89342b046`
- [ ] Close km#2746 as won’t-fix with quorum rationale (separate comment)

Closes nothing by itself; pairs with closing #2746.