### PR TITLE
fix(mimir): drop invalid remediation strategy blocking the whole Kustomization

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -29,10 +29,11 @@ spec:
     cleanupOnFail: true
     timeout: 15m
     remediation:
-      # Retry the upgrade itself; do not dig a deeper hole by rolling back a
-      # merely-slow ring join into another 5m-default stall (#713).
+      # 'retry' is NOT a valid strategy (live CRD accepts only rollback |
+      # uninstall), and setting it fails the whole Kustomization dry-run.
+      # The 15m timeouts above are the actual fix: a healthy ring join no
+      # longer times out, so remediation is not triggered at all.
       retries: 2
-      strategy: retry
   postRenderers:
     - kustomize:
         patches:


### PR DESCRIPTION
## Regression from km#2766, which I merged

km#2766 set `spec.upgrade.remediation.strategy: retry`. **That value does not exist.** The live CRD says so plainly:

```
HelmRelease/mimir/mimir dry-run failed (Invalid):
  spec.upgrade.remediation.strategy: Unsupported value: "retry":
  supported values: "rollback", "uninstall"
```

An invalid field fails the HelmRelease dry-run, which fails the **entire `mimir` Kustomization**, which means *nothing* in the mimir path can apply any more — including km#2766's own valid `timeout: 15m` fields and km#2765's query-window config. So the fix for #713 blocked itself, and left the tree worse than before: previously the Kustomization applied and only the HelmRelease was failing.

Evidence of the state it created:

```
kustomization/mimir  lastApplied: 7ceab5c7   lastAttempted: 17fd7879   Ready=False
helmrelease/mimir    spec.timeout: <empty>   Ready=False reason=RollbackFailed
```

`lastAttempted` moved to the merge, `lastApplied` did not.

## Change

Remove `strategy: retry`. The intent behind it — don't roll a merely-slow ring join into another stall — is already achieved by the timeouts: with `timeout: 15m` above Mimir's 5-minute ring-stability ceiling, the upgrade does not time out, so remediation is never triggered and there is no rollback to worry about. `retries: 2` stays.

## Verified with the check CI does not run

```
$ kubectl apply --dry-run=server -f .../mimir-ottawa/helmrelease.yaml
helmrelease.helm.toolkit.fluxcd.io/mimir created (server dry run)
```

**This is the whole lesson.** km#2766 passed all 9 checks — `validate`, `check`, three `test` jobs, three `diff` jobs, `diagram` — because none of them validates against the live cluster's CRD schema. `kubectl kustomize` renders an invalid field happily; only a server-side dry-run rejects it. A repo whose entire job is producing manifests for a live cluster cannot detect a manifest that cluster refuses.

I am filing that CI gap separately rather than bundling it here, since this PR needs to land immediately to unblock the mimir path.

## Acceptance

1. `kustomization/mimir` → `lastAppliedRevision` equals this merge, `Ready=True`
2. `helmrelease/mimir` → `spec.timeout: 15m` actually present, then `Ready=True` without manual suspend/resume
3. `mimir-config` ConfigMap contains `query_store_after: 4h` — km#2765 finally delivered

Mimir has kept serving throughout all of this (`count(up)` = 260, 2/2 queriers, 2/2 gateway). Still a delivery failure, not an outage.
