### PR TITLE
fix(mimir): raise HelmRelease timeout above the ingester grace period

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -10,9 +10,12 @@ spec:
   # readinessProbe.initialDelaySeconds=60 plus possible WAL replay. The Helm
   # default 5m wait treats that healthy join as a stall, fails the upgrade,
   # then fails the rollback for the same reason and burns remediation retries
-  # (corp/bhaiya#713). Keep the wait above the 5m ceiling so GitOps can land
-  # Mimir config (including #2765) without manual suspend/resume.
-  timeout: 15m
+  # (corp/bhaiya#713). The wait must also exceed the ingester's
+  # terminationGracePeriodSeconds of 1200s (20m): a graceful ingester shutdown
+  # flushes its whole TSDB head to long-term storage and can legitimately use
+  # that entire window, so a 15m Helm wait times out on a healthy drain and
+  # reproduces #713. 25m clears both the 5m ring ceiling and the 20m grace.
+  timeout: 25m
   chart:
     spec:
       chart: mimir-distributed
@@ -22,12 +25,12 @@ spec:
         name: grafana
         namespace: flux-system
   install:
-    timeout: 15m
+    timeout: 25m
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
-    timeout: 15m
+    timeout: 25m
     remediation:
       # 'retry' is NOT a valid strategy (live CRD accepts only rollback |
       # uninstall), and setting it fails the whole Kustomization dry-run.


### PR DESCRIPTION
## km#2766's 15m was the right idea against the wrong bound

It cleared Mimir's 5-minute ring-stability ceiling, which was the documented cause in corp/bhaiya#713. But it does **not** clear the ingester's shutdown window:

```
sts/mimir-ingester  terminationGracePeriodSeconds: 1200   # 20 minutes
spec.upgrade.timeout: 15m                                 # 900 seconds
```

A graceful ingester shutdown flushes its **entire TSDB head to long-term storage** (`flush_blocks_on_shutdown: true`) and is entitled to use that whole 1200s. So Helm can time out at 15m on a completely healthy drain, fail the upgrade, and reproduce #713 — with the added irony that the thing it kills is the process protecting our most recent metrics from permanent loss.

## This is not hypothetical — it is happening right now

Observed live while verifying #2768:

```
mimir-ingester-0   0/1   restarts=0   age=16m
deletionTimestamp: 2026-09-07T06:27:10Z      # request ~06:07 + 1200s grace
logs: "uploading new block to long-term storage" ... (2 uploads in the last 60s)
```

Sixteen minutes in, zero restarts, still shipping blocks, with roughly sixteen minutes of grace remaining. Nothing is wrong with it. A 15m Helm wait would have declared that a stall.

## Change

`spec.timeout`, `spec.install.timeout`, `spec.upgrade.timeout`: 15m → **25m**, which clears both bounds — the 5m ring ceiling and the 20m grace period — with margin.

## Same class as the bug it replaces

A health check shorter than the thing it is checking guarantees failure while the system is healthy. #713 was that against ring stability; this is that against graceful shutdown. Worth stating the general rule in review: **a Helm/Flux timeout must exceed `terminationGracePeriodSeconds` of every workload in the release**, not just the slowest startup. Startup was the visible symptom; shutdown is the longer bound.

## Verified with the check CI does not run

```
$ kubectl apply --dry-run=server -f .../mimir-ottawa/helmrelease.yaml
helmrelease.helm.toolkit.fluxcd.io/mimir created (server dry run)
```

Doing this on every Mimir change now, after #2766 shipped an invalid enum past all 9 checks and froze the whole Kustomization (fixed in #2768, gap filed as corp/bhaiya#715).

## Still outstanding

`query_store_after: 4h` has **not** reached the live ConfigMap. km#2765 remains undelivered; that is the only acceptance criterion that matters, and it is honestly still unmet. Mimir has kept serving throughout — 2/2 distributors, gateways and queriers.
