### PR TITLE
ci: fail PRs when a PVC namespace has no Velero Schedule

### DIFF
--- a/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
+++ b/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
@@ -1,0 +1,90 @@
+# Velero PVC→Schedule coverage exemptions.
+#
+# Consumed only by tools/check-velero-pvc-coverage.sh. NOT a Flux resource —
+# do not add this file to kustomization.yaml (no matching CRD).
+#
+# The check fails when a namespace that declares a PersistentVolumeClaim,
+# volumeClaimTemplate, or CNPG Cluster storage in Git is missing from every
+# Velero Schedule spec.template.includedNamespaces on that cluster — unless
+# it is listed here with a non-empty reason.
+#
+# Prefer a real decision in the reason. Prefix with "UNRESOLVED:" only while
+# coverage is still open (keeps the gap visible without blessing it).
+#
+# Scope: Git-declared volumes only. Out-of-band PVCs (e.g. StP
+# homeassistant-config hostPath) need a different detector.
+apiVersion: keiretsu.top/v1alpha1
+kind: VeleroPVCScheduleExemptions
+metadata:
+  name: pvc-schedule-exemptions
+exemptions:
+  # --- Ottawa ---
+  - cluster: ottawa
+    namespace: immich
+    reason: >-
+      Photo libraries deliberately not backed up per Raj 2026-09-07; see
+      corp/bhaiya#718. immich-library (Ceph) is exempt from Velero by decision.
+      immich-postgres remains protected separately via GarageBucket
+      immich-postgres (~CNPG/Barman dumps) — DB coverage must not be read as
+      "immich is backed up."
+
+  - cluster: ottawa
+    namespace: firefly
+    reason: >-
+      UNRESOLVED: corp/bhaiya#718 — firefly-upload PVC and firefly-postgres have
+      no Velero Schedule; CNPG S3 covers the DB only. Upload volume coverage
+      undecided.
+
+  - cluster: ottawa
+    namespace: woodpecker
+    reason: >-
+      UNRESOLVED: corp/bhaiya#718 — woodpecker server/workspace/nix-cache PVCs and
+      woodpecker-postgres have no Velero Schedule; CNPG S3 covers the DB only.
+      CI workspace data retention policy undecided.
+
+  - cluster: ottawa
+    namespace: teslamate
+    reason: >-
+      Postgres-only namespace: CNPG ScheduledBackup to Garage covers
+      teslamate-postgres. No app PVC beyond the database cluster.
+
+  - cluster: ottawa
+    namespace: mimir
+    reason: >-
+      Metrics TSDB is product-native multi-replica storage with its own
+      compaction/retention; Velero FSB of ingester PVCs is not the restore path.
+
+  - cluster: ottawa
+    namespace: cephfs-proof
+    reason: >-
+      Disposable CephFS RWX probe PVC for CSI validation; not production state.
+
+  - cluster: ottawa
+    namespace: tailscale-examples
+    reason: >-
+      Demo/sandbox tsidp volumeClaimTemplate under tailscale-examples; not a
+      production data plane.
+
+  # --- Robbinsdale ---
+  - cluster: robbinsdale
+    namespace: immich
+    reason: >-
+      Photo libraries deliberately not backed up per Raj 2026-09-07; see
+      corp/bhaiya#718. immich-library and immich-pics-v2 (SMB) are exempt from
+      Velero by decision. immich-postgres remains protected separately via
+      GarageBucket/CNPG dumps — DB coverage must not be read as "immich is
+      backed up."
+
+  - cluster: robbinsdale
+    namespace: tailscale-examples
+    reason: >-
+      Demo/sandbox tsidp volumeClaimTemplate under tailscale-examples; not a
+      production data plane.
+
+  # --- St Petersburg ---
+  - cluster: stpetersburg
+    namespace: ai
+    reason: >-
+      Model-weight caches on local-path (vLLM/qwen/dsv4); rebuildable from
+      registry, not application state. hostPath also cannot be Velero
+      fs-backed up (#695 class).

--- a/tools/check-velero-pvc-coverage.sh
+++ b/tools/check-velero-pvc-coverage.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# tools/check-velero-pvc-coverage.sh — repo-side contract: every namespace that
+# declares durable volume intent in Git must appear in a Velero Schedule's
+# includedNamespaces for that cluster, or in the committed exemption list.
+#
+# This is a CI check, not a Mimir alert: Schedule includedNamespaces are not
+# exported as metrics, and a PR-time failure prevents shipping a silent gap.
+#
+# See kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml.
+set -euo pipefail
+cd -- "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+  _yaml_site=$(find /workspace/.local/share/nix/root/nix/store -maxdepth 1 -name "*pyyaml*" -not -name "*.drv" -type d 2>/dev/null | head -1)
+  if [ -n "$_yaml_site" ]; then
+    export PYTHONPATH="${_yaml_site}/lib/python3.14/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+  fi
+fi
+
+python3 - <<'PY'
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import yaml
+
+ROOT = Path.cwd()
+CLUSTERS = ("ottawa", "robbinsdale", "stpetersburg")
+EXEMPTIONS_PATH = ROOT / "kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml"
+
+
+def load_docs(path: Path):
+    try:
+        text = path.read_text()
+    except OSError as err:
+        raise SystemExit(f"cannot read {path}: {err}") from err
+    try:
+        for doc in yaml.safe_load_all(text):
+            if isinstance(doc, dict):
+                yield doc
+    except yaml.YAMLError as err:
+        raise SystemExit(f"cannot parse {path}: {err}") from err
+
+
+def is_flux_kustomization(doc: dict) -> bool:
+    return (
+        doc.get("kind") == "Kustomization"
+        and str(doc.get("apiVersion", "")).startswith("kustomize.toolkit.fluxcd.io/")
+    )
+
+
+def is_velero_schedule(doc: dict) -> bool:
+    return (
+        doc.get("kind") == "Schedule"
+        and str(doc.get("apiVersion", "")).startswith("velero.io/")
+    )
+
+
+def normalize_repo_path(path: str) -> Path:
+    if path.startswith("./"):
+        path = path[2:]
+    return ROOT / path
+
+
+def path_declares_durable_volume(path: Path) -> bool:
+    """True when Git under the Flux path declares a PVC, VCT, or CNPG storage."""
+    if not path.exists():
+        return False
+    files = list(path.rglob("*.yaml")) + list(path.rglob("*.yml"))
+    for file_path in files:
+        for doc in load_docs(file_path):
+            kind = doc.get("kind")
+            if kind == "PersistentVolumeClaim":
+                return True
+            spec = doc.get("spec")
+            if isinstance(spec, dict) and spec.get("volumeClaimTemplates"):
+                return True
+            if (
+                kind == "Cluster"
+                and str(doc.get("apiVersion", "")).startswith("postgresql.cnpg.io/")
+            ):
+                storage = spec.get("storage") if isinstance(spec, dict) else None
+                wal = spec.get("walStorage") if isinstance(spec, dict) else None
+                if isinstance(storage, dict) and storage.get("size"):
+                    return True
+                if isinstance(wal, dict) and wal.get("size"):
+                    return True
+    return False
+
+
+def scheduled_namespaces(cluster: str) -> set[str]:
+    covered: set[str] = set()
+    schedule_dir = ROOT / f"kubernetes/apps/{cluster}/velero/schedules"
+    if not schedule_dir.is_dir():
+        return covered
+    for path in sorted(schedule_dir.glob("*.yaml")) + sorted(schedule_dir.glob("*.yml")):
+        for doc in load_docs(path):
+            if not is_velero_schedule(doc):
+                continue
+            template = (doc.get("spec") or {}).get("template") or {}
+            included = template.get("includedNamespaces") or []
+            if not isinstance(included, list):
+                continue
+            for name in included:
+                if isinstance(name, str) and name:
+                    covered.add(name)
+    return covered
+
+
+def pvc_namespaces(cluster: str) -> set[str]:
+    found: set[str] = set()
+    cluster_root = ROOT / f"kubernetes/apps/{cluster}"
+    for path in cluster_root.rglob("*.yaml"):
+        for doc in load_docs(path):
+            if not is_flux_kustomization(doc):
+                continue
+            spec = doc.get("spec") or {}
+            target = spec.get("targetNamespace")
+            source_path = spec.get("path")
+            if not isinstance(target, str) or not target:
+                continue
+            if not isinstance(source_path, str) or not source_path:
+                continue
+            if path_declares_durable_volume(normalize_repo_path(source_path)):
+                found.add(target)
+    return found
+
+
+def load_exemptions() -> dict[str, dict[str, str]]:
+    """cluster -> {namespace: reason}."""
+    if not EXEMPTIONS_PATH.is_file():
+        raise SystemExit(f"missing exemption list: {EXEMPTIONS_PATH}")
+    docs = list(load_docs(EXEMPTIONS_PATH))
+    if not docs:
+        raise SystemExit(f"empty exemption list: {EXEMPTIONS_PATH}")
+    doc = docs[0]
+    if doc.get("kind") != "VeleroPVCScheduleExemptions":
+        raise SystemExit(
+            f"{EXEMPTIONS_PATH}: expected kind VeleroPVCScheduleExemptions, "
+            f"got {doc.get('kind')!r}"
+        )
+    raw = doc.get("exemptions")
+    if not isinstance(raw, list) or not raw:
+        raise SystemExit(f"{EXEMPTIONS_PATH}: exemptions must be a non-empty list")
+
+    out: dict[str, dict[str, str]] = {c: {} for c in CLUSTERS}
+    for idx, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise SystemExit(f"{EXEMPTIONS_PATH}: exemptions[{idx}] must be a mapping")
+        cluster = entry.get("cluster")
+        namespace = entry.get("namespace")
+        reason = entry.get("reason")
+        if cluster not in CLUSTERS:
+            raise SystemExit(
+                f"{EXEMPTIONS_PATH}: exemptions[{idx}].cluster must be one of {CLUSTERS}"
+            )
+        if not isinstance(namespace, str) or not namespace:
+            raise SystemExit(f"{EXEMPTIONS_PATH}: exemptions[{idx}].namespace required")
+        if not isinstance(reason, str) or not reason.strip():
+            raise SystemExit(
+                f"{EXEMPTIONS_PATH}: exemptions[{idx}] ({cluster}/{namespace}) "
+                "needs a non-empty reason"
+            )
+        if namespace in out[cluster]:
+            raise SystemExit(
+                f"{EXEMPTIONS_PATH}: duplicate exemption {cluster}/{namespace}"
+            )
+        out[cluster][namespace] = " ".join(reason.split())
+    return out
+
+
+def main() -> int:
+    exemptions = load_exemptions()
+    failures: list[str] = []
+    stale: list[str] = []
+
+    for cluster in CLUSTERS:
+        pvc_ns = pvc_namespaces(cluster)
+        covered = scheduled_namespaces(cluster)
+        exempt = exemptions[cluster]
+
+        for namespace in sorted(pvc_ns - covered - set(exempt)):
+            failures.append(
+                f"{cluster}/{namespace}: declares a PVC/VCT/CNPG volume in Git "
+                f"but is in no Velero Schedule and has no exemption"
+            )
+
+        for namespace in sorted(set(exempt) - pvc_ns):
+            # Covered-by-schedule + exempt is also stale: exemption no longer needed.
+            stale.append(
+                f"{cluster}/{namespace}: exemption has no matching Git-declared "
+                f"PVC namespace on this cluster (remove or fix the entry)"
+            )
+        for namespace in sorted(set(exempt) & covered):
+            stale.append(
+                f"{cluster}/{namespace}: exempted but also listed in a Schedule "
+                f"(drop the exemption or the schedule membership)"
+            )
+
+    if failures or stale:
+        print("velero PVC schedule coverage check failed:", file=sys.stderr)
+        for line in failures + stale:
+            print(f"  {line}", file=sys.stderr)
+        if failures:
+            print(
+                "  add a Schedule includedNamespaces entry, or document the "
+                "decision in "
+                "kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml",
+                file=sys.stderr,
+            )
+        return 1
+
+    covered_total = sum(len(scheduled_namespaces(c)) for c in CLUSTERS)
+    exempt_total = sum(len(exemptions[c]) for c in CLUSTERS)
+    print(
+        f"✓ velero PVC schedule coverage "
+        f"(schedules cover namespaces; {exempt_total} documented exemptions)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+PY

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -163,6 +163,7 @@ run_capped "notification-scope" tools/check-notification-scope.sh
 run_capped "cliproxy-pi-bridge" tools/check-cliproxy-pi-bridge.sh
 run_capped "zot-upload-affinity" tools/check-zot-upload-affinity.sh
 run_capped "mimir-rule-load-path" tools/check-mimir-rules.sh
+run_capped "velero-pvc-coverage" tools/check-velero-pvc-coverage.sh
 
 if [ "$QUICK" = 1 ]; then
   # Quick syntax check: validate kustomize build on a representative sample

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -599,6 +599,31 @@ assert "success prints one ✓ line" \
   grep -q '^✓ diagram OK:' <<<"$("$T/check-diagram.sh" 2>/dev/null)"
 rm -rf "$dtmp"
 
+# ---------------------------------------------------------------- check-velero-pvc-coverage.sh
+# Offline: mutate a real Schedule fixture, prove the guard fires, restore it.
+section "check-velero-pvc-coverage.sh"
+exits  "current tree passes coverage gate" 0 "$T/check-velero-pvc-coverage.sh"
+assert "success mentions exemptions" \
+  grep -q 'documented exemptions' <<<"$("$T/check-velero-pvc-coverage.sh" 2>/dev/null)"
+
+hsbak="$(mktemp)"
+cp "$ROOT/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml" "$hsbak"
+python3 - "$ROOT/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml" <<'PY'
+import pathlib, sys, yaml
+p = pathlib.Path(sys.argv[1])
+docs = [d for d in yaml.safe_load_all(p.read_text()) if isinstance(d, dict)]
+for doc in docs:
+    if doc.get("kind") == "Schedule":
+        doc.setdefault("spec", {}).setdefault("template", {})["includedNamespaces"] = ["tinyauth"]
+p.write_text("---\n" + "\n---\n".join(yaml.safe_dump(d, sort_keys=False) for d in docs))
+PY
+exits  "dropping home from schedule fails the gate" 1 "$T/check-velero-pvc-coverage.sh"
+assert "failure names ottawa/home" \
+  grep -q 'ottawa/home' <<<"$("$T/check-velero-pvc-coverage.sh" 2>&1 || true)"
+cp "$hsbak" "$ROOT/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml"
+rm -f "$hsbak"
+exits  "restored schedule passes again" 0 "$T/check-velero-pvc-coverage.sh"
+
 # ---------------------------------------------------------------- summary
 printf '\n== %d passed, %d failed ==\n' "$pass" "$fail"
 [ "$fail" = 0 ]


### PR DESCRIPTION
## Summary

Detection half of Forgejo **corp/bhaiya#718**: make "namespace declares a PVC in Git but has no Velero Schedule" impossible to ship silently.

**CI check, not Mimir** — Schedule `includedNamespaces` is not a metric; a repo-side gate fails on the PR before the gap lands.

### What landed

- `tools/check-velero-pvc-coverage.sh` — per cluster:
  1. Flux Kustomizations → `targetNamespace` + `path`
  2. path declares `PersistentVolumeClaim`, `volumeClaimTemplates`, or CNPG `Cluster` storage
  3. must be in some Velero Schedule `includedNamespaces` **or** the exemption list
- Wired into `tools/check.sh` (same gate as flate CI)
- Exemption log: `kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml` (**not** in Flux kustomization — no CRD)
- Offline proof in `tools/tests/run.sh`: drop `home` from `ottawa/home-backup` → gate fails → restore → passes

### Immich (Raj 2026-09-07)

Exempt as an **explicit decision**, not UNRESOLVED:

> photo libraries deliberately not backed up … immich-postgres remains protected separately via GarageBucket/CNPG — DB coverage must not be read as "immich is backed up."

### Seeded exemptions (honest)

| Cluster | Namespace | Kind |
|---------|-----------|------|
| ottawa / robbinsdale | **immich** | **Decision** (libraries out; DB separate) |
| ottawa | firefly, woodpecker | `UNRESOLVED:` #718 |
| ottawa | teslamate, mimir, cephfs-proof, tailscale-examples | documented non-Velero / disposable |
| robbinsdale | tailscale-examples | demo |
| stpetersburg | ai | rebuildable model cache / hostPath |

### Verify locally

```bash
tools/check-velero-pvc-coverage.sh   # pass
# mutate a schedule → fail; restore → pass
tools/tests/run.sh                   # includes negative test
```

**Do not merge** until reviewed.
