### PR TITLE
fix(mimir): stop Helm gating the release on ring readiness (#713)

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -31,11 +31,21 @@ spec:
   upgrade:
     cleanupOnFail: true
     timeout: 25m
+    # Helm must not gate this release on Mimir readiness. Its ring components
+    # (compactor/store-gateway/ingester) legitimately take 1-5m to join and the
+    # ingester's graceful shutdown flushes its whole TSDB head (grace 1200s).
+    # Helm reported "release is in a failed state" seconds into every upgrade
+    # and remediated, so the timeouts above were never even reached
+    # (corp/bhaiya#713). Flux health-checks the Kustomization separately and the
+    # ring self-heals, so waiting here buys nothing and blocked delivery of
+    # #2765's query-window config for four PRs.
+    disableWait: true
+    disableWaitForJobs: true
     remediation:
       # 'retry' is NOT a valid strategy (live CRD accepts only rollback |
       # uninstall), and setting it fails the whole Kustomization dry-run.
-      # The 15m timeouts above are the actual fix: a healthy ring join no
-      # longer times out, so remediation is not triggered at all.
+      # Timeouts alone were never the fix (see disableWait above); they are
+      # kept as a backstop for a genuinely hung operation.
       retries: 2
   postRenderers:
     - kustomize:


### PR DESCRIPTION
Raj approved this direction. It is the third and, I believe, correct attempt at corp/bhaiya#713 — the first two treated a bound that is never reached.

## Why the timeouts were the wrong lever

helm-controller log, with the 25m timeout already applied:

```
running "upgrade" action with timeout of 25m0s
release is in a failed state          <- seconds later, not 25m
running "rollback" action with timeout of 25m0s
```

Helm evaluates the release state, declares failure, and remediates almost immediately. **Neither km#2766's 15m nor km#2772's 25m was ever reached**, so raising the number could not have helped. The observable result was a self-recovering upgrade→rollback cycle: v74 reached `deployed` (a *rollback*, carrying the old values), then the next upgrade failed, then it rolled back again.

That cycle is not benign. Each iteration restarts ring members, and with `replication_factor: 1` an unready `mimir-ingester-0` gates **every recent query** — `count(up)` returned 259 several times and then returned nothing. So it caused intermittent blindness on recent metrics, which is precisely the #674 failure mode this thread set out to reduce.

## Change

```yaml
upgrade:
  disableWait: true
  disableWaitForJobs: true
```

Helm stops gating the release on Mimir readiness. That is appropriate here for reasons specific to this workload:

- Ring components (`compactor`, `store-gateway`, `ingester`) log `waiting until ring topology is stable, min_waiting=1m0s max_waiting=5m0s` and reach ready with `restarts=0`. They are self-healing; Helm watching them adds no safety.
- The ingester's graceful shutdown flushes its **entire TSDB head** to long-term storage, with `terminationGracePeriodSeconds: 1200`. Observed live: an 18-minute drain, 0 restarts, continuously logging `uploading new block to long-term storage`, then replaced cleanly. Helm has no business declaring that a stall.
- **Flux still health-checks the Kustomization separately**, so we do not lose failure detection — we lose Helm's *duplicate*, wrong-shaped version of it.

The timeouts stay as a backstop for a genuinely hung operation, and the stale comment claiming they were "the actual fix" is corrected.

## Verified with the check CI does not run

```
$ kubectl apply --dry-run=server -f .../mimir-ottawa/helmrelease.yaml
helmrelease.helm.toolkit.fluxcd.io/mimir created (server dry run)
```

This matters more than usual here. km#2766 introduced `remediation.strategy: retry` — **not a valid value** (the CRD accepts only `rollback` or `uninstall`) — and it passed all 9 CI checks while failing the HelmRelease dry-run in production, which failed the entire `mimir` Kustomization and froze every change to that path. Fixed in km#2768, gap filed as corp/bhaiya#715. So `disableWait` being a real field was checked against the live CRD rather than assumed.

## Acceptance — do not accept a `deployed` release as proof

1. `helmrelease/mimir` → `Ready=True` without manual suspend/resume
2. `kubectl -n mimir get cm mimir-config -o jsonpath='{.data.mimir\.yaml}' | grep query_store_after` → **`4h`**
3. querier pods younger than the merge

Criterion 2 is the only one that counts. A successful *rollback* also produces a `deployed` release, carrying the **old** values — that is exactly how v74 read `deployed` while `query_store_after` was absent. km#2765's config has never reached the cluster across four PRs; this is the attempt that should change that.
