### PR TITLE
feat(stpetersburg): kopiur Direct backup for Home Assistant (#695)

### DIFF
--- a/docs/incidents/695-kopiur-stp-ha.md
+++ b/docs/incidents/695-kopiur-stp-ha.md
@@ -1,0 +1,28 @@
+# #695 — StP HA capture via kopiur (Direct)
+
+**Status:** GitOps draft on `work/kopiur-stp-ha`. **Not merged / not applied.**  
+VolSync is out (Raj). Velero FSB still skips hostPath; leave `home-assistant-backup` + km#2764 alone.
+
+## Constraints encoded in manifests
+
+| # | Constraint | Where |
+|---|------------|--------|
+| 1 | `copyMethod: Direct` **explicit** | `SnapshotPolicy` |
+| 2 | Source `readOnly: true` | `SnapshotPolicy.sources[]` |
+| 3 | Dedicated bucket `kopiur-stpetersburg` + own Kopia password | GarageBucket + ESO Password |
+| 4 | `maintenance.enabled: false` (km#2767 RAW) | `Repository` |
+| 5 | Chart `0.10.7` + image digests pinned | `HelmRelease` |
+| 6 | StP only | `kubernetes/apps/stpetersburg/kopiur` |
+
+Root mover + `privileged-movers` annotation: live `/config` has root-owned `0600` files; mount stays read-only.
+
+## Acceptance (do not claim success without)
+
+1. A `Snapshot` for `homeassistant-config` reaches **Succeeded** with **non-zero** `status.stats.files*` (zero files = UID mismatch false success).
+2. `Restore` into a **new empty PVC**; byte-compare critical paths (`configuration.yaml`, `home-assistant_v2.db`, `.storage/`) against source.
+
+“Schedule exists” is **not** acceptance.
+
+## License
+
+kopiur is **AGPL-3.0-only**.

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -30,8 +30,8 @@ diagram in the [README](../../README.md#architecture).
 |---|---:|---:|---:|
 | `ottawa` | 4 | 59 | 122 |
 | `robbinsdale` | 3 | 43 | 87 |
-| `stpetersburg` | 3 | 39 | 79 |
-| **total** | **10** | **141** | **288** |
+| `stpetersburg` | 3 | 40 | 82 |
+| **total** | **10** | **142** | **291** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -285,7 +285,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Networking, ingress and identity | `tailscale-system` | `tailscale-system-app` |
 | Networking, ingress and identity | `tinyauth-egress` | `tinyauth-egress` → ns `tinyauth` |
 | Storage and data services | `cnpg-system` | `cnpg-system` |
-| Storage and data services | `garage` | `garage`, `garage-bucket`, `garage-keys`, `garage-nodes-stpetersburg`, `garage-reference-grants`, `garage-velero-bucket`, `garage-webui` |
+| Storage and data services | `garage` | `garage`, `garage-bucket`, `garage-keys`, `garage-kopiur-stpetersburg-bucket`, `garage-nodes-stpetersburg`, `garage-reference-grants`, `garage-velero-bucket`, `garage-webui` |
 | Storage and data services | `garage-operator-system` | `garage-operator-system-install` |
 | Storage and data services | `local-path-storage` | `local-path-storage` |
 | Storage and data services | `snapshot-controller` | `snapshot-controller` |
@@ -304,12 +304,15 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | GPU, RDMA and inference | `rdma-shared-dp` | `rdma-shared-dp` → ns `rdma-system` |
 | Application workloads | `home-assistant` | `home-assistant` |
 | Application workloads | `homer-operator` | `homer-operator-install` |
+| Application workloads | `kopiur` | `home-assistant-kopiur` → ns `home-assistant`, `kopiur` → ns `kopiur-system` |
 
 Pointers whose objects land outside their directory's namespace — use the right-hand column with `kubectl -n`:
 
 | Flux Kustomization | Pointer directory | Actual namespace |
 |---|---|---|
 | `actions-runner-controller-runners` | `arc-systems` | `arc-runners` |
+| `home-assistant-kopiur` | `kopiur` | `home-assistant` |
+| `kopiur` | `kopiur` | `kopiur-system` |
 | `rdma-shared-dp` | `rdma-shared-dp` | `rdma-system` |
 | `tinyauth-egress` | `tinyauth-egress` | `tinyauth` |
 | `tuppr` | `tuppr` | `system-upgrade` |

--- a/kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket/bucket.yaml
+++ b/kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket/bucket.yaml
@@ -1,0 +1,26 @@
+---
+# DEDICATED Garage bucket for StP kopiur — do NOT reuse the Velero `velero`
+# bucket. Kopia allows one maintenance owner per repository; Velero already
+# runs uploaderType: kopia against `velero`. Sharing would mean lease
+# contention on `_maintenance` (see kopiur-eval / km#2767).
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: kopiur-stpetersburg
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  globalAlias: kopiur-stpetersburg
+  quotas:
+    # HA /config is ~12MiB; leave headroom for retention + indexes.
+    maxSize: 5Gi
+    maxObjects: 100000
+  keyPermissions:
+    - keyRef:
+        name: kopiur-stpetersburg-key
+        namespace: home-assistant
+      read: true
+      write: true
+      owner: true

--- a/kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket/key.yaml
+++ b/kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket/key.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: kopiur-stpetersburg-key
+  namespace: home-assistant
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  name: "Kopiur StPetersburg HA Repository Key"
+  secretTemplate:
+    # Own credentials Secret for the kopiur Repository — not velero-credentials-*.
+    name: kopiur-stpetersburg-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    includeEndpoint: false
+    includeRegion: false
+  bucketPermissions:
+    - bucketRef:
+        name: kopiur-stpetersburg
+        namespace: garage
+      read: true
+      write: true
+      owner: true
+---
+# Cross-namespace grant so GarageBucket in `garage` may reference this key.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-kopiur-stpetersburg-key
+  namespace: home-assistant
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: kopiur-stpetersburg-key

--- a/kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./bucket.yaml
+  - ./key.yaml

--- a/kubernetes/apps/base/garage/garage/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage/reference-grants.yaml
@@ -25,6 +25,11 @@ spec:
       namespace: hermes
     - kind: GarageKey
       namespace: home
+    # kopiur Repository for StP homeassistant-config (#695): the GarageKey in
+    # home-assistant must reference GarageCluster garage/garage. Without this
+    # the vgaragekey webhook denies it and the Kustomization never converges.
+    - kind: GarageKey
+      namespace: home-assistant
     - kind: GarageKey
       namespace: tailscale-examples
     - kind: GarageKey

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/README.md
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/README.md
@@ -1,0 +1,16 @@
+# StP Home Assistant — kopiur (Direct)
+
+Narrow protect for `homeassistant-config` (local-path → hostPath on orin-0).
+
+Constraints (also comments on the CRs):
+
+1. `copyMethod: Direct` explicit (default Snapshot fails hostPath).
+2. Source mount `readOnly: true` (never live-chgrp the only copy).
+3. Dedicated Garage bucket `kopiur-stpetersburg` + own Kopia password (not Velero).
+4. `Repository.spec.maintenance.enabled: false` (Garage degraded `_maintenance` RAW / km#2767).
+5. Chart `0.10.7` + controller/webhook/mover digests pinned.
+6. StP only — OT/RB HA already have Velero PVBs.
+
+**Acceptance (not “schedule exists”):** a `Snapshot` reaches Succeeded with
+non-zero files, then a `Restore` into a **new empty PVC** byte-compares to
+source. Leave the Velero `home-assistant-backup` schedule alone (km#2764).

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kopia-password.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kopia-password.yaml
@@ -1,0 +1,38 @@
+---
+# Own Kopia repository encryption password — NOT COMMON_RESTIC_SECRET and NOT
+# anything from the Velero credential Secrets. Lose this and the snapshots are
+# unrecoverable; ESO persists the generated value in cluster Secret state.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: kopiur-stpetersburg-kopia-password
+  namespace: home-assistant
+spec:
+  length: 64
+  digits: 16
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-stpetersburg-kopia-password
+  namespace: home-assistant
+spec:
+  # Long interval: password must stay stable for the life of the repository.
+  refreshInterval: 8760h
+  target:
+    name: kopiur-stpetersburg-kopia-password
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Repository.spec.encryption.passwordSecretRef.key expects this name.
+        KOPIA_PASSWORD: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: kopiur-stpetersburg-kopia-password

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kustomization.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home-assistant
+resources:
+  - ./kopia-password.yaml
+  - ./repository.yaml
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/repository.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/repository.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: kopiur-stpetersburg
+  namespace: home-assistant
+spec:
+  backend:
+    s3:
+      # DEDICATED bucket — never `velero`. Separate Kopia repo identity from
+      # Velero's uploaderType:kopia BSL (one maintenance owner per repo).
+      bucket: kopiur-stpetersburg
+      prefix: home-assistant/config/
+      # Bare host:port — no scheme (tls.disableTls below).
+      endpoint: ${COMMON_S3_ENDPOINT}
+      region: garage
+      tls:
+        disableTls: true
+      auth:
+        # GarageKey-minted AWS keys only (no KOPIA_PASSWORD in that Secret).
+        secretRef:
+          name: kopiur-stpetersburg-s3
+  encryption:
+    passwordSecretRef:
+      name: kopiur-stpetersburg-kopia-password
+      key: KOPIA_PASSWORD
+  create:
+    enabled: true
+  # Maintenance DISABLED — kopiur Maintenance runs real `kopia maintenance`,
+  # which PUTs `_maintenance` then immediately HEADs it. Under Garage
+  # consistencyMode:degraded that HEAD can see a stale replica and refuse with
+  # a false clock-skew error (km#2767 / #575). Do NOT flip Garage to
+  # consistent for this. ~12MiB HA config: unbounded growth is acceptable;
+  # a broken maintenance loop is not.
+  maintenance:
+    enabled: false

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotpolicy.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: homeassistant-config
+  namespace: home-assistant
+spec:
+  repository:
+    kind: Repository
+    name: kopiur-stpetersburg
+  # copyMethod MUST be Direct and MUST be explicit. Default is now Snapshot,
+  # which fails on this local-path→hostPath PVC with SourceNotCSIProvisioned
+  # (#695 blocker). Direct mounts the live PVC for kopia — same capability
+  # VolSync Direct had; Velero FSB refuses hostPath.
+  copyMethod: Direct
+  sources:
+    - pvc:
+        name: homeassistant-config
+      # Keep Direct mount READ-ONLY (kopiur default). readOnly:false would
+      # make kubelet fsGroup-chgrp the LIVE PVC — HA's only copy. Never.
+      readOnly: true
+  retention:
+    keepDaily: 14
+    keepWeekly: 4
+    keepMonthly: 3
+  mover:
+    # Live /config has root-owned 0600 files under .storage/ (auth, etc.).
+    # Default mover UID 65532 would Succeed with 0 files. Root mover is
+    # required to READ; mount stays read-only (above). Namespace must carry
+    # kopiur.home-operations.com/privileged-movers=true.
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotschedule.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotschedule.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: homeassistant-config
+  namespace: home-assistant
+spec:
+  policyRef:
+    name: homeassistant-config
+  schedule:
+    # Daily; acceptance is a completed Snapshot + restore drill, not this cron.
+    cron: "0 12 * * *"
+    jitter: 30m

--- a/kubernetes/apps/base/kopiur/kopiur/helmrelease.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/helmrelease.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+  namespace: kopiur-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: kopiur
+      # PIN chart version — kopiur is alpha (v1alpha1); docs record a breaking
+      # 0.5.x → 0.6.0 CRD/values move. Do not float on latest.
+      version: "0.10.7"
+      sourceRef:
+        kind: HelmRepository
+        name: home-operations-kopiur
+        namespace: kopiur-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # License: AGPL-3.0-only (chart annotation). Flag if that is a problem for
+    # this fleet — see PR body.
+    installScope: cluster
+
+    # PIN controller image digest (from oci chart 0.10.7 values). Digest wins
+    # over tag so a re-pulled :0.10.7 cannot change bits under us.
+    image:
+      repository: ghcr.io/home-operations/kopiur-controller
+      tag: "0.10.7"
+      digest: "sha256:ce50917db136e4f19b480724d5cff7a4e1eeed9431e737aeb7808b2693dcefe5"
+      pullPolicy: IfNotPresent
+
+    webhook:
+      image:
+        repository: ghcr.io/home-operations/kopiur-webhook
+        tag: "0.10.7"
+        digest: "sha256:788171c81579946053479fb81c7762564471761c3bdf45721dc6a0eacebfc6fa"
+        pullPolicy: IfNotPresent
+
+    mover:
+      image:
+        repository: ghcr.io/home-operations/kopiur-mover
+        tag: "0.10.7"
+        # PIN mover digest — this is the Job that mounts HA's PVC.
+        digest: "sha256:b6efbb3dedb88a87bc01f089f5f5e61dc3b306a4003a604c3bf01b1d3c335033"
+        pullPolicy: IfNotPresent
+
+    # StP: tolerate control-plane so Direct movers can co-locate on orin-0
+    # with the RWO local-path PVC (HA is pinned there).
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/kubernetes/apps/base/kopiur/kopiur/helmrepository.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/helmrepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: home-operations-kopiur
+  namespace: kopiur-system
+spec:
+  interval: 1h
+  type: oci
+  # Published OCI chart; chart version + image digests are pinned on the HelmRelease.
+  url: oci://ghcr.io/home-operations/charts

--- a/kubernetes/apps/base/kopiur/kopiur/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+resources:
+  - ./namespace.yaml
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/kopiur/kopiur/namespace.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    app.kubernetes.io/name: kopiur
+    app.kubernetes.io/part-of: kopiur
+    # Operator namespace only — workload CRs live in home-assistant.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/kubernetes/apps/stpetersburg/garage/garage.yaml
+++ b/kubernetes/apps/stpetersburg/garage/garage.yaml
@@ -116,3 +116,26 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+# Dedicated kopiur HA repo bucket — StP only; do not share with Velero.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-kopiur-stpetersburg-bucket
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage-bucket
+    - name: home-assistant
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-kopiur-stpetersburg-bucket
+  path: ./kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/home-assistant/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/home-assistant/namespace.yaml
@@ -8,3 +8,8 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
+  annotations:
+    # Root mover required to READ root-owned 0600 files under /config/.storage
+    # (auth, etc.). Direct mount stays readOnly:true — this opt-in is for UID 0
+    # on the mover Job only, not for writing the live PVC.
+    kopiur.home-operations.com/privileged-movers: "true"

--- a/kubernetes/apps/stpetersburg/kopiur/kopiur.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur/kopiur.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+  namespace: flux-system
+spec:
+  targetNamespace: kopiur-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kopiur
+      app.kubernetes.io/part-of: kopiur
+  path: ./kubernetes/apps/base/kopiur/kopiur
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+---
+# HA recipe CRs (Repository / SnapshotPolicy / SnapshotSchedule). Depends on
+# the operator CRDs and the dedicated Garage bucket+key.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: home-assistant-kopiur
+  namespace: flux-system
+spec:
+  targetNamespace: home-assistant
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: home-assistant-kopiur
+      app.kubernetes.io/part-of: kopiur
+  dependsOn:
+    - name: kopiur
+    - name: garage-kopiur-stpetersburg-bucket
+    - name: home-assistant
+  path: ./kubernetes/apps/base/home-assistant/home-assistant/kopiur
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/kopiur/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./kopiur.yaml

--- a/kubernetes/apps/stpetersburg/kopiur/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    app.kubernetes.io/name: kopiur
+    app.kubernetes.io/part-of: kopiur
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./gvisor
   - ./home
   - ./home-assistant
+  - ./kopiur
   - ./homer-operator
   - ./kro-system
   - ./kube-system


### PR DESCRIPTION
## Summary

Narrow **#695** capture for StP `homeassistant-config` (local-path → hostPath on orin-0) using [kopiur](https://github.com/home-operations/kopiur) instead of VolSync.

**License:** kopiur is **AGPL-3.0-only** — flag if that is a problem for this fleet.

### Constraints (from kopiur-eval; encoded as comments on the CRs)

1. **`copyMethod: Direct` explicit** — default Snapshot fails hostPath (`SourceNotCSIProvisioned`).
2. **Source `readOnly: true`** — never live-chgrp HA’s only copy.
3. **Dedicated Garage bucket `kopiur-stpetersburg`** + own Kopia password (ESO Password generator) — **not** the Velero `velero` bucket/repo (one Kopia maintenance owner per repo).
4. **`Repository.spec.maintenance.enabled: false`** — avoid Garage `degraded` `_maintenance` RAW / false clock-skew (**km#2767**). Do **not** flip Garage to `consistent`. Tiny ~12 MiB repo: growth OK; broken maintenance loop not.
5. **Chart `0.10.7` + controller/webhook/mover digests pinned** (alpha churn / breaking 0.5→0.6).
6. **StP only** — Ottawa/Robbinsdale HA already have working Velero PVBs.

Also: root mover + `kopiur.home-operations.com/privileged-movers=true` on `home-assistant` so root-owned `0600` `.storage/*` files are readable; mount stays read-only.

### Left alone on purpose

- Velero `home-assistant-backup` schedule **unchanged** — km#2764 critical warning stays the signal that hostPath skip is still happening until CSI SMB.

### Acceptance (do **not** claim success without)

“Schedule exists” created #695. Required:

1. A `Snapshot` for `homeassistant-config` reaches **Succeeded** with **non-zero** files (zero files = UID mismatch false success).
2. `Restore` into a **new empty PVC**; byte-compare `configuration.yaml` / `home-assistant_v2.db` / `.storage/` against source.

### Layout

- Operator: `kubernetes/apps/base/kopiur` ← `stpetersburg/kopiur`
- Bucket/key: `kubernetes/apps/base/garage/garage-kopiur-stpetersburg-bucket`
- Recipe: `kubernetes/apps/base/home-assistant/home-assistant/kopiur`
- Notes: `docs/incidents/695-kopiur-stp-ha.md`

**Do not merge** until reviewed; post-merge still needs the acceptance drill above.
