### PR TITLE
fix(mimir): remove invalid querier.query_ingesters_within (crashloop)

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -146,8 +146,14 @@ spec:
           # until blocks age past the boundary. Shrink the ingester-only
           # window without paying for a second ~4GiB RSS replica. Does not
           # protect the unshipped head; RF/replica HA remains a capacity call.
+          # NOTE: query_ingesters_within is NOT valid under `querier` in this
+          # Mimir version — it crashes every component at config parse:
+          #   field query_ingesters_within not found in type querier.Config
+          # query_store_after alone achieves the #674 goal: queries older than
+          # 4h go to the store-gateway (which serves blocks >2h via
+          # ignore_blocks_within), and the ingester default window still covers
+          # everything newer. Do not re-add it here.
           query_store_after: 4h
-          query_ingesters_within: 5h
         limits:
           compactor_blocks_retention_period: 7d
           ingestion_rate: 500000


### PR DESCRIPTION
**Mimir is degraded right now.** Every new pod is in `CrashLoopBackOff` with 9 restarts; the previous generation is still serving, so queries return 500 via a downed query-scheduler rather than going fully dark.

```
error loading config from /etc/mimir/mimir.yaml: error parsing config file:
yaml: unmarshal errors:
  line 97: field query_ingesters_within not found in type querier.Config
```

`querier.query_ingesters_within` does not exist in this Mimir version. km#2765 set it to `5h`. Every component that parses the config dies: compactor, distributor, ingester, overrides-exporter, querier, query-frontend, query-scheduler.

## Why it took four hours to surface, which is the real lesson

This bad ConfigMap was merged in km#2765 and **could not roll**, because Helm's readiness wait was failing the upgrade for an entirely unrelated reason (corp/bhaiya#713). So a broken config sat in git, "delivered" by every check we had, while the cluster kept running the previous good one.

Then km#2774 removed that wait — correctly, for the reasons in #713 — the upgrade finally applied, and the bad config rolled.

**Helm's wait was accidentally protecting production from a config error.** Removing it was still right; the wait was blocking every legitimate change too. But it means #713's fix converted a *delivery* failure into a *runtime* failure, and I should have anticipated that the first successful upgrade in four hours would apply four hours of accumulated config.

## Change

Remove the invalid field. `query_store_after: 4h` alone achieves corp/bhaiya#674:

- queries older than 4h route to the store-gateway, which serves blocks older than 2h via `ignore_blocks_within: 2h`
- the ingester's default window covers everything newer

So the recent-query blind window is still reduced from ~12h to ~4h. The overlap that `ignore_blocks_within` provides is what makes `query_ingesters_within` unnecessary rather than merely unavailable.

## A third validation gap, distinct from corp/bhaiya#715

Worth recording, because it is not the same bug as the last two:

| defect | what would have caught it |
| --- | --- |
| km#2766 `remediation.strategy: retry` | server-side dry-run (CRD schema) |
| km#2775 missing GarageReferenceGrant | server-side dry-run of the whole Kustomization |
| **this** | **neither** — the HelmRelease is schema-valid; the invalid key is inside `spec.values`, which no API server validates |

Helm values are opaque to Kubernetes. A server-side dry-run accepts this HelmRelease happily because `values` is a free-form object; only Mimir's own config parser rejects it, at container start. So #715's fix must also cover **app config inside Helm values**, and for Mimir specifically the cheap check is rendering the chart and running `mimir -config.file=... -modules` or equivalent validation in CI.

## Acceptance

1. no `CrashLoopBackOff` pods in `mimir`
2. `count(up)` returns data through the gateway (currently 500)
3. `mimir-config` still contains `query_store_after: 4h` and `ignore_blocks_within: 2h`
4. `mimir-robbinsdale` and `mimir-stpetersburg` tenants queryable — they share this Mimir and were collateral

Criterion 4 matters: an agent authoring the SMART sector-growth alert (km#2777) could not validate its expression against the Robbinsdale tenant because of this, and fell back to the exporter's `/metrics`. That validation should be redone once queries work.
