### PR TITLE
fix(stpetersburg): kopiur Direct mover scheduling without invalid CRD fields

### DIFF
--- a/docs/incidents/695-kopiur-stp-ha.md
+++ b/docs/incidents/695-kopiur-stp-ha.md
@@ -1,6 +1,6 @@
 # #695 — StP HA capture via kopiur (Direct)
 
-**Status:** GitOps draft on `work/kopiur-stp-ha`. **Not merged / not applied.**  
+**Status:** merged via km#2775; apply fix for mover scheduling on `work/kopiur-mover-schedule`.  
 VolSync is out (Raj). Velero FSB still skips hostPath; leave `home-assistant-backup` + km#2764 alone.
 
 ## Constraints encoded in manifests
@@ -14,7 +14,25 @@ VolSync is out (Raj). Velero FSB still skips hostPath; leave `home-assistant-bac
 | 5 | Chart `0.10.7` + image digests pinned | `HelmRelease` |
 | 6 | StP only | `kubernetes/apps/stpetersburg/kopiur` |
 
-Root mover + `privileged-movers` annotation: live `/config` has root-owned `0600` files; mount stays read-only.
+## Apply fix (invalid `SnapshotPolicy.spec.mover.tolerations`)
+
+Installed CRD: `spec.mover` allows only `cache`, `inheritSecurityContextFrom`,
+`podSecurityContext`, `privilegedMode`, `resources`, `securityContext`,
+`ttlSecondsAfterFinished` — **no tolerations**.
+
+How Direct movers still schedule onto tainted orin-0:
+
+1. **Not** HelmRelease root `tolerations` — chart model: root = controller only.
+2. **Not** `inheritSecurityContextFrom` — security only; HA also pins no `runAsUser`.
+3. **Yes:** `Repository.moverDefaults.sourceColocation: Auto` (default) pins the
+   mover to the RWO holder node and **unions the holder pod's tolerations**.
+   `homeassistant-0` already has `node-role.kubernetes.io/control-plane` Exists
+   NoSchedule.
+4. **Yes:** `Repository.moverDefaults.tolerations` (CRD-valid) as explicit base.
+
+Root read access: `securityContext.runAsUser: 0` + `runAsNonRoot: false` **and**
+`privilegedMode: true` (namespace-gated; preserve ownership on restore). Mount
+stays `readOnly: true`.
 
 ## Acceptance (do not claim success without)
 

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/README.md
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/README.md
@@ -11,6 +11,19 @@ Constraints (also comments on the CRs):
 5. Chart `0.10.7` + controller/webhook/mover digests pinned.
 6. StP only — OT/RB HA already have Velero PVBs.
 
+Root mover (`runAsUser: 0` + `privilegedMode: true`) and Namespace
+`privileged-movers` annotation: live `/config` has root-owned `0600` files;
+mount stays read-only. `inheritSecurityContextFrom` is unusable — HA pins no
+`runAsUser` in the pod spec (image USER only → InheritPinnedNoUid / empty tree).
+
+**Scheduling:** `SnapshotPolicy.spec.mover` has **no** `tolerations` field
+(schema reject). Direct movers reach tainted orin-0 via
+`Repository.moverDefaults.sourceColocation: Auto` (default): pin to the RWO
+holder node and **union the holder pod's tolerations** (HA already tolerates
+`node-role.kubernetes.io/control-plane`). Explicit
+`moverDefaults.tolerations` is belt-and-suspenders. HelmRelease root
+`tolerations` only affect the **controller** Deployment, not mover Jobs.
+
 **Acceptance (not “schedule exists”):** a `Snapshot` reaches Succeeded with
 non-zero files, then a `Restore` into a **new empty PVC** byte-compares to
 source. Leave the Velero `home-assistant-backup` schedule alone (km#2764).

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/repository.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/repository.yaml
@@ -34,3 +34,24 @@ spec:
   # a broken maintenance loop is not.
   maintenance:
     enabled: false
+  moverDefaults:
+    # Scheduling for Direct movers on tainted orin-0:
+    # - HelmRelease top-level `tolerations` apply to the CONTROLLER pod only
+    #   (chart model: root = controller; mover Jobs do not inherit them).
+    # - SnapshotPolicy.spec.mover has NO tolerations field (CRD reject).
+    # - sourceColocation Auto (default) pins the mover to the RWO holder node
+    #   and unions the holder pod's tolerations — HA already carries
+    #   node-role.kubernetes.io/control-plane Exists NoSchedule, so Direct
+    #   movers get that toleration automatically when homeassistant-0 holds
+    #   the PVC.
+    # - This explicit moverDefaults.tolerations is a belt-and-suspenders base
+    #   so bootstrap/maintenance-shaped Jobs (if ever re-enabled) and any
+    #   moment the PVC is briefly unheld still tolerate the CP taint. Do not
+    #   set sourceColocation: Disabled — that would drop holder-union and
+    #   leave Direct movers Pending on the taint.
+    sourceColocation:
+      mode: Auto
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotpolicy.yaml
@@ -25,13 +25,22 @@ spec:
     keepMonthly: 3
   mover:
     # Live /config has root-owned 0600 files under .storage/ (auth, etc.).
-    # Default mover UID 65532 would Succeed with 0 files. Root mover is
-    # required to READ; mount stays read-only (above). Namespace must carry
-    # kopiur.home-operations.com/privileged-movers=true.
+    # Default mover UID 65532 would Succeed with 0 files — a silent empty
+    # backup. inheritSecurityContextFrom cannot help: HA's pod spec pins no
+    # runAsUser (image USER only), so inheritance would fall back to 65532
+    # (InheritPinnedNoUid). Explicit root is required to READ.
+    #
+    # privilegedMode is the CRD's namespace-gated elevation flag (pairs with
+    # kopiur.home-operations.com/privileged-movers on the Namespace). It alone
+    # does not set UID 0 for backup reads — docs pair it with runAsUser: 0
+    # (and use privilegedMode especially so restores can preserve ownership).
+    privilegedMode: true
     securityContext:
       runAsUser: 0
       runAsNonRoot: false
-    tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
+    # Do NOT put tolerations here — SnapshotPolicy.spec.mover has no
+    # tolerations field (schema reject / Flux dry-run fail). Scheduling onto
+    # tainted orin-0 is handled by Repository.sourceColocation Auto (default):
+    # Direct movers pin to the RWO holder node and union the holder pod's
+    # tolerations (HA already tolerates control-plane). Optional explicit base
+    # tolerations live on Repository.spec.moverDefaults.tolerations only.


### PR DESCRIPTION
## Summary

Fixes Flux apply failure after km#2775:

```
SnapshotPolicy/... dry-run failed: .spec.mover.tolerations: field not declared in schema
```

**Do not** just delete the tolerations and ship — Direct movers must run on **orin-0** (`control-plane:NoSchedule`) with the RWO local-path PVC. A Pending Job forever is a silent non-backup.

### Real scheduling mechanism (verified in upstream docs + CRD)

| Path | Reaches mover Jobs? |
|------|---------------------|
| HelmRelease **root** `tolerations` | **No** — chart model: root = **controller** only |
| `SnapshotPolicy.spec.mover.tolerations` | **No** — not in CRD (this failure) |
| `inheritSecurityContextFrom` | **Security only**; HA also pins **no** `runAsUser` in the pod spec → would fall back to UID 65532 / empty tree |
| **`Repository.moverDefaults.sourceColocation: Auto` (default)** | **Yes** — pins mover to RWO holder node and **unions holder pod tolerations**. `homeassistant-0` already has `node-role.kubernetes.io/control-plane` Exists NoSchedule |
| **`Repository.moverDefaults.tolerations`** | **Yes** — CRD-valid explicit base (belt-and-suspenders) |

### Privilege API

Keep explicit `securityContext.runAsUser: 0` + `runAsNonRoot: false` (required to **read** root-owned `0600` `.storage/*`). Add `privilegedMode: true` (namespace-gated; intended CRD flag; pairs with existing `privileged-movers` annotation; needed for ownership-preserving restore). `privilegedMode` alone does not substitute for UID 0 on backup reads.

### Verify

```text
kustomize build .../home-assistant/kopiur \
  | sed "s|\${COMMON_S3_ENDPOINT}|garage-gateway.garage.svc.cluster.local:3900|g" \
  | kubectl --context=stpetersburg-k8s-operator.keiretsu.ts.net apply --dry-run=server -f -
```

Result: all five objects `created (server dry run)` including `SnapshotPolicy/homeassistant-config`.

**Do not merge** until reviewed. Acceptance after apply remains: Succeeded Snapshot with non-zero files + restore into a new empty PVC.
