### PR TITLE
feat(garage): alert on cluster integrity, not just the serving path

### DIFF
--- a/clusters/talos-ottawa/apps/mimir/app/rules/garage.yaml
+++ b/clusters/talos-ottawa/apps/mimir/app/rules/garage.yaml
@@ -38,3 +38,70 @@ groups:
             storage probes).
         labels:
           severity: critical
+
+      # ---- cluster integrity (durability), distinct from the probes above ----
+      # The two probes above measure the SERVING path. On 2026-09-07 a storage
+      # node (asuka) silently left the cluster for 4.5h after an image upgrade
+      # (km#2751) and both probes stayed green the whole time — correctly, since
+      # every partition kept quorum and Garage kept serving. Nothing measured
+      # durability, so a lost replica on 12 partitions went unnoticed until it
+      # was found by accident. See corp/bhaiya#725.
+      #
+      # Observed during that incident, which is what these thresholds are
+      # calibrated against:
+      #   cluster_available=1  cluster_partitions_quorum=256  <- probes green
+      #   cluster_healthy=0    cluster_partitions_all_ok=244  <- degraded
+      - alert: GarageClusterUnhealthy
+        expr: min by (cluster) (cluster_healthy) == 0
+        for: 15m
+        annotations:
+          summary: Garage cluster reports unhealthy in {{ $labels.cluster }}
+          description: >-
+            Garage's own cluster_healthy has been 0 for 15m. The cluster is
+            still serving (see GarageServingUnavailable, which is separate), so
+            this is a durability problem, not an outage: a storage node is
+            disconnected or partitions are under-replicated. Run
+            `kubectl -n garage exec garage-gateway-0-0 -- /garage status` and
+            compare HEALTHY against FAILED NODES. A node whose pod is Running
+            with 0 restarts can still be absent from the cluster — check its
+            RPC endpoint answers, since a refused connection means the process
+            is up but its port mapping did not rebind.
+        labels:
+          severity: warning
+
+      # Under-replication: every partition still has quorum, so reads and
+      # writes work, but replicas are missing and a second failure loses data.
+      - alert: GarageClusterPartitionsUnderReplicated
+        expr: >-
+          min by (cluster) (cluster_partitions_all_ok)
+            < min by (cluster) (cluster_partitions)
+        for: 30m
+        annotations:
+          summary: Garage partitions under-replicated in {{ $labels.cluster }}
+          description: >-
+            cluster_partitions_all_ok has been below cluster_partitions for
+            30m, so some partitions are missing a replica while still holding
+            quorum. Nothing is failing yet and it will not appear in the
+            serving probes. With replication.factor=2 this is one node away
+            from data loss on the affected partitions.
+        labels:
+          severity: warning
+
+      # Quorum loss is the escalation: reads in the affected partitions fail.
+      # Inert today (quorum 256/256 even with a node down), which is the point
+      # — it distinguishes degraded-but-serving from actually broken.
+      - alert: GarageClusterPartitionsWithoutQuorum
+        expr: >-
+          min by (cluster) (cluster_partitions_quorum)
+            < min by (cluster) (cluster_partitions)
+        for: 5m
+        annotations:
+          summary: Garage partitions have lost quorum in {{ $labels.cluster }}
+          description: >-
+            cluster_partitions_quorum is below cluster_partitions: some
+            partitions no longer have enough up nodes to serve. Under
+            consistencyMode=degraded reads come from a single replica and may
+            still succeed; writes to those partitions fail. Restore the missing
+            storage nodes.
+        labels:
+          severity: critical

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/garage.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/garage.yaml
@@ -38,3 +38,70 @@ groups:
             storage probes).
         labels:
           severity: critical
+
+      # ---- cluster integrity (durability), distinct from the probes above ----
+      # The two probes above measure the SERVING path. On 2026-09-07 a storage
+      # node (asuka) silently left the cluster for 4.5h after an image upgrade
+      # (km#2751) and both probes stayed green the whole time — correctly, since
+      # every partition kept quorum and Garage kept serving. Nothing measured
+      # durability, so a lost replica on 12 partitions went unnoticed until it
+      # was found by accident. See corp/bhaiya#725.
+      #
+      # Observed during that incident, which is what these thresholds are
+      # calibrated against:
+      #   cluster_available=1  cluster_partitions_quorum=256  <- probes green
+      #   cluster_healthy=0    cluster_partitions_all_ok=244  <- degraded
+      - alert: GarageClusterUnhealthy
+        expr: min by (cluster) (cluster_healthy) == 0
+        for: 15m
+        annotations:
+          summary: Garage cluster reports unhealthy in {{ $labels.cluster }}
+          description: >-
+            Garage's own cluster_healthy has been 0 for 15m. The cluster is
+            still serving (see GarageServingUnavailable, which is separate), so
+            this is a durability problem, not an outage: a storage node is
+            disconnected or partitions are under-replicated. Run
+            `kubectl -n garage exec garage-gateway-0-0 -- /garage status` and
+            compare HEALTHY against FAILED NODES. A node whose pod is Running
+            with 0 restarts can still be absent from the cluster — check its
+            RPC endpoint answers, since a refused connection means the process
+            is up but its port mapping did not rebind.
+        labels:
+          severity: warning
+
+      # Under-replication: every partition still has quorum, so reads and
+      # writes work, but replicas are missing and a second failure loses data.
+      - alert: GarageClusterPartitionsUnderReplicated
+        expr: >-
+          min by (cluster) (cluster_partitions_all_ok)
+            < min by (cluster) (cluster_partitions)
+        for: 30m
+        annotations:
+          summary: Garage partitions under-replicated in {{ $labels.cluster }}
+          description: >-
+            cluster_partitions_all_ok has been below cluster_partitions for
+            30m, so some partitions are missing a replica while still holding
+            quorum. Nothing is failing yet and it will not appear in the
+            serving probes. With replication.factor=2 this is one node away
+            from data loss on the affected partitions.
+        labels:
+          severity: warning
+
+      # Quorum loss is the escalation: reads in the affected partitions fail.
+      # Inert today (quorum 256/256 even with a node down), which is the point
+      # — it distinguishes degraded-but-serving from actually broken.
+      - alert: GarageClusterPartitionsWithoutQuorum
+        expr: >-
+          min by (cluster) (cluster_partitions_quorum)
+            < min by (cluster) (cluster_partitions)
+        for: 5m
+        annotations:
+          summary: Garage partitions have lost quorum in {{ $labels.cluster }}
+          description: >-
+            cluster_partitions_quorum is below cluster_partitions: some
+            partitions no longer have enough up nodes to serve. Under
+            consistencyMode=degraded reads come from a single replica and may
+            still succeed; writes to those partitions fail. Restore the missing
+            storage nodes.
+        labels:
+          severity: critical


### PR DESCRIPTION
## Why

Garage has two alerts today and both probe the **serving** path:

| existing alert | measures |
| --- | --- |
| `GarageServingUnavailable` | `/health` non-2xx (write-quorum lost) |
| `GarageGatewayUnreachable` | gateway Service has no endpoint |

On 2026-09-07 a storage node (`asuka`, Ottawa) left the cluster and stayed out for **4.5 hours** after the v2.4.0 image upgrade in #2751. **Both alerts stayed green the whole time — correctly.** Every partition kept quorum, Garage kept serving, S3 clients never noticed.

Nothing measured **durability**. So a lost replica on 12 of 256 partitions went unnoticed until it was found by accident while chasing an unrelated blocked Kustomization. Details in corp/bhaiya#725.

The signal was already there. `cluster_healthy` has been `0` since `03:04Z`, scraped into Mimir the entire time, with no rule reading it:

```
02:34:10Z  cluster_healthy=1
02:48:10Z  #2751 merged
02:48:31Z  GarageCluster -> phase: Failed
03:04:10Z  cluster_healthy=0     <- and stayed 0, unalerted, for 4.5h
```

## What this adds

Three rules over metrics Garage already exports and `kube-prometheus-stack` already scrapes. No new exporter, no new scrape config.

| alert | expression | for | severity |
| --- | --- | --- | --- |
| `GarageClusterUnhealthy` | `min by (cluster) (cluster_healthy) == 0` | 15m | warning |
| `GarageClusterPartitionsUnderReplicated` | `all_ok < partitions` | 30m | warning |
| `GarageClusterPartitionsWithoutQuorum` | `quorum < partitions` | 5m | critical |

The split is deliberate. Under-replicated means *a second failure loses data* and is a warning; quorum loss means *requests are failing now* and is critical. `for: 30m` on under-replication is long on purpose — rebalances and rolling restarts transiently drop `all_ok`, and a 15-minute window would make this noisy during any normal Garage upgrade.

## Verification — run against live Mimir mid-incident

This is the check that matters, since a rule file is app config that no API server validates (corp/bhaiya#715, class 4). Each expression run verbatim against `mimir-ottawa` while the cluster was degraded:

```
min by (cluster) (cluster_healthy) == 0                    -> {cluster="talos-ottawa"} 0     FIRES
min by (cluster) (cluster_partitions_all_ok) < ...         -> {cluster="talos-ottawa"} 244   FIRES
min by (cluster) (cluster_partitions_quorum)  < ...        -> (no data)                      SILENT
```

**The third one staying silent is the important result.** Quorum is 256/256 with a node down, so the critical rule correctly does not fire — it discriminates degraded-but-serving from actually broken, rather than pattern-matching on "something is wrong."

Concurrently, `cluster_available=1` and `probe_success=1`, confirming the existing serving alerts were right to stay quiet and that these three cover a genuinely disjoint failure mode.

## Test plan

- [x] `tools/check.sh talos-ottawa` — `✓ render OK`
- [x] `tools/check.sh talos-robbinsdale` — `✓ render OK`
- [x] `tools/check.sh talos-stpetersburg` — `✓ render OK`
- [x] `tools/check-mimir-rules.sh` — `✓ 24 files, 3 tenant loaders, 23 unique namespaces`
- [x] All three expressions evaluated against live `mimir-ottawa`
- [x] `clusters/talos-ottawa/apps/mimir/app/rules/garage.yaml` twin mirrored (byte-identical to base on `main` before the edit, so mirroring is safe)
- [ ] After merge: `GarageClusterUnhealthy` should fire within 15m, since the condition is live right now — that is the end-to-end proof

## Not in scope

Fixing `asuka` itself. corp/bhaiya#725 has the diagnosis (Tailscale RPC port never rebound after pod recreation — `ConnectionRefused` on `:3901` while its sibling on the same image/site/secret connects fine) and the recommended pod delete, held pending a check on whether the wedged operator would respond by mutating the layout and triggering a 700 GiB cross-site rebalance.

Refs corp/bhaiya#725, corp/bhaiya#715