### PR TITLE
fix(garage): scope the kopiur grant to StP; unblock 12 Kustomizations

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -30,8 +30,8 @@ diagram in the [README](../../README.md#architecture).
 |---|---:|---:|---:|
 | `ottawa` | 4 | 59 | 122 |
 | `robbinsdale` | 3 | 43 | 87 |
-| `stpetersburg` | 3 | 40 | 82 |
-| **total** | **10** | **142** | **291** |
+| `stpetersburg` | 3 | 40 | 83 |
+| **total** | **10** | **142** | **292** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -285,7 +285,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Networking, ingress and identity | `tailscale-system` | `tailscale-system-app` |
 | Networking, ingress and identity | `tinyauth-egress` | `tinyauth-egress` → ns `tinyauth` |
 | Storage and data services | `cnpg-system` | `cnpg-system` |
-| Storage and data services | `garage` | `garage`, `garage-bucket`, `garage-keys`, `garage-kopiur-stpetersburg-bucket`, `garage-nodes-stpetersburg`, `garage-reference-grants`, `garage-velero-bucket`, `garage-webui` |
+| Storage and data services | `garage` | `garage`, `garage-bucket`, `garage-keys`, `garage-kopiur-stpetersburg-bucket`, `garage-nodes-stpetersburg`, `garage-reference-grants`, `garage-stpetersburg-reference-grants`, `garage-velero-bucket`, `garage-webui` |
 | Storage and data services | `garage-operator-system` | `garage-operator-system-install` |
 | Storage and data services | `local-path-storage` | `local-path-storage` |
 | Storage and data services | `snapshot-controller` | `snapshot-controller` |

--- a/kubernetes/apps/base/garage/garage-reference-grants-stpetersburg/kopiur-reference-grant.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-stpetersburg/kopiur-reference-grant.yaml
@@ -1,0 +1,25 @@
+---
+# kopiur StP Home Assistant repository key (#695 / km#2775).
+#
+# Site-scoped, not in garage-reference-grants: that base is applied to all
+# three clusters, and the home-assistant namespace exists only on St.
+# Petersburg. Putting it there made the grants Kustomization fail on Ottawa and
+# Robbinsdale with `namespaces "home-assistant" not found`, stalling every
+# Kustomization that dependsOn it (km#2776 regression).
+#
+# It also cannot live beside the GarageBucket: Flux dry-runs a Kustomization as
+# a set, so a grant in the same Kustomization as the bucket needing it can
+# never be persisted first — the bucket's dry-run is denied and it retries
+# forever. Hence a separate site-scoped Kustomization.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: garage-bucket-to-kopiur-stpetersburg-key
+  namespace: home-assistant
+spec:
+  from:
+    - kind: GarageBucket
+      namespace: garage
+  to:
+    - kind: GarageKey
+      name: kopiur-stpetersburg-key

--- a/kubernetes/apps/base/garage/garage-reference-grants-stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants-stpetersburg/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kopiur-reference-grant.yaml

--- a/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
+++ b/kubernetes/apps/base/garage/garage-reference-grants/reference-grants.yaml
@@ -69,21 +69,3 @@ spec:
   to:
     - kind: GarageKey
       name: tailscale-recorder-key
----
-# kopiur StP HA repository key (#695 / km#2775). MUST live here, not beside the
-# GarageBucket: Flux dry-runs a Kustomization as a set, so a grant in the same
-# Kustomization as the bucket that needs it can never be persisted first — the
-# bucket's dry-run is denied and the Kustomization retries forever.
-apiVersion: garage.rajsingh.info/v1beta1
-kind: GarageReferenceGrant
-metadata:
-  name: garage-bucket-to-kopiur-stpetersburg-key
-  namespace: home-assistant
-spec:
-  from:
-    - kind: GarageBucket
-      namespace: garage
-  to:
-    - kind: GarageKey
-      name: kopiur-stpetersburg-key
-

--- a/kubernetes/apps/stpetersburg/garage/garage-stpetersburg-reference-grants.yaml
+++ b/kubernetes/apps/stpetersburg/garage/garage-stpetersburg-reference-grants.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-stpetersburg-reference-grants
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: garage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: garage-stpetersburg-reference-grants
+  path: ./kubernetes/apps/base/garage/garage-reference-grants-stpetersburg
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/stpetersburg/garage/garage.yaml
+++ b/kubernetes/apps/stpetersburg/garage/garage.yaml
@@ -127,6 +127,7 @@ spec:
   dependsOn:
     - name: garage-bucket
     - name: garage-reference-grants
+    - name: garage-stpetersburg-reference-grants
     - name: home-assistant
   commonMetadata:
     labels:

--- a/kubernetes/apps/stpetersburg/garage/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/garage/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ./namespace.yaml
   - ./garage.yaml
   - ./garage-reference-grants.yaml
+  - ./garage-stpetersburg-reference-grants.yaml
   - ./garage-nodes-stpetersburg.yaml


### PR DESCRIPTION
## P1 — this unblocks 12 Kustomizations on Ottawa, including velero, forgejo, woodpecker and bhaiya

My own regression from #2776. That PR moved `garage-bucket-to-kopiur-stpetersburg-key` out of the kopiur bucket's Kustomization to escape a same-Kustomization dry-run deadlock — correct fix, wrong destination. `garage-reference-grants` is a **shared base applied to all three clusters**, and the `home-assistant` namespace exists only on St. Petersburg:

| cluster | `home-assistant` ns | `garage-reference-grants` |
| --- | --- | --- |
| ottawa | **absent** | `False / ReconciliationFailed` |
| robbinsdale | **absent** | `False / DependencyNotReady` |
| stpetersburg | Active | `True / ReconciliationSucceeded` |

```
GarageReferenceGrant/home-assistant/garage-bucket-to-kopiur-stpetersburg-key
  not found: namespaces "home-assistant" not found
```

`lastAppliedRevision` on Ottawa was stuck at `d4ec82f` (#2775) while `lastAttemptedRevision` tracked main tip. So the grants Kustomization applied nothing for hours, and everything with `dependsOn: garage-reference-grants` stalled behind it:

`bhaiya` (provider-fence-activation) · `firefly` · `forgejo` · `garage-bucket` · `garage-keys` · `garage-velero-bucket` · `media-apps` · `teslamate` · `teslamate-secret-sync` · `velero` · `velero-ui` · `woodpecker`

Twelve, all `DependencyNotReady`. **Backups, git, CI and bhaiya itself were frozen for deployment.**

## Fix

Site-scoped overlay, mirroring the `garage-ottawa-reference-grants` pattern that already exists in this repo for exactly this reason:

- `kubernetes/apps/base/garage/garage-reference-grants-stpetersburg/` — the grant, alone
- `kubernetes/apps/stpetersburg/garage/garage-stpetersburg-reference-grants.yaml` — its Flux Kustomization
- registered in `kubernetes/apps/stpetersburg/garage/kustomization.yaml`
- `garage-kopiur-stpetersburg-bucket` gains `dependsOn: garage-stpetersburg-reference-grants`
- grant removed from the shared base

**#2776's original fix is preserved.** The grant still lives in a *different* Kustomization from the bucket that needs it, so the dry-run-as-a-set deadlock stays solved — it is now merely also in the right cluster.

## Verification — four server-side dry-runs, including a negative control

```
[1] shared base   -> ottawa         PASS   (was failing)
[2] shared base   -> robbinsdale    PASS
[3] StP overlay   -> stpetersburg   PASS
[4] StP overlay   -> ottawa         FAIL: namespaces "home-assistant" not found
```

**Check 4 is the one that matters.** Applying the new overlay against Ottawa still reproduces the original error verbatim, which proves the site scoping is load-bearing rather than cosmetic. If all four had passed, the fix would not have been tested.

## Test plan

- [x] `tools/check.sh talos-ottawa` — `✓ render OK`
- [x] `tools/check.sh talos-robbinsdale` — `✓ render OK`
- [x] `tools/check.sh talos-stpetersburg` — `✓ render OK`
- [x] Four server-side dry-runs above
- [ ] After merge: `garage-reference-grants` reaches `Ready=True` on Ottawa and Robbinsdale, and the 12 dependents drain from `DependencyNotReady`
- [ ] After merge: StP's `garage-kopiur-stpetersburg-bucket` still converges (it must not regress — it is the only cluster where this worked)

## How this went unnoticed, and what would have caught it

The render gate passed #2776 because `kubectl kustomize` renders a grant for a non-existent namespace perfectly happily — class 2 in corp/bhaiya#715. Nothing alerted on twelve stalled Kustomizations; I found them by querying `flux_resource_info{kind="Kustomization", ready="False"}` while investigating something else.

That metric **already exists and already carries a `ready` label**, which means the stuck-Kustomization alert corp/bhaiya#715 asks for is writable today with no new scrape config:

```promql
count by (cluster) (flux_resource_info{kind="Kustomization", ready="False"}) > 0
```

I had assumed that alert was blocked on `gotk_reconcile_condition`, which is genuinely not scraped. It is not blocked. Filing that separately.

Refs #2776, corp/bhaiya#695, corp/bhaiya#715
