### PR TITLE
fix(ai): serve the Qwen alias CLIProxy actually requests

### DIFF
--- a/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
+++ b/kubernetes/apps/base/ai/ai/inference/qwen38.yaml
@@ -3,6 +3,15 @@
 #
 # Qwen3.8-Flash-Next-NVFP4 on 2× DGX Spark — vLLM TP=2+EP+MTP3.
 #
+# --served-model-name carries three IDs on purpose. CLIProxy's vllm provider is
+# configured as name: Qwen3.8-Flash-Next-NVFP4 / alias: Qwen3.8-Flash-Next, but
+# it sends the ALIAS upstream, so serving only the canonical name returns
+# `404: The model \'Qwen3.8-Flash-Next\' does not exist`. With
+# disable-cooling: false that 404 trips CLIProxy's breaker and every later
+# request fails `auth_unavailable`, which also drops vllm/* out of /v1/models
+# and reads as a retired route. Serving the alias too makes the ID Bhaiya pins
+# as BHAIYA_CLIPROXY_DEFAULT_MODEL valid whichever field CLIProxy sends.
+#
 # The model and serving recipe are from:
 # https://github.com/MiaAI-Lab/Qwen3.8-Flash-Next-Dual-DGX-Sparks
 # Target checkpoint: nvidia/Qwen3.8-Flash-Next-NVFP4@fc694b54
@@ -200,7 +209,7 @@ spec:
             if [ -f /tmp/qwen-patches/config_patched.json ]; then cp /tmp/qwen-patches/config_patched.json /models/qwen38/config.json; fi
             if [ -f /tmp/qwen-patches/hf_quant_config_patched.json ]; then cp /tmp/qwen-patches/hf_quant_config_patched.json /models/qwen38/hf_quant_config.json; fi
             exec vllm serve /models/qwen38 \
-              --served-model-name qwen3.8-flash-next Qwen3.8-Flash-Next-NVFP4 \
+              --served-model-name qwen3.8-flash-next Qwen3.8-Flash-Next Qwen3.8-Flash-Next-NVFP4 \
               --tensor-parallel-size 2 --distributed-executor-backend mp \
               --enable-expert-parallel --all2all-backend allgather_reducescatter \
               --gpu-memory-utilization 0.72 --max-num-seqs 8 --max-num-batched-tokens 8192 \
@@ -378,7 +387,7 @@ spec:
             if [ -f /tmp/qwen-patches/config_patched.json ]; then cp /tmp/qwen-patches/config_patched.json /models/qwen38/config.json; fi
             if [ -f /tmp/qwen-patches/hf_quant_config_patched.json ]; then cp /tmp/qwen-patches/hf_quant_config_patched.json /models/qwen38/hf_quant_config.json; fi
             exec vllm serve /models/qwen38 \
-              --served-model-name qwen3.8-flash-next Qwen3.8-Flash-Next-NVFP4 \
+              --served-model-name qwen3.8-flash-next Qwen3.8-Flash-Next Qwen3.8-Flash-Next-NVFP4 \
               --tensor-parallel-size 2 --distributed-executor-backend mp \
               --enable-expert-parallel --all2all-backend allgather_reducescatter \
               --gpu-memory-utilization 0.72 --max-num-seqs 8 --max-num-batched-tokens 8192 \


### PR DESCRIPTION
## The symptom

`vllm/Qwen3.8-Flash-Next` returns 404 and disappears from CLIProxy's `/v1/models` entirely, which reads exactly like the route has been retired. It has not been. **The Qwen server is healthy** — `ai/qwen38-0` and `qwen38-0-1`, both `2/2 Running`, 0 restarts.

It silently hard-blocked four Herdr agents. A `pi` agent that 404s on every request settles at `agent_status=done`, indistinguishable from one that finished its work.

## Root cause

vLLM served two IDs:

```
--served-model-name qwen3.8-flash-next Qwen3.8-Flash-Next-NVFP4
```

CLIProxy's provider is configured with the canonical name upstream and the short name client-facing, which is correct and documented in `providers.yaml`:

```yaml
- name: "vllm"
  prefix: "vllm"
  base-url: "http://stpetersburg-vllm-upstream/v1"
  disable-cooling: false
  models:
    - name: "Qwen3.8-Flash-Next-NVFP4"     # intended upstream ID
      alias: "Qwen3.8-Flash-Next"          # what Bhaiya pins
```

**But CLIProxy sends the alias upstream**, and `Qwen3.8-Flash-Next` was not one of the two served names:

```
auth_unavailable: no auth available (providers=openai-compatible-vllm,
  model=vllm/Qwen3.8-Flash-Next; last upstream error:
  404: The model `Qwen3.8-Flash-Next` does not exist)
```

Then `disable-cooling: false` turns a single 404 into a persistent outage: the breaker trips, every later request fails `auth_unavailable`, and the provider drops out of the advertised catalog.

## Why a cliproxy restart is not the fix

I measured it. After `rollout restart deployment/cliproxy`:

| observation | result |
| --- | --- |
| `/v1/models` | **247** models, `vllm/Qwen3.8-Flash-Next` back |
| 1st completion | **succeeded**, gateway reported `model: qwen3.8-flash-next` |
| 2nd completion | `404 The model 'Qwen3.8-Flash-Next' does not exist` |
| next 6 completions | **6/6** `auth_unavailable` |

So the restart resets the breaker and buys roughly one request. The cause survives it.

Also worth noting for anyone testing this by hand: Qwen defaults to thinking, so the one successful call spent all 150 completion tokens on reasoning and returned empty `content`. Give it real headroom or it looks broken when it is working.

## The fix

Add the alias as a third served name, in both the leader and worker command:

```diff
- --served-model-name qwen3.8-flash-next Qwen3.8-Flash-Next-NVFP4 \
+ --served-model-name qwen3.8-flash-next Qwen3.8-Flash-Next Qwen3.8-Flash-Next-NVFP4 \
```

Additive — the two existing IDs keep working — and it makes the ID Bhaiya pins as `BHAIYA_CLIPROXY_DEFAULT_MODEL` valid upstream **whichever field CLIProxy chooses to send**. That robustness is deliberate: I did not want to invert `name`/`alias` on an inference about CLIProxy's internals when serving both names removes the question.

Reasoning is recorded in the file header so the third name does not look redundant later.

## Cost

This rolls the `LeaderWorkerSet`, so Qwen reloads its checkpoint and is unavailable for several minutes — the header notes a cold StP GPU once held the pod in Init for ~8.5 minutes. The route is currently failing **100%** of requests through CLIProxy, so there is nothing to lose by rolling it.

## Test plan

- [x] `tools/check.sh talos-stpetersburg` — `✓ render OK`
- [x] `tools/check.sh talos-ottawa` — `✓ render OK`
- [x] `tools/check.sh talos-robbinsdale` — `✓ render OK`
- [x] `kubectl apply --dry-run=server` on `kubernetes/apps/base/ai/ai/inference` against StP — clean
- [ ] After the roll: upstream `/v1/models` lists all three IDs
- [ ] After the roll: repeated `vllm/Qwen3.8-Flash-Next` completions succeed, not just the first
- [ ] Consider whether `disable-cooling: false` is right here — a single upstream 404 currently causes an indefinite provider outage with no alerting

## Follow-up worth filing separately

Nothing alerted on any of this. A provider being cooled out of the catalog is invisible, and bhaiya's own model resolution degraded silently to `codex-subscription/vllm-fallback` (verified working) with no signal that the pinned default had stopped resolving. `internal/metrics/metrics.go` has no model-resolution metric at all.
