### PR TITLE
feat(mimir): alert on stuck Flux Kustomizations

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
@@ -17,3 +17,22 @@ groups:
           severity: critical
         annotations:
           summary: Flux instance is not ready
+
+      - alert: FluxKustomizationNotReady
+        expr: |
+          max by (cluster, namespace, name, path) (
+            flux_resource_info{
+              kind="Kustomization",
+              ready="False",
+              suspended="False"
+            } == 1
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Flux Kustomization {{ $labels.name }} is not ready
+          description: >-
+            Kustomization {{ $labels.name }} at {{ $labels.path }} has remained
+            not ready for 15 minutes. Inspect its current condition and root
+            dependency before investigating dependent resources.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/flux_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/flux_test.yaml
@@ -1,0 +1,131 @@
+rule_files:
+  - ../flux.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="mimir",namespace="flux-system",path="./kubernetes/apps/base/mimir/mimir-ottawa",reason="ReconciliationFailed",revision="main@sha1:bad",source_name="kubernetes-manifests",suspended="False",ready="False"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: FluxKustomizationNotReady
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: FluxKustomizationNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              name: mimir
+              namespace: flux-system
+              path: ./kubernetes/apps/base/mimir/mimir-ottawa
+            exp_annotations:
+              summary: Flux Kustomization mimir is not ready
+              description: >-
+                Kustomization mimir at ./kubernetes/apps/base/mimir/mimir-ottawa
+                has remained not ready for 15 minutes. Inspect its current
+                condition and root dependency before investigating dependent
+                resources.
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="transient",namespace="flux-system",path="./transient",reason="ReconciliationFailed",revision="main@sha1:transient",source_name="kubernetes-manifests",suspended="False",ready="False"}'
+        values: "1+0x5 _x15"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: FluxKustomizationNotReady
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="suspended",namespace="flux-system",path="./suspended",reason="ReconciliationFailed",revision="main@sha1:suspended",source_name="kubernetes-manifests",suspended="True",ready="False"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: FluxKustomizationNotReady
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="healthy",namespace="flux-system",path="./healthy",reason="ReconciliationSucceeded",revision="main@sha1:good",source_name="kubernetes-manifests",suspended="False",ready="True"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: FluxKustomizationNotReady
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="media-apps",namespace="flux-system",path="./kubernetes/apps/base/media/media-apps",reason="DependencyNotReady",revision="main@sha1:dep",source_name="kubernetes-manifests",suspended="False",ready="False"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: FluxKustomizationNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              name: media-apps
+              namespace: flux-system
+              path: ./kubernetes/apps/base/media/media-apps
+            exp_annotations:
+              summary: Flux Kustomization media-apps is not ready
+              description: >-
+                Kustomization media-apps at ./kubernetes/apps/base/media/media-apps
+                has remained not ready for 15 minutes. Inspect its current
+                condition and root dependency before investigating dependent
+                resources.
+
+  # Revision and reason labels may change during one continuous failure. The
+  # stable identity aggregation must keep the alert pending across the change.
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="rollover",namespace="flux-system",path="./rollover",reason="ReconciliationFailed",revision="main@sha1:first",source_name="kubernetes-manifests",suspended="False",ready="False"}'
+        values: "1+0x9 _x11"
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="rollover",namespace="flux-system",path="./rollover",reason="DependencyNotReady",revision="main@sha1:second",source_name="kubernetes-manifests",suspended="False",ready="False"}'
+        values: "_x10 1+0x10"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: FluxKustomizationNotReady
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: FluxKustomizationNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              namespace: flux-system
+              name: rollover
+              path: ./rollover
+            exp_annotations:
+              summary: Flux Kustomization rollover is not ready
+              description: >-
+                Kustomization rollover at ./rollover has remained not ready
+                for 15 minutes. Inspect its current condition and root
+                dependency before investigating dependent resources.
+
+  # The same Kustomization name is independent in another cluster.
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="shared-name",namespace="flux-system",path="./shared-name",reason="ReconciliationFailed",revision="main@sha1:bad",source_name="kubernetes-manifests",suspended="False",ready="False"}'
+        values: "1+0x20"
+      - series: 'flux_resource_info{cluster="talos-robbinsdale",kind="Kustomization",name="shared-name",namespace="flux-system",path="./shared-name",reason="ReconciliationSucceeded",revision="main@sha1:good",source_name="kubernetes-manifests",suspended="False",ready="True"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: FluxKustomizationNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              namespace: flux-system
+              name: shared-name
+              path: ./shared-name
+            exp_annotations:
+              summary: Flux Kustomization shared-name is not ready
+              description: >-
+                Kustomization shared-name at ./shared-name has remained not
+                ready for 15 minutes. Inspect its current condition and root
+                dependency before investigating dependent resources.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RULE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/mimir-flux-rules.XXXXXX")
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+# Mimir's native rule files require a top-level namespace, which promtool does
+# not understand. Keep the production rule as the source of truth and remove
+# only that Mimir wrapper in the temporary test copy.
+sed '/^namespace: flux$/d' "$RULE_DIR/flux.yaml" >"$tmpdir/flux.yaml"
+sed "s#../flux.yaml#$tmpdir/flux.yaml#" \
+  "$RULE_DIR/tests/flux_test.yaml" >"$tmpdir/flux_test.yaml"
+
+promtool check rules "$tmpdir/flux.yaml"
+promtool test rules "$tmpdir/flux_test.yaml"


### PR DESCRIPTION
## Summary

- add `FluxKustomizationNotReady` to the existing Mimir Flux rule path
- alert only for unsuspended Kustomizations continuously not ready for 15 minutes
- aggregate on stable `(cluster, namespace, name, path)` identity so revision/reason changes do not reset the timer
- add deterministic offline promtool coverage for sustained, transient, suspended, healthy, dependency, rollover, and cross-cluster cases

## Verification

- `kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh` (promtool 3.14.0): pass
- `flock -o -w3600 /workspace/briefs/cos-heavy-build.lock tools/check.sh talos-ottawa`: `✓ render OK: talos-ottawa`

No live mutations, server-side dry-runs, credentials, or model-alert changes are included.
