### PR TITLE
feat(mimir): alert on CLIProxy model resolution

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -22,6 +22,7 @@ configMapGenerator:
   - name: mimir-rules
     files:
       - rules/bhaiya.yaml
+      - rules/bhaiya-model.yaml
       - rules/bhaiya-reconciler.yaml
       - rules/bhaiya-provider-provisioning.yaml
       - rules/bhaiya-ssh.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -32,6 +32,7 @@ spec:
             - --address=http://mimir-gateway.mimir.svc.cluster.local:8080
             - --id=talos-ottawa
             - /rules/bhaiya.yaml
+            - /rules/bhaiya-model.yaml
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
             - /rules/bhaiya-ssh.yaml
@@ -69,6 +70,7 @@ spec:
             - --address=http://mimir-gateway.mimir.svc.cluster.local:8080
             - --id=talos-robbinsdale
             - /rules/bhaiya.yaml
+            - /rules/bhaiya-model.yaml
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
             - /rules/bhaiya-ssh.yaml
@@ -102,6 +104,7 @@ spec:
             - --address=http://mimir-gateway.mimir.svc.cluster.local:8080
             - --id=talos-stpetersburg
             - /rules/bhaiya.yaml
+            - /rules/bhaiya-model.yaml
             - /rules/bhaiya-reconciler.yaml
             - /rules/bhaiya-provider-provisioning.yaml
             - /rules/bhaiya-ssh.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-model.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-model.yaml
@@ -1,0 +1,103 @@
+# CLIProxy model discovery is written by API-serving replicas as well as the
+# reconciler. Correlate gauges from one scrape target before aggregating by
+# stable cluster; an idle replica must not mask an active nonleader.
+namespace: bhaiya-model
+groups:
+  - name: bhaiya-model.rules
+    rules:
+      - alert: BhaiyaCLIProxyDefaultModelFallback
+        expr: |
+          max by (cluster) (
+            bhaiya_cliproxy_default_model_resolution{
+              namespace="bhaiya", job="bhaiya", service="bhaiya",
+              container="bhaiya", source="fallback"
+            } == 1
+            and on (cluster, instance)
+            (
+              bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{
+                namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+              } > 0
+              and on (cluster, instance)
+              (
+                time() - bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{
+                  namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+                } < 300
+              )
+            )
+          )
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: Bhaiya CLIProxy is using its fallback model in {{ $labels.cluster }}
+          description: >-
+            A fresh successful CLIProxy discovery has selected the configured
+            fallback model for at least 30 minutes in {{ $labels.cluster }}.
+            Inspect the primary model provider and CLIProxy catalog.
+
+      - alert: BhaiyaCLIProxyNoResolvedModel
+        expr: |
+          max by (cluster) (
+            bhaiya_cliproxy_default_model_resolution{
+              namespace="bhaiya", job="bhaiya", service="bhaiya",
+              container="bhaiya", source="none"
+            } == 1
+            and on (cluster, instance)
+            (
+              bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{
+                namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+              } > 0
+              and on (cluster, instance)
+              (
+                time() - bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{
+                  namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+                } < 300
+              )
+            )
+          )
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya CLIProxy resolved no model in {{ $labels.cluster }}
+          description: >-
+            A fresh successful CLIProxy discovery selected no usable built-in
+            model in {{ $labels.cluster }}. Inspect the live CLIProxy catalog.
+
+      - alert: BhaiyaCLIProxyModelDiscoveryFailure
+        expr: |
+          max by (cluster) (
+            increase(
+              bhaiya_cliproxy_model_discovery_errors_total{
+                namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+              }[5m]
+            ) > 0
+            and on (cluster, instance)
+            (
+              time() - bhaiya_cliproxy_model_discovery_last_attempt_timestamp_seconds{
+                namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+              } < 300
+            )
+            and on (cluster, instance)
+            (
+              bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{
+                namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+              } == 0
+              or on (cluster, instance)
+              (
+                time() - bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{
+                  namespace="bhaiya", job="bhaiya", service="bhaiya", container="bhaiya"
+                } > 300
+              )
+            )
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya CLIProxy model discovery is failing in {{ $labels.cluster }}
+          description: >-
+            Bhaiya has recent CLIProxy discovery errors without a fresh
+            successful observation in {{ $labels.cluster }}. This includes
+            repeated startup failures; a never-attempted idle process remains
+            quiet.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_model_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_model_test.yaml
@@ -1,0 +1,169 @@
+rule_files:
+  - ../bhaiya-model.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # A process that has never attempted discovery has the initialized zero
+  # values for every source and timestamp. It is idle/no-demand, not failed.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="never",cluster="talos-ottawa",source="primary"}'
+        values: "0+0x40"
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="never",cluster="talos-ottawa",source="fallback"}'
+        values: "0+0x40"
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="never",cluster="talos-ottawa",source="none"}'
+        values: "0+0x40"
+      - series: 'bhaiya_cliproxy_model_discovery_last_attempt_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="never",cluster="talos-ottawa"}'
+        values: "0+0x40"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="never",cluster="talos-ottawa"}'
+        values: "0+0x40"
+      - series: 'bhaiya_cliproxy_model_discovery_errors_total{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="never",cluster="talos-ottawa"}'
+        values: "0+0x40"
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: BhaiyaCLIProxyDefaultModelFallback
+        exp_alerts: []
+      - eval_time: 40m
+        alertname: BhaiyaCLIProxyNoResolvedModel
+        exp_alerts: []
+      - eval_time: 40m
+        alertname: BhaiyaCLIProxyModelDiscoveryFailure
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa",source="fallback"}'
+        values: "1+0x40"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "60+60x40"
+    alert_rule_test:
+      - eval_time: 29m
+        alertname: BhaiyaCLIProxyDefaultModelFallback
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: BhaiyaCLIProxyDefaultModelFallback
+        exp_alerts:
+          - exp_labels: {cluster: talos-ottawa, severity: warning}
+            exp_annotations:
+              summary: Bhaiya CLIProxy is using its fallback model in talos-ottawa
+              description: >-
+                A fresh successful CLIProxy discovery has selected the configured
+                fallback model for at least 30 minutes in talos-ottawa. Inspect the
+                primary model provider and CLIProxy catalog.
+
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa",source="none"}'
+        values: "0 1+0x10"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "0 120+60x10"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: BhaiyaCLIProxyNoResolvedModel
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: BhaiyaCLIProxyNoResolvedModel
+        exp_alerts:
+          - exp_labels: {cluster: talos-ottawa, severity: critical}
+            exp_annotations:
+              summary: Bhaiya CLIProxy resolved no model in talos-ottawa
+              description: >-
+                A fresh successful CLIProxy discovery selected no usable built-in
+                model in talos-ottawa. Inspect the live CLIProxy catalog.
+
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_cliproxy_model_discovery_errors_total{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "0 1 2 3 4 5 6 7 8 9"
+      - series: 'bhaiya_cliproxy_model_discovery_last_attempt_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "0 60 120 180 240 300 360 420 480 540"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "0+0x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: BhaiyaCLIProxyModelDiscoveryFailure
+        exp_alerts: []
+      - eval_time: 6m
+        alertname: BhaiyaCLIProxyModelDiscoveryFailure
+        exp_alerts:
+          - exp_labels: {cluster: talos-ottawa, severity: critical}
+            exp_annotations:
+              summary: Bhaiya CLIProxy model discovery is failing in talos-ottawa
+              description: >-
+                Bhaiya has recent CLIProxy discovery errors without a fresh
+                successful observation in talos-ottawa. This includes repeated
+                startup failures; a never-attempted idle process remains quiet.
+
+  # A prior success older than five minutes plus recent errors is an outage;
+  # recovery clears it. Idle old fallback is quiet.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_cliproxy_model_discovery_errors_total{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "0 0 0 1 2 3 4 5 6 7 8 9 10 11 12 13"
+      - series: 'bhaiya_cliproxy_model_discovery_last_attempt_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "60 60 60 180 240 300 360 420 480 540 600 660 720 780 840 900"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="a",cluster="talos-ottawa"}'
+        values: "60 60 60 60 60 60 60 60 60 60 60 60 60 60 900 960"
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: BhaiyaCLIProxyModelDiscoveryFailure
+        exp_alerts: []
+      - eval_time: 12m
+        alertname: BhaiyaCLIProxyModelDiscoveryFailure
+        exp_alerts:
+          - exp_labels: {cluster: talos-ottawa, severity: critical}
+            exp_annotations:
+              summary: Bhaiya CLIProxy model discovery is failing in talos-ottawa
+              description: >-
+                Bhaiya has recent CLIProxy discovery errors without a fresh
+                successful observation in talos-ottawa. This includes repeated
+                startup failures; a never-attempted idle process remains quiet.
+      - eval_time: 14m
+        alertname: BhaiyaCLIProxyModelDiscoveryFailure
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="idle",cluster="talos-ottawa",source="fallback"}'
+        values: "1+0x40"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="idle",cluster="talos-ottawa"}'
+        values: "60+0x40"
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: BhaiyaCLIProxyDefaultModelFallback
+        exp_alerts: []
+
+  # A fresh nonleader remains visible despite an idle replica; replacement of
+  # the old instance keeps the cluster-level identity stable.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="old",cluster="talos-ottawa",source="fallback"}'
+        values: "1+0x10 _x30"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="old",cluster="talos-ottawa"}'
+        values: "60+60x10 _x30"
+      - series: 'bhaiya_cliproxy_default_model_resolution{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="new",cluster="talos-ottawa",source="fallback"}'
+        values: "_x10 1+0x30"
+      - series: 'bhaiya_cliproxy_model_discovery_last_success_timestamp_seconds{namespace="bhaiya",job="bhaiya",service="bhaiya",container="bhaiya",instance="new",cluster="talos-ottawa"}'
+        values: "_x10 660+60x30"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: BhaiyaCLIProxyDefaultModelFallback
+        exp_alerts:
+          - exp_labels: {cluster: talos-ottawa, severity: warning}
+            exp_annotations:
+              summary: Bhaiya CLIProxy is using its fallback model in talos-ottawa
+              description: >-
+                A fresh successful CLIProxy discovery has selected the configured
+                fallback model for at least 30 minutes in talos-ottawa. Inspect the
+                primary model provider and CLIProxy catalog.
+      - eval_time: 40m
+        alertname: BhaiyaCLIProxyDefaultModelFallback
+        exp_alerts:
+          - exp_labels: {cluster: talos-ottawa, severity: warning}
+            exp_annotations:
+              summary: Bhaiya CLIProxy is using its fallback model in talos-ottawa
+              description: >-
+                A fresh successful CLIProxy discovery has selected the configured
+                fallback model for at least 30 minutes in talos-ottawa. Inspect the
+                primary model provider and CLIProxy catalog.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -2,15 +2,20 @@
 set -euo pipefail
 
 RULE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/mimir-flux-rules.XXXXXX")
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/mimir-rules.XXXXXX")
 trap 'rm -rf -- "$tmpdir"' EXIT
 
 # Mimir's native rule files require a top-level namespace, which promtool does
-# not understand. Keep the production rule as the source of truth and remove
+# not understand. Keep each production rule as the source of truth and remove
 # only that Mimir wrapper in the temporary test copy.
-sed '/^namespace: flux$/d' "$RULE_DIR/flux.yaml" >"$tmpdir/flux.yaml"
-sed "s#../flux.yaml#$tmpdir/flux.yaml#" \
-  "$RULE_DIR/tests/flux_test.yaml" >"$tmpdir/flux_test.yaml"
-
-promtool check rules "$tmpdir/flux.yaml"
-promtool test rules "$tmpdir/flux_test.yaml"
+for rule in flux bhaiya-model; do
+  case "$rule" in
+    flux) test_file=flux_test.yaml ;;
+    bhaiya-model) test_file=bhaiya_model_test.yaml ;;
+  esac
+  sed "/^namespace: ${rule}$/d" "$RULE_DIR/${rule}.yaml" >"$tmpdir/${rule}.yaml"
+  sed "s#../${rule}.yaml#$tmpdir/${rule}.yaml#" \
+    "$RULE_DIR/tests/$test_file" >"$tmpdir/$test_file"
+  promtool check rules "$tmpdir/${rule}.yaml"
+  promtool test rules "$tmpdir/$test_file"
+done


### PR DESCRIPTION
Implements the platform alerting slice of #727.

Adds Mimir alerts for sustained fresh fallback, fresh no-model resolution, and recent discovery failures including repeated initial failures. Idle/never-attempted replicas remain quiet; joins correlate real Bhaiya scrape labels by cluster and instance before stable cluster aggregation.

Verification:
- Pinned Prometheus 3.14.0 promtool adapter: Flux and Bhaiya model fixtures passed
- Kustomize render passed
- Mimir rule load-path check passed: 25 files, 3 tenant loaders, 24 unique namespaces

Do not close #727 until the rules are deployed and observed.