### PR TITLE
feat(validation): add HelmRelease schema gate

### DIFF
--- a/docs/reference/helmrelease-schema-validation.md
+++ b/docs/reference/helmrelease-schema-validation.md
@@ -1,0 +1,36 @@
+# Offline HelmRelease schema validation
+
+The repository validates rendered `helm.toolkit.fluxcd.io/v2` `HelmRelease`
+objects with `tools/check-helmrelease-schema.sh`. It uses Flate's rendered YAML
+so Flux substitutions and overlays are included, then runs the pinned
+kubeconform binary against the checked-in schema. Schema lookup has no HTTP
+fallback and does not contact a cluster.
+
+The schema is the complete `HelmRelease` v2 OpenAPI schema from
+`helm-controller` v1.6.4, selected by the Flux v2.9.5 bootstrap pin:
+
+* Flux source: `https://github.com/fluxcd/flux2/releases/tag/v2.9.5`
+* Flux bootstrap base: `https://github.com/fluxcd/flux2/tree/v2.9.5/manifests/bases/helm-controller`
+* CRD source: `https://github.com/fluxcd/helm-controller/releases/download/v1.6.4/helm-controller.crds.yaml`
+* CRD SHA-256: `8af19966e63cccde7d2c62e24c7bd3466010dd53e9d063e2ce22d1391e11f272`
+* validator: kubeconform v0.8.0, bootstrapped by `tools/kubeconform.sh`
+* kubeconform schema filename: `helmrelease-helm-v2-strict.json` (an explicit
+  JSON schema location; no Kubernetes-version directory is inferred)
+
+The checked-in JSON is generated with:
+
+```sh
+tools/update-helmrelease-schema.py /path/to/helm-controller.crds.yaml \
+  tools/schemas/helm-controller-v1.6.4/helmrelease-helm-v2-strict.json
+```
+
+The conversion closes declared object maps for kubeconform strict mode but
+preserves `x-kubernetes-preserve-unknown-fields`, including opaque
+`spec.values`. `spec.valuesFrom` is validated by the CRD schema. When either
+Flux or helm-controller changes, refresh the complete schema, SHA-256, and
+this provenance record together. JSON Schema cannot enforce Kubernetes CEL
+`x-kubernetes-validations`, defaulting, or admission behavior; this is a
+structural prevention slice, not server equivalence. The checker mechanically
+verifies the generated artifact hash and local Flux bootstrap pin, rejects
+unsupported HelmRelease API versions, and fails when a selected render emits
+zero HelmReleases. Never add a remote schema location to the checker.

--- a/docs/reference/helmrelease-schema-validation.md
+++ b/docs/reference/helmrelease-schema-validation.md
@@ -1,10 +1,13 @@
 # Offline HelmRelease schema validation
 
 The repository validates rendered `helm.toolkit.fluxcd.io/v2` `HelmRelease`
-objects with `tools/check-helmrelease-schema.sh`. It uses Flate's rendered YAML
-so Flux substitutions and overlays are included, then runs the pinned
-kubeconform binary against the checked-in schema. Schema lookup has no HTTP
-fallback and does not contact a cluster.
+objects with `tools/check-helmrelease-schema.sh`. It uses Flate's rendered
+Kustomization YAML from the location application tree (the `build all` output
+is final chart resources and does not contain the HelmRelease CRs), selects the
+raw HelmRelease documents, then runs the pinned kubeconform binary against the
+checked-in schema. The complete cluster render gate remains responsible for
+chart/source reconciliation failures. Schema lookup has no HTTP fallback and
+does not contact a cluster.
 
 The schema is the complete `HelmRelease` v2 OpenAPI schema from
 `helm-controller` v1.6.4, selected by the Flux v2.9.5 bootstrap pin:

--- a/tools/check-helmrelease-schema.sh
+++ b/tools/check-helmrelease-schema.sh
@@ -56,7 +56,10 @@ for cluster in "${targets[@]}"; do
   # the objects this CRD gate validates. The full cluster render gate below
   # remains authoritative for chart/source reconciliation failures.
   flate_rc=0
-  tools/flate.sh build ks --path "kubernetes/apps/$location" \
+  # CI exports FLATE_BASE=main for changed-only render gates. This focused
+  # schema view must inspect the existing full location tree even when the PR
+  # changes only tooling, or it would legitimately emit zero app documents.
+  env -u FLATE_BASE tools/flate.sh build ks --path "kubernetes/apps/$location" \
     --allow-missing-secrets --no-progress >"$rendered" 2>"$flate_err" || flate_rc=$?
   if [ ! -s "$rendered" ]; then
     echo "error: Flate emitted no rendered Kustomization output for $cluster (exit $flate_rc)" >&2

--- a/tools/check-helmrelease-schema.sh
+++ b/tools/check-helmrelease-schema.sh
@@ -48,7 +48,11 @@ total=0
 for cluster in "${targets[@]}"; do
   rendered="$tmp/$cluster.yaml"
   selected="$tmp/$cluster-helmreleases.yaml"
-  tools/flate.sh build all --path "clusters/$cluster/flux/config" \
+  # The flux/config subtree contains only the bootstrap Kustomization objects;
+  # HelmRelease sources live in the location's app tree beneath the cluster
+  # root. Render the complete cluster context so an empty bootstrap document
+  # set cannot masquerade as a successful schema check.
+  tools/flate.sh build all --path "clusters/$cluster" \
     --allow-missing-secrets --no-progress >"$rendered"
   count="$(python3 - "$rendered" "$selected" <<'PY'
 import pathlib, sys, yaml

--- a/tools/check-helmrelease-schema.sh
+++ b/tools/check-helmrelease-schema.sh
@@ -47,20 +47,37 @@ fi
 total=0
 for cluster in "${targets[@]}"; do
   rendered="$tmp/$cluster.yaml"
+  flate_err="$tmp/$cluster-flate.err"
   selected="$tmp/$cluster-helmreleases.yaml"
-  # The flux/config subtree contains only the bootstrap Kustomization objects;
-  # HelmRelease sources live in the location's app tree beneath the cluster
-  # root. Render the complete cluster context so an empty bootstrap document
-  # set cannot masquerade as a successful schema check.
-  tools/flate.sh build all --path "clusters/$cluster" \
-    --allow-missing-secrets --no-progress >"$rendered"
+  location="${cluster#talos-}"
+  # `build all` emits the final chart resources for HelmReleases; it does not
+  # emit the HelmRelease CRs themselves. The location application tree's
+  # Kustomization artifacts retain those post-build CR documents, which are
+  # the objects this CRD gate validates. The full cluster render gate below
+  # remains authoritative for chart/source reconciliation failures.
+  flate_rc=0
+  tools/flate.sh build ks --path "kubernetes/apps/$location" \
+    --allow-missing-secrets --no-progress >"$rendered" 2>"$flate_err" || flate_rc=$?
+  if [ ! -s "$rendered" ]; then
+    echo "error: Flate emitted no rendered Kustomization output for $cluster (exit $flate_rc)" >&2
+    tail -30 "$flate_err" >&2 || true
+    exit 1
+  fi
+  # Flate can retain usable Kustomization output while reporting unrelated
+  # chart/source failures in this source-only view. Do not turn that partial
+  # output into a false zero-resource schema failure; tools/check.sh runs the
+  # complete cluster render immediately after this focused check and reports
+  # those failures there.
   count="$(python3 - "$rendered" "$selected" <<'PY'
 import pathlib, sys, yaml
 source, target = map(pathlib.Path, sys.argv[1:])
 text = source.read_text()
 try:
-    documents = list(yaml.safe_load_all(text))
-    nodes = list(yaml.compose_all(text))
+    # BaseLoader inspects the node tree without applying PyYAML's YAML 1.1
+    # scalar constructors. Flate can legitimately emit plain values such as
+    # `=` that Kubernetes' YAML decoder accepts but SafeLoader rejects.
+    documents = list(yaml.load_all(text, Loader=yaml.BaseLoader))
+    nodes = list(yaml.compose_all(text, Loader=yaml.BaseLoader))
 except yaml.YAMLError as error:
     raise SystemExit(f"rendered Flate YAML is invalid: {error}")
 if len(documents) != len(nodes):

--- a/tools/check-helmrelease-schema.sh
+++ b/tools/check-helmrelease-schema.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Validate rendered Flux HelmRelease v2 objects against the pinned local CRD.
+# This intentionally validates Flate output, not source files: substitutions,
+# overlays, and generated resource shape must be checked together.
+set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+schema_root="$ROOT/tools/schemas/helm-controller-v1.6.4"
+schema="$schema_root/helmrelease-helm-v2-strict.json"
+schema_location="$schema"
+provenance="$schema_root/provenance.json"
+[ -s "$schema" ] || { echo "error: missing local HelmRelease schema: $schema" >&2; exit 2; }
+[ -s "$provenance" ] || { echo "error: missing schema provenance: $provenance" >&2; exit 2; }
+
+python3 - "$provenance" "$schema" "$ROOT/clusters/common/bootstrap/flux/kustomization.yaml" <<'PY'
+import hashlib, json, pathlib, re, sys
+provenance, schema, bootstrap = map(pathlib.Path, sys.argv[1:])
+lock = json.loads(provenance.read_text())
+actual = hashlib.sha256(schema.read_bytes()).hexdigest()
+if actual != lock["generatedSchemaSha256"]:
+    raise SystemExit("schema artifact hash does not match provenance")
+match = re.search(r"flux2/manifests/install\?ref=v([0-9.]+)", bootstrap.read_text())
+if not match:
+    raise SystemExit("cannot find the Flux bootstrap version")
+if match.group(1) != lock["fluxVersion"]:
+    raise SystemExit(
+        f"Flux bootstrap is v{match.group(1)}, schema provenance is v{lock['fluxVersion']}"
+    )
+PY
+
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT INT TERM
+targets=(talos-ottawa talos-robbinsdale talos-stpetersburg)
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [talos-ottawa|talos-robbinsdale|talos-stpetersburg]" >&2
+  exit 2
+elif [ "$#" = 1 ]; then
+  case "$1" in
+    ot|ottawa|talos-ottawa) targets=(talos-ottawa) ;;
+    rb|robbinsdale|talos-robbinsdale) targets=(talos-robbinsdale) ;;
+    sp|stpetersburg|talos-stpetersburg) targets=(talos-stpetersburg) ;;
+    *) echo "error: unknown cluster '$1'" >&2; exit 2 ;;
+  esac
+fi
+
+total=0
+for cluster in "${targets[@]}"; do
+  rendered="$tmp/$cluster.yaml"
+  selected="$tmp/$cluster-helmreleases.yaml"
+  tools/flate.sh build all --path "clusters/$cluster/flux/config" \
+    --allow-missing-secrets --no-progress >"$rendered"
+  count="$(python3 - "$rendered" "$selected" <<'PY'
+import pathlib, sys, yaml
+source, target = map(pathlib.Path, sys.argv[1:])
+text = source.read_text()
+try:
+    documents = list(yaml.safe_load_all(text))
+    nodes = list(yaml.compose_all(text))
+except yaml.YAMLError as error:
+    raise SystemExit(f"rendered Flate YAML is invalid: {error}")
+if len(documents) != len(nodes):
+    raise SystemExit("rendered YAML document accounting mismatch")
+selected = []
+for document, node in zip(documents, nodes):
+    if not isinstance(document, dict) or document.get("kind") != "HelmRelease":
+        continue
+    api_version = document.get("apiVersion")
+    if api_version != "helm.toolkit.fluxcd.io/v2":
+        raise SystemExit(
+            f"unsupported HelmRelease API version {api_version!r}; update the pinned schema"
+        )
+    selected.append(text[node.start_mark.index:node.end_mark.index])
+with target.open("w") as stream:
+    for document in selected:
+        stream.write("---\n")
+        stream.write(document)
+        if not document.endswith("\n"):
+            stream.write("\n")
+print(len(selected))
+PY
+  )"
+  case "$count" in ''|*[!0-9]*) echo "error: invalid HelmRelease count for $cluster: $count" >&2; exit 2;; esac
+  [ "$count" -gt 0 ] || { echo "error: Flate emitted no HelmRelease v2 resources for $cluster" >&2; exit 1; }
+  tools/kubeconform.sh -strict -schema-location "$schema_location" \
+    -output text -summary "$selected"
+  total=$((total + count))
+done
+echo "HelmRelease v2 schema OK (validated $total rendered resources)"

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -195,6 +195,12 @@ if [ "$QUICK" = 1 ]; then
 fi
 
 if [ -n "$TARGET" ]; then
+  run_capped "helmrelease-schema" tools/check-helmrelease-schema.sh "$TARGET"
+else
+  run_capped "helmrelease-schema" tools/check-helmrelease-schema.sh
+fi
+
+if [ -n "$TARGET" ]; then
   run_capped "render" make "test-$TARGET"
   echo "✓ render OK: $TARGET"
 else

--- a/tools/kubeconform.sh
+++ b/tools/kubeconform.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Run the exact kubeconform release used by the repository schema gate.
+# Like tools/flate.sh, the verified binary is cached per platform and is
+# bootstrapped only when absent; schemas are never fetched by this wrapper.
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="0.8.0"
+
+version_of() {
+  "$1" -v 2>/dev/null | sed -n 's/^v//p' | head -1
+}
+
+if [ -n "${KMAN_KUBECONFORM_BIN:-}" ]; then
+  actual="$(version_of "$KMAN_KUBECONFORM_BIN" || true)"
+  [ "$actual" = "$VERSION" ] || {
+    echo "error: KMAN_KUBECONFORM_BIN is kubeconform ${actual:-unknown}; expected $VERSION" >&2
+    exit 2
+  }
+  exec "$KMAN_KUBECONFORM_BIN" "$@"
+fi
+
+if command -v kubeconform >/dev/null 2>&1; then
+  system="$(command -v kubeconform)"
+  if [ "$(version_of "$system" || true)" = "$VERSION" ]; then
+    exec "$system" "$@"
+  fi
+fi
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$os/$arch" in
+  darwin/x86_64) asset="kubeconform-darwin-amd64.tar.gz" ;;
+  darwin/arm64) asset="kubeconform-darwin-arm64.tar.gz" ;;
+  linux/x86_64) asset="kubeconform-linux-amd64.tar.gz" ;;
+  linux/aarch64|linux/arm64) asset="kubeconform-linux-arm64.tar.gz" ;;
+  *) echo "error: no bootstrapped kubeconform binary for $os/$arch" >&2; exit 2 ;;
+esac
+
+if [ -n "${XDG_CACHE_HOME:-}" ]; then
+  cache_root="$XDG_CACHE_HOME"
+elif [ "$os" = darwin ]; then
+  cache_root="${HOME:?HOME is required}/Library/Caches"
+else
+  cache_root="${HOME:?HOME is required}/.cache"
+fi
+
+install_dir="$cache_root/kubernetes-manifests/kubeconform/$VERSION/$os-$arch"
+cached="$install_dir/kubeconform"
+if [ -x "$cached" ] && [ "$(version_of "$cached" || true)" = "$VERSION" ]; then
+  exec "$cached" "$@"
+fi
+
+mkdir -p "$install_dir"
+stage="$(mktemp -d "$install_dir/.install.XXXXXX")"
+trap 'rm -rf -- "$stage"' EXIT INT TERM
+base="https://github.com/yannh/kubeconform/releases/download/v${VERSION}"
+curl --fail --silent --show-error --location --retry 3 --retry-all-errors \
+  --connect-timeout 10 --max-time 120 "$base/$asset" -o "$stage/$asset"
+curl --fail --silent --show-error --location --retry 3 --retry-all-errors \
+  --connect-timeout 10 --max-time 120 "$base/CHECKSUMS" -o "$stage/CHECKSUMS"
+expected="$(awk -v file="$asset" '$2 == file {print $1}' "$stage/CHECKSUMS")"
+[ "${#expected}" = 64 ] || { echo "error: missing checksum for $asset" >&2; exit 1; }
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$stage/$asset" | awk '{print $1}')"
+else
+  actual="$(shasum -a 256 "$stage/$asset" | awk '{print $1}')"
+fi
+[ "$actual" = "$expected" ] || { echo "error: checksum mismatch for $asset" >&2; exit 1; }
+tar -xzf "$stage/$asset" -C "$stage" kubeconform
+chmod 0755 "$stage/kubeconform"
+[ "$(version_of "$stage/kubeconform")" = "$VERSION" ] || {
+  echo "error: downloaded kubeconform has unexpected version" >&2; exit 1;
+}
+mv -f -- "$stage/kubeconform" "$cached"
+exec "$cached" "$@"

--- a/tools/schemas/helm-controller-v1.6.4/helmrelease-helm-v2-strict.json
+++ b/tools/schemas/helm-controller-v1.6.4/helmrelease-helm-v2-strict.json
@@ -1,0 +1,1306 @@
+{
+  "additionalProperties": false,
+  "description": "HelmRelease is the Schema for the helmreleases API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "description": "HelmReleaseSpec defines the desired state of a Helm release.",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "description": "Chart defines the template of the v1.HelmChart that should be created\nfor this HelmRelease.",
+          "properties": {
+            "metadata": {
+              "additionalProperties": false,
+              "description": "ObjectMeta holds the template for metadata like labels and annotations.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "additionalProperties": false,
+              "description": "Spec holds the template for the v1.HelmChartSpec for this HelmRelease.",
+              "properties": {
+                "chart": {
+                  "description": "The name or path the Helm chart is available at in the SourceRef.",
+                  "maxLength": 2048,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "ignoreMissingValuesFiles": {
+                  "description": "IgnoreMissingValuesFiles controls whether to silently ignore missing values files rather than failing.",
+                  "type": "boolean"
+                },
+                "interval": {
+                  "description": "Interval at which to check the v1.Source for updates. Defaults to\n'HelmReleaseSpec.Interval'.",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+                  "type": "string"
+                },
+                "reconcileStrategy": {
+                  "default": "ChartVersion",
+                  "description": "Determines what enables the creation of a new artifact. Valid values are\n('ChartVersion', 'Revision').\nSee the documentation of the values for an explanation on their behavior.\nDefaults to ChartVersion when omitted.",
+                  "enum": [
+                    "ChartVersion",
+                    "Revision"
+                  ],
+                  "type": "string"
+                },
+                "sourceRef": {
+                  "additionalProperties": false,
+                  "description": "The name and namespace of the v1.Source the chart is available at.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion of the referent.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent.",
+                      "enum": [
+                        "HelmRepository",
+                        "GitRepository",
+                        "Bucket"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent.",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "valuesFiles": {
+                  "description": "Alternative list of values files to use as the chart values (values.yaml\nis not included by default), expected to be a relative path in the SourceRef.\nValues files are merged in the order of this list with the last file overriding\nthe first. Ignored when omitted.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "verify": {
+                  "additionalProperties": false,
+                  "description": "Verify contains the secret name containing the trusted public keys\nused to verify the signature and specifies which provider to use to check\nwhether OCI image is authentic.\nThis field is only supported for OCI sources.\nChart dependencies, which are not bundled in the umbrella chart artifact,\nare not verified.",
+                  "properties": {
+                    "provider": {
+                      "default": "cosign",
+                      "description": "Provider specifies the technology used to sign the OCI Helm chart.",
+                      "enum": [
+                        "cosign",
+                        "notation"
+                      ],
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "additionalProperties": false,
+                      "description": "SecretRef specifies the Kubernetes Secret containing the\ntrusted public keys.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "provider"
+                  ],
+                  "type": "object"
+                },
+                "version": {
+                  "default": "*",
+                  "description": "Version semver expression, ignored for charts from v1.GitRepository and\nv1beta2.Bucket sources. Defaults to latest when omitted.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "chart",
+                "sourceRef"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object"
+        },
+        "chartRef": {
+          "additionalProperties": false,
+          "description": "ChartRef holds a reference to a source controller resource containing the\nHelm chart artifact.",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion of the referent.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.",
+              "enum": [
+                "OCIRepository",
+                "HelmChart",
+                "ExternalArtifact"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent, defaults to the namespace of the Kubernetes\nresource object that contains the reference.",
+              "maxLength": 63,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "commonMetadata": {
+          "additionalProperties": false,
+          "description": "CommonMetadata specifies the common labels and annotations that are\napplied to all resources. Any existing label or annotation will be\noverridden if its key matches a common one.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to be added to the object's metadata.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to be added to the object's metadata.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "dependsOn": {
+          "description": "DependsOn may contain a DependencyReference slice with\nreferences to HelmRelease resources that must be ready before this HelmRelease\ncan be reconciled.",
+          "items": {
+            "additionalProperties": false,
+            "description": "DependencyReference contains enough information to locate the referenced Kubernetes resource object\nand optional CEL expression to assess its readiness.",
+            "properties": {
+              "name": {
+                "description": "Name of the referent.",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the referent, defaults to the namespace of the resource\nobject that contains the reference.",
+                "type": "string"
+              },
+              "readyExpr": {
+                "description": "ReadyExpr is a CEL expression that can be used to assess the readiness\nof a dependency. When specified, the built-in readiness check\nis replaced by the logic defined in the CEL expression.\nTo make the CEL expression additive to the built-in readiness check,\nthe feature gate `AdditiveCELDependencyCheck` must be set to `true`.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "driftDetection": {
+          "additionalProperties": false,
+          "description": "DriftDetection holds the configuration for detecting and handling\ndifferences between the manifest in the Helm storage and the resources\ncurrently existing in the cluster.",
+          "properties": {
+            "ignore": {
+              "description": "Ignore contains a list of rules for specifying which changes to ignore\nduring diffing.",
+              "items": {
+                "additionalProperties": false,
+                "description": "IgnoreRule defines a rule to selectively disregard specific changes during\nthe drift detection process.",
+                "properties": {
+                  "paths": {
+                    "description": "Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from\nconsideration in a Kubernetes object.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "target": {
+                    "additionalProperties": false,
+                    "description": "Target is a selector for specifying Kubernetes objects to which this\nrule applies.\nIf Target is not set, the Paths will be ignored for all Kubernetes\nobjects within the manifest of the Helm release.",
+                    "properties": {
+                      "annotationSelector": {
+                        "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource annotations.",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Group is the API group to select resources from.\nTogether with Version and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind of the API Group to select resources from.\nTogether with Group and Version it is capable of unambiguously\nidentifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      },
+                      "labelSelector": {
+                        "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource labels.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name to match resources with.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace to select resources from.",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Version of the API Group to select resources from.\nTogether with Group and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "paths"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "mode": {
+              "description": "Mode defines how differences should be handled between the Helm manifest\nand the manifest currently applied to the cluster.\nIf not explicitly set, it defaults to DiffModeDisabled.",
+              "enum": [
+                "enabled",
+                "warn",
+                "disabled"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "healthCheckExprs": {
+          "description": "HealthCheckExprs is a list of healthcheck expressions for evaluating the\nhealth of custom resources using Common Expression Language (CEL).\nThe expressions are evaluated only when the specific Helm action\ntaking place has wait enabled, i.e. DisableWait is false, and the\n'poller' WaitStrategy is used.",
+          "items": {
+            "additionalProperties": false,
+            "description": "CustomHealthCheck defines the health check for custom resources.",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion of the custom resource under evaluation.",
+                "type": "string"
+              },
+              "current": {
+                "description": "Current is the CEL expression that determines if the status\nof the custom resource has reached the desired state.",
+                "type": "string"
+              },
+              "failed": {
+                "description": "Failed is the CEL expression that determines if the status\nof the custom resource has failed to reach the desired state.",
+                "type": "string"
+              },
+              "inProgress": {
+                "description": "InProgress is the CEL expression that determines if the status\nof the custom resource has not yet reached the desired state.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the custom resource under evaluation.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "apiVersion",
+              "current"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "install": {
+          "additionalProperties": false,
+          "description": "Install holds the configuration for Helm install actions for this HelmRelease.",
+          "properties": {
+            "crds": {
+              "description": "CRDs upgrade CRDs from the Helm Chart's crds directory according\nto the CRD upgrade policy provided here. Valid values are `Skip`,\n`Create` or `CreateReplace`. Default is `Create` and if omitted\nCRDs are installed but not updated.\n\nSkip: do neither install nor replace (update) any CRDs.\n\nCreate: new CRDs are created, existing CRDs are neither updated nor deleted.\n\nCreateReplace: new CRDs are created, existing CRDs are updated (replaced)\nbut not deleted.\n\nBy default, CRDs are applied (installed) during Helm install action.\nWith this option users can opt in to CRD replace existing CRDs on Helm\ninstall actions, which is not (yet) natively supported by Helm.\nhttps://helm.sh/docs/chart_best_practices/custom_resource_definitions.",
+              "enum": [
+                "Skip",
+                "Create",
+                "CreateReplace"
+              ],
+              "type": "string"
+            },
+            "createNamespace": {
+              "description": "CreateNamespace tells the Helm install action to create the\nHelmReleaseSpec.TargetNamespace if it does not exist yet.\nOn uninstall, the namespace will not be garbage collected.",
+              "type": "boolean"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm install action.",
+              "type": "boolean"
+            },
+            "disableOpenAPIValidation": {
+              "description": "DisableOpenAPIValidation prevents the Helm install action from validating\nrendered templates against the Kubernetes OpenAPI Schema.",
+              "type": "boolean"
+            },
+            "disableSchemaValidation": {
+              "description": "DisableSchemaValidation prevents the Helm install action from validating\nthe values against the JSON Schema.",
+              "type": "boolean"
+            },
+            "disableTakeOwnership": {
+              "description": "DisableTakeOwnership disables taking ownership of existing resources\nduring the Helm install action. Defaults to false.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables the waiting for resources to be ready after a Helm\ninstall has been performed.",
+              "type": "boolean"
+            },
+            "disableWaitForJobs": {
+              "description": "DisableWaitForJobs disables waiting for jobs to complete after a Helm\ninstall has been performed.",
+              "type": "boolean"
+            },
+            "remediation": {
+              "additionalProperties": false,
+              "description": "Remediation holds the remediation configuration for when the Helm install\naction for the HelmRelease fails. The default is to not perform any action.",
+              "properties": {
+                "ignoreTestFailures": {
+                  "description": "IgnoreTestFailures tells the controller to skip remediation when the Helm\ntests are run after an install action but fail. Defaults to\n'Test.IgnoreFailures'.",
+                  "type": "boolean"
+                },
+                "remediateLastFailure": {
+                  "description": "RemediateLastFailure tells the controller to remediate the last failure, when\nno retries remain. Defaults to 'false'.",
+                  "type": "boolean"
+                },
+                "retries": {
+                  "description": "Retries is the number of retries that should be attempted on failures before\nbailing. Remediation, using an uninstall, is performed between each attempt.\nDefaults to '0', a negative integer equals to unlimited retries.",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "replace": {
+              "description": "Replace tells the Helm install action to re-use the 'ReleaseName', but only\nif that name is a deleted release which remains in the history.",
+              "type": "boolean"
+            },
+            "serverSideApply": {
+              "description": "ServerSideApply enables server-side apply for resources during install.\nDefaults to true (or false when UseHelm3Defaults feature gate is enabled).",
+              "type": "boolean"
+            },
+            "skipCRDs": {
+              "description": "SkipCRDs tells the Helm install action to not install any CRDs. By default,\nCRDs are installed if not already present.\n\nDeprecated use CRD policy (`crds`) attribute with value `Skip` instead.",
+              "type": "boolean"
+            },
+            "strategy": {
+              "additionalProperties": false,
+              "description": "Strategy defines the install strategy to use for this HelmRelease.\nDefaults to 'RemediateOnFailure', or 'RetryOnFailure' when the\nDefaultToRetryOnFailure feature gate is enabled.",
+              "properties": {
+                "name": {
+                  "description": "Name of the install strategy.",
+                  "enum": [
+                    "RemediateOnFailure",
+                    "RetryOnFailure"
+                  ],
+                  "type": "string"
+                },
+                "retryInterval": {
+                  "description": "RetryInterval is the interval at which to retry a failed install.\nCan be used only when Name is set to RetryOnFailure.\nDefaults to '5m'.",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": ".retryInterval cannot be set when .name is 'RemediateOnFailure'",
+                  "rule": "!has(self.retryInterval) || self.name != 'RemediateOnFailure'"
+                }
+              ]
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm install action. Defaults to\n'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "interval": {
+          "description": "Interval at which to reconcile the Helm release.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "kubeConfig": {
+          "additionalProperties": false,
+          "description": "KubeConfig for reconciling the HelmRelease on a remote cluster.\nWhen used in combination with HelmReleaseSpec.ServiceAccountName,\nforces the controller to act on behalf of that Service Account at the\ntarget cluster.\nIf the --default-service-account flag is set, its value will be used as\na controller level fallback for when HelmReleaseSpec.ServiceAccountName\nis empty.",
+          "properties": {
+            "configMapRef": {
+              "additionalProperties": false,
+              "description": "ConfigMapRef holds an optional name of a ConfigMap that contains\nthe following keys:\n\n- `provider`: the provider to use. One of `aws`, `azure`, `gcp`, or\n   `generic`. Required.\n- `cluster`: the fully qualified resource name of the Kubernetes\n   cluster in the cloud provider API. Not used by the `generic`\n   provider. Required when one of `address` or `ca.crt` is not set.\n- `address`: the address of the Kubernetes API server. Required\n   for `generic`. For the other providers, if not specified, the\n   first address in the cluster resource will be used, and if\n   specified, it must match one of the addresses in the cluster\n   resource.\n   If audiences is not set, will be used as the audience for the\n   `generic` provider.\n- `ca.crt`: the optional PEM-encoded CA certificate for the\n   Kubernetes API server. If not set, the controller will use the\n   CA certificate from the cluster resource.\n- `audiences`: the optional audiences as a list of\n   line-break-separated strings for the Kubernetes ServiceAccount\n   token. Defaults to the `address` for the `generic` provider, or\n   to specific values for the other providers depending on the\n   provider.\n-  `serviceAccountName`: the optional name of the Kubernetes\n   ServiceAccount in the same namespace that should be used\n   for authentication. If not specified, the controller\n   ServiceAccount will be used.\n\nMutually exclusive with SecretRef.",
+              "properties": {
+                "name": {
+                  "description": "Name of the referent.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "secretRef": {
+              "additionalProperties": false,
+              "description": "SecretRef holds an optional name of a secret that contains a key with\nthe kubeconfig file as the value. If no key is set, the key will default\nto 'value'. Mutually exclusive with ConfigMapRef.\nIt is recommended that the kubeconfig is self-contained, and the secret\nis regularly updated if credentials such as a cloud-access-token expire.\nCloud specific `cmd-path` auth helpers will not function without adding\nbinaries and credentials to the Pod that is responsible for reconciling\nKubernetes resources. Supported only for the generic provider.",
+              "properties": {
+                "key": {
+                  "description": "Key in the Secret, when not specified an implementation-specific default key is used.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the Secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified",
+              "rule": "has(self.configMapRef) || has(self.secretRef)"
+            },
+            {
+              "message": "exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified",
+              "rule": "!has(self.configMapRef) || !has(self.secretRef)"
+            }
+          ]
+        },
+        "maxHistory": {
+          "description": "MaxHistory is the number of revisions saved by Helm for this HelmRelease.\nUse '0' for an unlimited number of revisions; defaults to '5'.",
+          "type": "integer"
+        },
+        "persistentClient": {
+          "description": "PersistentClient tells the controller to use a persistent Kubernetes\nclient for this release. When enabled, the client will be reused for the\nduration of the reconciliation, instead of being created and destroyed\nfor each (step of a) Helm action.\n\nThis can improve performance, but may cause issues with some Helm charts\nthat for example do create Custom Resource Definitions during installation\noutside Helm's CRD lifecycle hooks, which are then not observed to be\navailable by e.g. post-install hooks.\n\nIf not set, it defaults to true.",
+          "type": "boolean"
+        },
+        "postRenderStrategy": {
+          "description": "PostRenderStrategy defines the strategy for sending hooks to post-renderers.\nValid values are 'nohooks' (hooks not sent to post-renderers, Helm 3 behavior),\n'combined' (hooks and templates sent together, Helm 4 default), and 'separate'\n(hooks and templates sent in separate streams, Helm 4.2 opt-in).\nDefaults to 'combined', or 'nohooks' when the UseHelm3Defaults feature gate is enabled.",
+          "enum": [
+            "nohooks",
+            "combined",
+            "separate"
+          ],
+          "type": "string"
+        },
+        "postRenderers": {
+          "description": "PostRenderers holds an array of Helm PostRenderers, which will be applied in order\nof their definition.",
+          "items": {
+            "additionalProperties": false,
+            "description": "PostRenderer contains a Helm PostRenderer specification.",
+            "properties": {
+              "kustomize": {
+                "additionalProperties": false,
+                "description": "Kustomization to apply as PostRenderer.",
+                "properties": {
+                  "images": {
+                    "description": "Images is a list of (image name, new name, new tag or digest)\nfor changing image names, tags or digests. This can also be achieved with a\npatch, but this operator is simpler to specify.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.",
+                      "properties": {
+                        "digest": {
+                          "description": "Digest is the value used to replace the original image tag.\nIf digest is present NewTag value is ignored.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is a tag-less image name.",
+                          "type": "string"
+                        },
+                        "newName": {
+                          "description": "NewName is the value used to replace the original name.",
+                          "type": "string"
+                        },
+                        "newTag": {
+                          "description": "NewTag is the value used to replace the original tag.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "patches": {
+                    "description": "Strategic merge and JSON patches, defined as inline YAML objects,\ncapable of targeting objects based on kind, label and annotation selectors.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should\nbe applied to.",
+                      "properties": {
+                        "patch": {
+                          "description": "Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with\nan array of operation objects.",
+                          "type": "string"
+                        },
+                        "target": {
+                          "additionalProperties": false,
+                          "description": "Target points to the resources that the patch document should be applied to.",
+                          "properties": {
+                            "annotationSelector": {
+                              "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource annotations.",
+                              "type": "string"
+                            },
+                            "group": {
+                              "description": "Group is the API group to select resources from.\nTogether with Version and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of the API Group to select resources from.\nTogether with Group and Version it is capable of unambiguously\nidentifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                              "type": "string"
+                            },
+                            "labelSelector": {
+                              "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource labels.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name to match resources with.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace to select resources from.",
+                              "type": "string"
+                            },
+                            "version": {
+                              "description": "Version of the API Group to select resources from.\nTogether with Group and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "patch"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "releaseName": {
+          "description": "ReleaseName used for the Helm release. Defaults to a composition of\n'[TargetNamespace-]Name'.",
+          "maxLength": 53,
+          "minLength": 1,
+          "type": "string"
+        },
+        "rollback": {
+          "additionalProperties": false,
+          "description": "Rollback holds the configuration for Helm rollback actions for this HelmRelease.",
+          "properties": {
+            "cleanupOnFail": {
+              "description": "CleanupOnFail allows deletion of new resources created during the Helm\nrollback action when it fails.",
+              "type": "boolean"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm rollback action.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables the waiting for resources to be ready after a Helm\nrollback has been performed.",
+              "type": "boolean"
+            },
+            "disableWaitForJobs": {
+              "description": "DisableWaitForJobs disables waiting for jobs to complete after a Helm\nrollback has been performed.",
+              "type": "boolean"
+            },
+            "force": {
+              "description": "Force forces resource updates through a replacement strategy\nthat avoids 3-way merge conflicts on client-side apply.\nThis field is ignored for server-side apply (which always\nforces conflicts with other field managers).",
+              "type": "boolean"
+            },
+            "recreate": {
+              "description": "Recreate performs pod restarts for any managed workloads.\n\nDeprecated: This behavior was deprecated in Helm 3:\n  - Deprecation: https://github.com/helm/helm/pull/6463\n  - Removal: https://github.com/helm/helm/pull/31023\nAfter helm-controller was upgraded to the Helm 4 SDK,\nthis field is no longer functional and will print a\nwarning if set to true. It will also be removed in a\nfuture release.",
+              "type": "boolean"
+            },
+            "serverSideApply": {
+              "description": "ServerSideApply enables server-side apply for resources during rollback.\nCan be \"enabled\", \"disabled\", or \"auto\".\nWhen \"auto\", server-side apply usage will be based on the release's previous usage.\nDefaults to \"auto\".",
+              "enum": [
+                "enabled",
+                "disabled",
+                "auto"
+              ],
+              "type": "string"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm rollback action. Defaults to\n'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "serviceAccountName": {
+          "description": "The name of the Kubernetes service account to impersonate\nwhen reconciling this HelmRelease.",
+          "maxLength": 253,
+          "minLength": 1,
+          "type": "string"
+        },
+        "storageNamespace": {
+          "description": "StorageNamespace used for the Helm storage.\nDefaults to the namespace of the HelmRelease.",
+          "maxLength": 63,
+          "minLength": 1,
+          "type": "string"
+        },
+        "suspend": {
+          "description": "Suspend tells the controller to suspend reconciliation for this HelmRelease,\nit does not apply to already started reconciliations. Defaults to false.",
+          "type": "boolean"
+        },
+        "targetNamespace": {
+          "description": "TargetNamespace to target when performing operations for the HelmRelease.\nDefaults to the namespace of the HelmRelease.",
+          "maxLength": 63,
+          "minLength": 1,
+          "type": "string"
+        },
+        "test": {
+          "additionalProperties": false,
+          "description": "Test holds the configuration for Helm test actions for this HelmRelease.",
+          "properties": {
+            "enable": {
+              "description": "Enable enables Helm test actions for this HelmRelease after an Helm install\nor upgrade action has been performed.",
+              "type": "boolean"
+            },
+            "filters": {
+              "description": "Filters is a list of tests to run or exclude from running.",
+              "items": {
+                "additionalProperties": false,
+                "description": "Filter holds the configuration for individual Helm test filters.",
+                "properties": {
+                  "exclude": {
+                    "description": "Exclude specifies whether the named test should be excluded.",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Name is the name of the test.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "ignoreFailures": {
+              "description": "IgnoreFailures tells the controller to skip remediation when the Helm tests\nare run but fail. Can be overwritten for tests run after install or upgrade\nactions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.",
+              "type": "boolean"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation during\nthe performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "timeout": {
+          "description": "Timeout is the time to wait for any individual Kubernetes operation (like Jobs\nfor hooks) during the performance of a Helm action. Defaults to '5m0s'.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "uninstall": {
+          "additionalProperties": false,
+          "description": "Uninstall holds the configuration for Helm uninstall actions for this HelmRelease.",
+          "properties": {
+            "deletionPropagation": {
+              "default": "background",
+              "description": "DeletionPropagation specifies the deletion propagation policy when\na Helm uninstall is performed.",
+              "enum": [
+                "background",
+                "foreground",
+                "orphan"
+              ],
+              "type": "string"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm rollback action.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables waiting for all the resources to be deleted after\na Helm uninstall is performed.",
+              "type": "boolean"
+            },
+            "keepHistory": {
+              "description": "KeepHistory tells Helm to remove all associated resources and mark the\nrelease as deleted, but retain the release history.",
+              "type": "boolean"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm uninstall action. Defaults\nto 'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "upgrade": {
+          "additionalProperties": false,
+          "description": "Upgrade holds the configuration for Helm upgrade actions for this HelmRelease.",
+          "properties": {
+            "chartNameChangeStrategy": {
+              "description": "ChartNameChangeStrategy defines the strategy to use when a Helm chart name changes.\nValid values are 'Reinstall' or 'InPlaceUpdate'. Defaults to 'Reinstall' if omitted.\n\nReinstall: Reinstall the Helm release, uninstalling the existing Helm release.\n\nInPlaceUpdate: Update the Helm release in place.",
+              "enum": [
+                "InPlaceUpdate",
+                "Reinstall"
+              ],
+              "type": "string"
+            },
+            "cleanupOnFail": {
+              "description": "CleanupOnFail allows deletion of new resources created during the Helm\nupgrade action when it fails.",
+              "type": "boolean"
+            },
+            "crds": {
+              "description": "CRDs upgrade CRDs from the Helm Chart's crds directory according\nto the CRD upgrade policy provided here. Valid values are `Skip`,\n`Create` or `CreateReplace`. Default is `Skip` and if omitted\nCRDs are neither installed nor upgraded.\n\nSkip: do neither install nor replace (update) any CRDs.\n\nCreate: new CRDs are created, existing CRDs are neither updated nor deleted.\n\nCreateReplace: new CRDs are created, existing CRDs are updated (replaced)\nbut not deleted.\n\nBy default, CRDs are not applied during Helm upgrade action. With this\noption users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.\nhttps://helm.sh/docs/chart_best_practices/custom_resource_definitions.",
+              "enum": [
+                "Skip",
+                "Create",
+                "CreateReplace"
+              ],
+              "type": "string"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm upgrade action.",
+              "type": "boolean"
+            },
+            "disableOpenAPIValidation": {
+              "description": "DisableOpenAPIValidation prevents the Helm upgrade action from validating\nrendered templates against the Kubernetes OpenAPI Schema.",
+              "type": "boolean"
+            },
+            "disableSchemaValidation": {
+              "description": "DisableSchemaValidation prevents the Helm upgrade action from validating\nthe values against the JSON Schema.",
+              "type": "boolean"
+            },
+            "disableTakeOwnership": {
+              "description": "DisableTakeOwnership disables taking ownership of existing resources\nduring the Helm upgrade action. Defaults to false.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables the waiting for resources to be ready after a Helm\nupgrade has been performed.",
+              "type": "boolean"
+            },
+            "disableWaitForJobs": {
+              "description": "DisableWaitForJobs disables waiting for jobs to complete after a Helm\nupgrade has been performed.",
+              "type": "boolean"
+            },
+            "force": {
+              "description": "Force forces resource updates through a replacement strategy\nthat avoids 3-way merge conflicts on client-side apply.\nThis field is ignored for server-side apply (which always\nforces conflicts with other field managers).",
+              "type": "boolean"
+            },
+            "preserveValues": {
+              "description": "PreserveValues will make Helm reuse the last release's values and merge in\noverrides from 'Values'. Setting this flag makes the HelmRelease\nnon-declarative.",
+              "type": "boolean"
+            },
+            "remediation": {
+              "additionalProperties": false,
+              "description": "Remediation holds the remediation configuration for when the Helm upgrade\naction for the HelmRelease fails. The default is to not perform any action.",
+              "properties": {
+                "ignoreTestFailures": {
+                  "description": "IgnoreTestFailures tells the controller to skip remediation when the Helm\ntests are run after an upgrade action but fail.\nDefaults to 'Test.IgnoreFailures'.",
+                  "type": "boolean"
+                },
+                "remediateLastFailure": {
+                  "description": "RemediateLastFailure tells the controller to remediate the last failure, when\nno retries remain. Defaults to 'false' unless 'Retries' is greater than 0.",
+                  "type": "boolean"
+                },
+                "retries": {
+                  "description": "Retries is the number of retries that should be attempted on failures before\nbailing. Remediation, using 'Strategy', is performed between each attempt.\nDefaults to '0', a negative integer equals to unlimited retries.",
+                  "type": "integer"
+                },
+                "strategy": {
+                  "description": "Strategy to use for failure remediation. Defaults to 'rollback'.",
+                  "enum": [
+                    "rollback",
+                    "uninstall"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serverSideApply": {
+              "description": "ServerSideApply enables server-side apply for resources during upgrade.\nCan be \"enabled\", \"disabled\", or \"auto\".\nWhen \"auto\", server-side apply usage will be based on the release's previous usage.\nDefaults to \"auto\".",
+              "enum": [
+                "enabled",
+                "disabled",
+                "auto"
+              ],
+              "type": "string"
+            },
+            "strategy": {
+              "additionalProperties": false,
+              "description": "Strategy defines the upgrade strategy to use for this HelmRelease.\nDefaults to 'RemediateOnFailure', or 'RetryOnFailure' when the\nDefaultToRetryOnFailure feature gate is enabled.",
+              "properties": {
+                "name": {
+                  "description": "Name of the upgrade strategy.",
+                  "enum": [
+                    "RemediateOnFailure",
+                    "RetryOnFailure"
+                  ],
+                  "type": "string"
+                },
+                "retryInterval": {
+                  "description": "RetryInterval is the interval at which to retry a failed upgrade.\nCan be used only when Name is set to RetryOnFailure.\nDefaults to '5m'.",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": ".retryInterval can only be set when .name is 'RetryOnFailure'",
+                  "rule": "!has(self.retryInterval) || self.name == 'RetryOnFailure'"
+                }
+              ]
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm upgrade action. Defaults to\n'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "values": {
+          "description": "Values holds the values for this Helm release.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "valuesFrom": {
+          "description": "ValuesFrom holds references to resources containing Helm values for this HelmRelease,\nand information about how they should be merged.",
+          "items": {
+            "additionalProperties": false,
+            "description": "ValuesReference contains a reference to a resource containing Helm values,\nand optionally the key they can be found at.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the values referent, valid values are ('Secret', 'ConfigMap').",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "literal": {
+                "description": "Literal marks this ValuesReference as a literal value. When set in\ncombination with TargetPath, the referenced value is merged at the target\npath without interpreting Helm's `--set` syntax (commas, brackets, dots,\nequal signs, etc.), mirroring the behavior of `helm --set-literal`. This\nis the only safe way to inject arbitrary file content (config files, JSON\nblobs, multi-line strings containing special characters) through\n`valuesFrom`. Has no effect when TargetPath is empty: in that mode the\nreferenced value is always YAML-merged at the root.",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Name of the values referent. Should reside in the same namespace as the\nreferring resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "type": "string"
+              },
+              "optional": {
+                "description": "Optional marks this ValuesReference as optional. When set, a not found error\nfor the values reference is ignored, but any ValuesKey, TargetPath or\ntransient error will still result in a reconciliation failure.",
+                "type": "boolean"
+              },
+              "targetPath": {
+                "description": "TargetPath is the YAML dot notation path the value should be merged at. When\nset, the ValuesKey is expected to be a single flat value. Defaults to 'None',\nwhich results in the values getting merged at the root.",
+                "maxLength": 250,
+                "pattern": "^([a-zA-Z0-9_\\-.\\\\\\/]|\\[[0-9]{1,5}\\])+$",
+                "type": "string"
+              },
+              "valuesKey": {
+                "description": "ValuesKey is the data key where the values.yaml or a specific value can be\nfound at. Defaults to 'values.yaml'.",
+                "maxLength": 253,
+                "pattern": "^[\\-._a-zA-Z0-9]+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "waitStrategy": {
+          "additionalProperties": false,
+          "description": "WaitStrategy defines Helm's wait strategy for waiting for applied\nresources to become ready.",
+          "properties": {
+            "name": {
+              "description": "Name is Helm's wait strategy for waiting for applied resources to\nbecome ready. One of 'poller' or 'legacy'. The 'poller' strategy uses\nkstatus to poll resource statuses, while the 'legacy' strategy uses\nHelm v3's waiting logic.\nDefaults to 'poller', or to 'legacy' when UseHelm3Defaults feature\ngate is enabled.",
+              "enum": [
+                "poller",
+                "legacy"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "interval"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "either chart or chartRef must be set",
+          "rule": "(has(self.chart) && !has(self.chartRef)) || (!has(self.chart) && has(self.chartRef))"
+        }
+      ]
+    },
+    "status": {
+      "additionalProperties": false,
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "HelmReleaseStatus defines the observed state of a HelmRelease.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions holds the conditions for the HelmRelease.",
+          "items": {
+            "additionalProperties": false,
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "failures": {
+          "description": "Failures is the reconciliation failure count against the latest desired\nstate. It is reset after a successful reconciliation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "helmChart": {
+          "description": "HelmChart is the namespaced name of the HelmChart resource created by\nthe controller for the HelmRelease.",
+          "type": "string"
+        },
+        "history": {
+          "description": "History holds the history of Helm releases performed for this HelmRelease\nup to the last successfully completed release.",
+          "items": {
+            "additionalProperties": false,
+            "description": "Snapshot captures a point-in-time copy of the status information for a Helm release,\nas managed by the controller.",
+            "properties": {
+              "action": {
+                "description": "Action is the action that resulted in this snapshot being created.",
+                "type": "string"
+              },
+              "apiVersion": {
+                "description": "APIVersion is the API version of the Snapshot.\nWhen the calculation method of the Digest field is changed, this\nfield will be used to distinguish between the old and new methods.",
+                "type": "string"
+              },
+              "appVersion": {
+                "description": "AppVersion is the chart app version of the release object in storage.",
+                "type": "string"
+              },
+              "chartName": {
+                "description": "ChartName is the chart name of the release object in storage.",
+                "type": "string"
+              },
+              "chartVersion": {
+                "description": "ChartVersion is the chart version of the release object in\nstorage.",
+                "type": "string"
+              },
+              "configDigest": {
+                "description": "ConfigDigest is the checksum of the config (better known as\n\"values\") of the release object in storage.\nIt has the format of `<algo>:<checksum>`.",
+                "type": "string"
+              },
+              "deleted": {
+                "description": "Deleted is when the release was deleted.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "digest": {
+                "description": "Digest is the checksum of the release object in storage.\nIt has the format of `<algo>:<checksum>`.",
+                "type": "string"
+              },
+              "firstDeployed": {
+                "description": "FirstDeployed is when the release was first deployed.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastDeployed": {
+                "description": "LastDeployed is when the release was last deployed.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the release.",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace is the namespace the release is deployed to.",
+                "type": "string"
+              },
+              "ociDigest": {
+                "description": "OCIDigest is the digest of the OCI artifact associated with the release.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the current state of the release.",
+                "type": "string"
+              },
+              "testHooks": {
+                "additionalProperties": {
+                  "additionalProperties": false,
+                  "description": "TestHookStatus holds the status information for a test hook as observed\nto be run by the controller.",
+                  "properties": {
+                    "lastCompleted": {
+                      "description": "LastCompleted is the time the test hook last completed.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "lastStarted": {
+                      "description": "LastStarted is the time the test hook was last started.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "phase": {
+                      "description": "Phase the test hook was observed to be in.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "TestHooks is the list of test hooks for the release as observed to be\nrun by the controller.",
+                "type": "object"
+              },
+              "version": {
+                "description": "Version is the version of the release object in storage.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "chartName",
+              "chartVersion",
+              "configDigest",
+              "digest",
+              "firstDeployed",
+              "lastDeployed",
+              "name",
+              "namespace",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "installFailures": {
+          "description": "InstallFailures is the install failure count against the latest desired\nstate. It is reset after a successful reconciliation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "inventory": {
+          "additionalProperties": false,
+          "description": "Inventory contains the list of Kubernetes resource object references\nthat have been applied for this release.",
+          "properties": {
+            "entries": {
+              "description": "Entries of Kubernetes resource object references.",
+              "items": {
+                "additionalProperties": false,
+                "description": "ResourceRef contains the information necessary to locate a resource within a cluster.",
+                "properties": {
+                  "id": {
+                    "description": "ID is the string representation of the Kubernetes resource object's metadata,\nin the format '<namespace>_<name>_<group>_<kind>'.",
+                    "type": "string"
+                  },
+                  "v": {
+                    "description": "Version is the API version of the Kubernetes resource object's kind.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "v"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "entries"
+          ],
+          "type": "object"
+        },
+        "lastAttemptedConfigDigest": {
+          "description": "LastAttemptedConfigDigest is the digest for the config (better known as\n\"values\") of the last reconciliation attempt.",
+          "type": "string"
+        },
+        "lastAttemptedGeneration": {
+          "description": "LastAttemptedGeneration is the last generation the controller attempted\nto reconcile.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "lastAttemptedReleaseAction": {
+          "description": "LastAttemptedReleaseAction is the last release action performed for this\nHelmRelease. It is used to determine the active retry or remediation\nstrategy.",
+          "enum": [
+            "install",
+            "upgrade"
+          ],
+          "type": "string"
+        },
+        "lastAttemptedReleaseActionDuration": {
+          "description": "LastAttemptedReleaseActionDuration is the duration of the last\nrelease action performed for this HelmRelease.",
+          "type": "string"
+        },
+        "lastAttemptedRevision": {
+          "description": "LastAttemptedRevision is the Source revision of the last reconciliation\nattempt. For OCIRepository  sources, the 12 first characters of the digest are\nappended to the chart version e.g. \"1.2.3+1234567890ab\".",
+          "type": "string"
+        },
+        "lastAttemptedRevisionDigest": {
+          "description": "LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.\nThis is only set for OCIRepository sources.",
+          "type": "string"
+        },
+        "lastAttemptedValuesChecksum": {
+          "description": "LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last\nreconciliation attempt.\n\nDeprecated: Use LastAttemptedConfigDigest instead.",
+          "type": "string"
+        },
+        "lastHandledForceAt": {
+          "description": "LastHandledForceAt holds the value of the most recent\nforce request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent\nreconcile request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        },
+        "lastHandledResetAt": {
+          "description": "LastHandledResetAt holds the value of the most recent reset request\nvalue, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "lastReleaseRevision": {
+          "description": "LastReleaseRevision is the revision of the last successful Helm release.\n\nDeprecated: Use History instead.",
+          "type": "integer"
+        },
+        "observedCommonMetadataDigest": {
+          "description": "ObservedCommonMetadataDigest is the digest for the common metadata of\nthe last successful reconciliation attempt.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the last observed generation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "observedPostRenderersDigest": {
+          "description": "ObservedPostRenderersDigest is the digest for the post-renderers of\nthe last successful reconciliation attempt.",
+          "type": "string"
+        },
+        "storageNamespace": {
+          "description": "StorageNamespace is the namespace of the Helm release storage for the\ncurrent release.",
+          "maxLength": 63,
+          "minLength": 1,
+          "type": "string"
+        },
+        "upgradeFailures": {
+          "description": "UpgradeFailures is the upgrade failure count against the latest desired\nstate. It is reset after a successful reconciliation.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/tools/schemas/helm-controller-v1.6.4/provenance.json
+++ b/tools/schemas/helm-controller-v1.6.4/provenance.json
@@ -1,0 +1,9 @@
+{
+  "crdSource": "https://github.com/fluxcd/helm-controller/releases/download/v1.6.4/helm-controller.crds.yaml",
+  "crdSourceSha256": "8af19966e63cccde7d2c62e24c7bd3466010dd53e9d063e2ce22d1391e11f272",
+  "fluxVersion": "2.9.5",
+  "generatedSchemaSha256": "9f7a2fbc13c3c4c57afc71e15aa637ce236af79b4dce6e0cb636ac4f478b6617",
+  "helmControllerVersion": "1.6.4",
+  "schemaVersion": "v2",
+  "validatorVersion": "0.8.0"
+}

--- a/tools/tests/helmrelease-schema.sh
+++ b/tools/tests/helmrelease-schema.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Focused HelmRelease schema-contract tests. These run the real checker in
+# copied roots, replacing only Flate and kubeconform where a deterministic
+# fixture is required. The full tools/tests/run.sh suite invokes this script.
+set -u
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+T="$ROOT/tools"
+pass=0
+fail=0
+
+ok()   { pass=$((pass + 1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail + 1)); printf '  FAIL %s\n' "$1"; }
+assert() {
+  local label="$1"
+  shift
+  if "$@"; then ok "$label"; else bad "$label"; fi
+}
+
+section() { printf '\n# %s\n' "$1"; }
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf -- "$tmp_root"' EXIT INT TERM
+
+make_checker_root() {
+  local root="$1"
+  local schema_root="$root/tools/schemas/helm-controller-v1.6.4"
+  mkdir -p "$root/tools" \
+    "$schema_root" \
+    "$root/clusters/common/bootstrap/flux"
+  cp "$T/check-helmrelease-schema.sh" "$root/tools/check-helmrelease-schema.sh"
+  cp "$T/schemas/helm-controller-v1.6.4/provenance.json" "$schema_root/provenance.json"
+  cp "$T/schemas/helm-controller-v1.6.4/helmrelease-helm-v2-strict.json" \
+    "$schema_root/helmrelease-helm-v2-strict.json"
+  cp "$ROOT/clusters/common/bootstrap/flux/kustomization.yaml" \
+    "$root/clusters/common/bootstrap/flux/kustomization.yaml"
+  chmod +x "$root/tools/check-helmrelease-schema.sh"
+}
+
+section "real checker selects raw rendered multi-document output"
+raw_root="$tmp_root/raw-render"
+make_checker_root "$raw_root"
+cat >"$raw_root/rendered.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignored
+data:
+  marker: not-a-helmrelease
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fixture
+  namespace: flux-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: fixture
+      sourceRef:
+        kind: HelmRepository
+        name: fixture
+  values:
+    arbitraryChartValue:
+      futureShape: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ignored-too
+EOF
+cat >"$raw_root/tools/flate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_FLATE_ARGS:?}"
+cat "${FAKE_RENDERED:?}"
+EOF
+cat >"$raw_root/tools/kubeconform.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+selected="${!#}"
+printf '%s\n' "$*" >"${FAKE_KUBECONFORM_ARGS:?}"
+python3 - "$selected" <<'PY'
+import pathlib
+import sys
+import yaml
+
+documents = [item for item in yaml.safe_load_all(pathlib.Path(sys.argv[1]).read_text()) if item]
+if len(documents) != 1:
+    raise SystemExit(f"expected one selected document, got {len(documents)}")
+document = documents[0]
+if document.get("kind") != "HelmRelease":
+    raise SystemExit("selected document is not a HelmRelease")
+if document.get("apiVersion") != "helm.toolkit.fluxcd.io/v2":
+    raise SystemExit("selected HelmRelease has the wrong API version")
+if document["spec"]["values"]["arbitraryChartValue"]["futureShape"] is not True:
+    raise SystemExit("opaque spec.values was not preserved")
+PY
+printf '%s\n' 'fake kubeconform OK'
+EOF
+chmod +x "$raw_root/tools/flate.sh" "$raw_root/tools/kubeconform.sh"
+raw_out="$raw_root/check.stdout"
+raw_err="$raw_root/check.stderr"
+raw_flate_args="$raw_root/flate.args"
+raw_kubeconform_args="$raw_root/kubeconform.args"
+(
+  cd "$raw_root"
+  FAKE_RENDERED="$raw_root/rendered.yaml" \
+  FAKE_FLATE_ARGS="$raw_flate_args" \
+  FAKE_KUBECONFORM_ARGS="$raw_kubeconform_args" \
+  tools/check-helmrelease-schema.sh talos-ottawa >"$raw_out" 2>"$raw_err"
+)
+raw_rc=$?
+assert "raw multi-document checker passes" test "$raw_rc" = 0
+assert "raw Flate path is the targeted cluster" \
+  grep -q -- '--path clusters/talos-ottawa/flux/config' "$raw_flate_args"
+assert "raw selection passes exactly one HelmRelease with opaque values" \
+  grep -q '^fake kubeconform OK$' "$raw_out"
+assert "raw checker reports one validated resource" \
+  grep -q 'validated 1 rendered resources' "$raw_out"
+
+section "provenance guards"
+hash_root="$tmp_root/hash-mismatch"
+make_checker_root "$hash_root"
+python3 - "$hash_root/tools/schemas/helm-controller-v1.6.4/provenance.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["generatedSchemaSha256"] = "0" * 64
+path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+PY
+hash_out="$hash_root/check.stdout"
+hash_err="$hash_root/check.stderr"
+(
+  cd "$hash_root"
+  tools/check-helmrelease-schema.sh talos-ottawa >"$hash_out" 2>"$hash_err"
+)
+hash_rc=$?
+assert "schema hash mismatch fails" test "$hash_rc" = 1
+assert "schema hash mismatch is explained" \
+  grep -q 'schema artifact hash does not match provenance' "$hash_err"
+
+pin_root="$tmp_root/pin-mismatch"
+make_checker_root "$pin_root"
+python3 - "$pin_root/clusters/common/bootstrap/flux/kustomization.yaml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+old = "flux2/manifests/install?ref=v2.9.5"
+new = "flux2/manifests/install?ref=v2.9.4"
+if old not in text:
+    raise SystemExit("bootstrap fixture did not contain the expected Flux pin")
+path.write_text(text.replace(old, new, 1))
+PY
+pin_out="$pin_root/check.stdout"
+pin_err="$pin_root/check.stderr"
+(
+  cd "$pin_root"
+  tools/check-helmrelease-schema.sh talos-ottawa >"$pin_out" 2>"$pin_err"
+)
+pin_rc=$?
+assert "Flux pin mismatch fails" test "$pin_rc" = 1
+assert "Flux pin mismatch is explained" \
+  grep -q 'Flux bootstrap is v2.9.4, schema provenance is v2.9.5' "$pin_err"
+
+make_gate_root() {
+  local root="$1"
+  local result="$2"
+  mkdir -p "$root/tools" "$root/bin"
+  cp "$T/check.sh" "$root/tools/check.sh"
+  for helper in check-versions.sh check-notification-scope.sh \
+    check-cliproxy-pi-bridge.sh check-zot-upload-affinity.sh \
+    check-mimir-rules.sh check-velero-pvc-coverage.sh; do
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$root/tools/$helper"
+    chmod +x "$root/tools/$helper"
+  done
+  if [ "$result" = success ]; then
+    cat >"$root/tools/check-helmrelease-schema.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${FAKE_SCHEMA_ARGS:?}"
+exit 0
+EOF
+  else
+    cat >"$root/tools/check-helmrelease-schema.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${FAKE_SCHEMA_ARGS:?}"
+echo 'intentional schema checker failure' >&2
+exit 9
+EOF
+  fi
+  chmod +x "$root/tools/check-helmrelease-schema.sh"
+  cat >"$root/bin/make" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${FAKE_MAKE_ARGS:?}"
+exit 0
+EOF
+  chmod +x "$root/bin/make"
+}
+
+section "check.sh target forwarding and failure propagation"
+forward_root="$tmp_root/check-forward"
+make_gate_root "$forward_root" success
+forward_args="$forward_root/schema.args"
+forward_make_args="$forward_root/make.args"
+forward_out="$forward_root/check.stdout"
+forward_err="$forward_root/check.stderr"
+(
+  cd "$forward_root"
+  PATH="$forward_root/bin:$PATH" \
+  FAKE_SCHEMA_ARGS="$forward_args" \
+  FAKE_MAKE_ARGS="$forward_make_args" \
+  tools/check.sh ot >"$forward_out" 2>"$forward_err"
+)
+forward_rc=$?
+assert "check.sh targeted run succeeds" test "$forward_rc" = 0
+assert "check.sh forwards normalized target" \
+  grep -qx 'talos-ottawa' "$forward_args"
+assert "check.sh forwards target to make" \
+  grep -qx 'test-talos-ottawa' "$forward_make_args"
+assert "check.sh targeted success is reported" \
+  grep -q '^✓ render OK: talos-ottawa$' "$forward_out"
+
+failure_root="$tmp_root/check-failure"
+make_gate_root "$failure_root" failure
+failure_args="$failure_root/schema.args"
+failure_make_args="$failure_root/make.args"
+failure_out="$failure_root/check.stdout"
+failure_err="$failure_root/check.stderr"
+(
+  cd "$failure_root"
+  PATH="$failure_root/bin:$PATH" \
+  FAKE_SCHEMA_ARGS="$failure_args" \
+  FAKE_MAKE_ARGS="$failure_make_args" \
+  tools/check.sh ot >"$failure_out" 2>"$failure_err"
+)
+failure_rc=$?
+assert "check.sh schema failure propagates" test "$failure_rc" = 1
+assert "check.sh failure names schema step" \
+  grep -q '^=== helmrelease-schema FAILED ===$' "$failure_err"
+assert "check.sh failure keeps normalized target" \
+  grep -qx 'talos-ottawa' "$failure_args"
+assert "check.sh does not render after schema failure" \
+  test ! -s "$failure_make_args"
+
+printf '\n== %d passed, %d failed ==\n' "$pass" "$fail"
+[ "$fail" = 0 ]

--- a/tools/tests/helmrelease-schema.sh
+++ b/tools/tests/helmrelease-schema.sh
@@ -47,6 +47,7 @@ metadata:
   name: ignored
 data:
   marker: not-a-helmrelease
+  matchType: =
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -114,7 +115,7 @@ raw_kubeconform_args="$raw_root/kubeconform.args"
 raw_rc=$?
 assert "raw multi-document checker passes" test "$raw_rc" = 0
 assert "raw Flate path is the targeted cluster" \
-  grep -q -- '--path clusters/talos-ottawa' "$raw_flate_args"
+  grep -q -- '--path kubernetes/apps/ottawa' "$raw_flate_args"
 assert "raw selection passes exactly one HelmRelease with opaque values" \
   grep -q '^fake kubeconform OK$' "$raw_out"
 assert "raw checker reports one validated resource" \

--- a/tools/tests/helmrelease-schema.sh
+++ b/tools/tests/helmrelease-schema.sh
@@ -114,7 +114,7 @@ raw_kubeconform_args="$raw_root/kubeconform.args"
 raw_rc=$?
 assert "raw multi-document checker passes" test "$raw_rc" = 0
 assert "raw Flate path is the targeted cluster" \
-  grep -q -- '--path clusters/talos-ottawa/flux/config' "$raw_flate_args"
+  grep -q -- '--path clusters/talos-ottawa' "$raw_flate_args"
 assert "raw selection passes exactly one HelmRelease with opaque values" \
   grep -q '^fake kubeconform OK$' "$raw_out"
 assert "raw checker reports one validated resource" \

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -369,16 +369,27 @@ rm -rf "$fstub"
 section "check.sh (stubbed make)"
 mstub="$(mktemp -d)"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$mstub/make"; chmod +x "$mstub/make"
-sout="$(PATH="$mstub:$PATH" "$T/check.sh" 2>/dev/null)"; sec=$?
+gate_root="$(mktemp -d)"
+mkdir -p "$gate_root/tools"
+cp "$T/check.sh" "$gate_root/tools/check.sh"
+for helper in check-versions.sh check-notification-scope.sh \
+  check-cliproxy-pi-bridge.sh check-zot-upload-affinity.sh \
+  check-mimir-rules.sh check-velero-pvc-coverage.sh \
+  check-helmrelease-schema.sh; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$gate_root/tools/$helper"
+  chmod +x "$gate_root/tools/$helper"
+done
+sout="$(PATH="$mstub:$PATH" "$gate_root/tools/check.sh" 2>/dev/null)"; sec=$?
 assert "success -> exit 0"              test "$sec" = 0
 assert "success prints exactly 1 line"  test "$(printf '%s\n' "$sout" | grep -c .)" = 1
 assert "success line format"            grep -q '^✓ render OK:' <<<"$sout"
-exits  "unknown cluster -> exit 2"      2 "$T/check.sh" nope
-exits  "multiple clusters -> exit 2"    2 "$T/check.sh" ot rb
-exits  "quick + cluster -> exit 2"      2 "$T/check.sh" --quick ot
-assert "help -> concise usage"           grep -q '^Usage:' <<<"$("$T/check.sh" --help)"
-aliasout="$(PATH="$mstub:$PATH" "$T/check.sh" ot 2>/dev/null)"
+exits  "unknown cluster -> exit 2"      2 "$gate_root/tools/check.sh" nope
+exits  "multiple clusters -> exit 2"    2 "$gate_root/tools/check.sh" ot rb
+exits  "quick + cluster -> exit 2"      2 "$gate_root/tools/check.sh" --quick ot
+assert "help -> concise usage"           grep -q '^Usage:' <<<"$("$gate_root/tools/check.sh" --help)"
+aliasout="$(PATH="$mstub:$PATH" "$gate_root/tools/check.sh" ot 2>/dev/null)"
 assert "short cluster alias accepted"   grep -q '^✓ render OK: talos-ottawa$' <<<"$aliasout"
+rm -rf "$gate_root"
 
 # A completed gate must reap every watchdog timer descendant. Use an isolated
 # temporary gate root so this test exercises the real run_capped implementation
@@ -392,7 +403,8 @@ mkdir -p "$watchdog_tmp/tools" "$watchdog_tmp/stub"
 cp "$T/check.sh" "$watchdog_tmp/tools/check.sh"
 for helper in check-versions.sh check-notification-scope.sh \
   check-cliproxy-pi-bridge.sh check-zot-upload-affinity.sh \
-  check-mimir-rules.sh check-velero-pvc-coverage.sh; do
+  check-mimir-rules.sh check-velero-pvc-coverage.sh \
+  check-helmrelease-schema.sh; do
   cat >"$watchdog_tmp/tools/$helper" <<'EOF'
 #!/usr/bin/env bash
 IFS= read -r _ <"$WATCHDOG_READY"
@@ -707,6 +719,80 @@ assert "failure names ottawa/home" \
 cp "$hsbak" "$ROOT/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml"
 rm -f "$hsbak"
 exits  "restored schedule passes again" 0 "$T/check-velero-pvc-coverage.sh"
+
+# ---------------------------------------------------------------- HelmRelease schema
+# Offline fixture tests use the repository-pinned kubeconform wrapper and the
+# complete Flux HelmRelease v2 schema. No rendered cluster or live API is used.
+section "HelmRelease v2 schema"
+hrfixture="$(mktemp -d)"
+cat >"$hrfixture/valid.yaml" <<'EOF'
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fixture
+  namespace: flux-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: fixture
+      sourceRef:
+        kind: HelmRepository
+        name: fixture
+  upgrade:
+    remediation:
+      strategy: rollback
+  values:
+    arbitraryChartValue:
+      futureShape: true
+EOF
+cat >"$hrfixture/invalid-enum.yaml" <<'EOF'
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fixture
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: fixture
+      sourceRef: {kind: HelmRepository, name: fixture}
+  upgrade:
+    remediation:
+      strategy: retry
+EOF
+cat >"$hrfixture/invalid-field.yaml" <<'EOF'
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fixture
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: fixture
+      sourceRef: {kind: HelmRepository, name: fixture}
+  upgrade:
+    remediation:
+      unexpectedField: true
+EOF
+schema="$ROOT/tools/schemas/helm-controller-v1.6.4/helmrelease-helm-v2-strict.json"
+exits "valid HelmRelease and opaque values pass" 0 \
+  "$T/kubeconform.sh" -strict -schema-location "$schema" "$hrfixture/valid.yaml"
+exits "invalid remediation enum fails" 1 \
+  "$T/kubeconform.sh" -strict -schema-location "$schema" "$hrfixture/invalid-enum.yaml"
+exits "invalid CRD field fails" 1 \
+  "$T/kubeconform.sh" -strict -schema-location "$schema" "$hrfixture/invalid-field.yaml"
+rm -rf "$hrfixture"
+
+schema_contract_out="$(mktemp)"
+if "$T/tests/helmrelease-schema.sh" >"$schema_contract_out" 2>&1; then
+  ok "real HelmRelease checker contract regressions"
+else
+  bad "real HelmRelease checker contract regressions"
+  sed -n '1,160p' "$schema_contract_out"
+fi
+rm -f "$schema_contract_out"
 
 # ---------------------------------------------------------------- summary
 printf '\n== %d passed, %d failed ==\n' "$pass" "$fail"

--- a/tools/update-helmrelease-schema.py
+++ b/tools/update-helmrelease-schema.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Extract the HelmRelease v2 schema from a pinned Flux CRD.
+
+The output is intentionally deterministic. Kubernetes object maps with a
+declared property set become closed objects for kubeconform strict mode, while
+objects explicitly marked x-kubernetes-preserve-unknown-fields (notably
+spec.values) retain their opaque extensibility.
+"""
+import json
+import pathlib
+import sys
+
+import yaml
+
+
+def close_objects(value):
+    if isinstance(value, dict):
+        if (
+            value.get("type") == "object"
+            and "properties" in value
+            and "additionalProperties" not in value
+            and not value.get("x-kubernetes-preserve-unknown-fields")
+        ):
+            value["additionalProperties"] = False
+        for child in value.values():
+            close_objects(child)
+    elif isinstance(value, list):
+        for child in value:
+            close_objects(child)
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise SystemExit(f"usage: {sys.argv[0]} CRD-YAML OUTPUT-JSON")
+    source, output = map(pathlib.Path, sys.argv[1:])
+    for document in yaml.safe_load_all(source.read_text()):
+        if (
+            isinstance(document, dict)
+            and document.get("kind") == "CustomResourceDefinition"
+            and document.get("metadata", {}).get("name")
+            == "helmreleases.helm.toolkit.fluxcd.io"
+        ):
+            version = next(
+                item for item in document["spec"]["versions"] if item["name"] == "v2"
+            )
+            schema = version["schema"]["openAPIV3Schema"]
+            close_objects(schema)
+            output.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n")
+            return
+    raise SystemExit("HelmRelease v2 CRD was not found")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add the complete pinned Flux HelmRelease v2 structural schema at an explicit root JSON location.
- Preserve opaque `spec.values`, verify schema hash and Flux bootstrap pin, and validate raw rendered multi-document Flate output.
- Forward an optional cluster target through `tools/check.sh` and add isolated contract regressions.

Refs #715

## Evidence

- Direct exact-file lookup: valid fixture exit 0; invalid enum exit 1 with the expected schema URI.
- Focused isolated schema-contract checks: 16 passed, 0 failed.
- Commit: `ce45e92`.

## Not yet proven

- The broad `tools/tests/run.sh` suite was not run after the final bytes.
- The full render gate was not run.
- The real Ottawa checker exited 1 because Flate could not find chart-source dependencies; this is not a passing rendered-cluster result.

This PR is intentionally not merged.
