### PR TITLE
fix(mimir): ignore superseded loader jobs in stale alert

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
@@ -28,7 +28,7 @@ groups:
       - alert: MimirRuleLoaderStale
         expr: |
           (
-            time() - max by (cluster, namespace, job_name) (
+            time() - max by (cluster, namespace) (
               max_over_time(
                 kube_job_status_completion_time{
                   namespace="mimir",

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/mimir-loader_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/mimir-loader_test.yaml
@@ -1,0 +1,53 @@
+rule_files:
+  - ../mimir-loader.yaml
+
+evaluation_interval: 1h
+
+tests:
+  - interval: 1h
+    input_series:
+      - series: 'kube_job_status_completion_time{cluster="talos-ottawa",job_name="mimir-rules-old",namespace="mimir"}'
+        values: "0+0x25"
+      - series: 'kube_job_status_completion_time{cluster="talos-ottawa",job_name="mimir-rules-current",namespace="mimir"}'
+        values: "86400+0x25"
+    alert_rule_test:
+      - eval_time: 26h
+        alertname: MimirRuleLoaderStale
+        exp_alerts: []
+
+  - interval: 1h
+    input_series:
+      - series: 'kube_job_status_completion_time{cluster="talos-ottawa",job_name="mimir-rules-old",namespace="mimir"}'
+        values: "0+0x25"
+    alert_rule_test:
+      - eval_time: 26h
+        alertname: MimirRuleLoaderStale
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              namespace: mimir
+            exp_annotations:
+              summary: Mimir rule loader has not completed successfully in 24 hours
+              description: >-
+                No successful content-hashed Mimir rules loader completion has been observed in
+                the last 24 hours. This also covers the loader Job not being
+                created; inspect Flux, the Job, and the three tenant sync logs.
+
+  - interval: 1h
+    input_series:
+      - series: 'kube_node_info{cluster="talos-ottawa",node="node-1"}'
+        values: "1+0x26"
+    alert_rule_test:
+      - eval_time: 26h
+        alertname: MimirRuleLoaderStale
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              namespace: mimir
+            exp_annotations:
+              summary: Mimir rule loader has not completed successfully in 24 hours
+              description: >-
+                No successful content-hashed Mimir rules loader completion has been observed in
+                the last 24 hours. This also covers the loader Job not being
+                created; inspect Flux, the Job, and the three tenant sync logs.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -19,3 +19,9 @@ for rule in flux bhaiya-model; do
   promtool check rules "$tmpdir/${rule}.yaml"
   promtool test rules "$tmpdir/$test_file"
 done
+
+sed '/^namespace: mimir-loader$/d' "$RULE_DIR/mimir-loader.yaml" >"$tmpdir/mimir-loader.yaml"
+sed "s#../mimir-loader.yaml#$tmpdir/mimir-loader.yaml#" \
+  "$RULE_DIR/tests/mimir-loader_test.yaml" >"$tmpdir/mimir-loader_test.yaml"
+promtool check rules "$tmpdir/mimir-loader.yaml"
+promtool test rules "$tmpdir/mimir-loader_test.yaml"


### PR DESCRIPTION
## Summary
- aggregate loader completion freshness across all content-hashed Jobs
- prevent an older completed Job from firing MimirRuleLoaderStale after a newer successful load
- add offline promtool regressions for superseded, genuinely stale, and absent loader cases

## Root cause and live evidence
MimirRuleLoaderStale has been firing as a FALSE POSITIVE. The loader was not broken: the current Job `mimir-rules-khkk47f4h6` completed successfully at 2026-09-07T15:47:18Z, and all three tenant containers reported `Sync Summary: 0 Groups Created, 0 Groups Updated, 0 Groups Deleted`. The old superseded `mimir-rules-tf4ktc8c85` completion crossed 24 hours, and the old expression grouped freshness by `job_name`, causing that historical Job to fire independently.

The Mimir ruler API independently verified that the shipped km#2784 `FluxKustomizationNotReady` rule and km#2786 model alert rules are loaded, healthy, and evaluating in all three tenants (Ottawa, Robbinsdale, and St. Petersburg).

## Validation
- focused pinned promtool tests: exit 0
- full three-cluster render gate: exit 0
- no live mutation or manual loader rerun performed

Do not merge automatically.