### PR TITLE
test(mimir): cover Garage quorum loss alerts

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/garage_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/garage_test.yaml
@@ -1,0 +1,81 @@
+rule_files:
+  - ../garage.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Quorum loss is a distinct escalation from under-replication: exercise the
+  # same rule independently for every cluster identity. This is the failure
+  # shape described by corp/bhaiya#725, where serving continued while some
+  # partitions became unreachable.
+  - interval: 1m
+    input_series:
+      - series: 'cluster_partitions{cluster="talos-ottawa"}'
+        values: "256+0x10"
+      - series: 'cluster_partitions_quorum{cluster="talos-ottawa"}'
+        values: "255+0x10"
+      - series: 'cluster_partitions{cluster="talos-robbinsdale"}'
+        values: "256+0x10"
+      - series: 'cluster_partitions_quorum{cluster="talos-robbinsdale"}'
+        values: "254+0x10"
+      - series: 'cluster_partitions{cluster="talos-stpetersburg"}'
+        values: "256+0x10"
+      - series: 'cluster_partitions_quorum{cluster="talos-stpetersburg"}'
+        values: "253+0x10"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: GarageClusterPartitionsWithoutQuorum
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: GarageClusterPartitionsWithoutQuorum
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+            exp_annotations:
+              summary: Garage partitions have lost quorum in talos-ottawa
+              description: >-
+                cluster_partitions_quorum is below cluster_partitions: some
+                partitions no longer have enough up nodes to serve. Under
+                consistencyMode=degraded reads come from a single replica and
+                may still succeed; writes to those partitions fail. Restore
+                the missing storage nodes.
+          - exp_labels:
+              severity: critical
+              cluster: talos-robbinsdale
+            exp_annotations:
+              summary: Garage partitions have lost quorum in talos-robbinsdale
+              description: >-
+                cluster_partitions_quorum is below cluster_partitions: some
+                partitions no longer have enough up nodes to serve. Under
+                consistencyMode=degraded reads come from a single replica and
+                may still succeed; writes to those partitions fail. Restore
+                the missing storage nodes.
+          - exp_labels:
+              severity: critical
+              cluster: talos-stpetersburg
+            exp_annotations:
+              summary: Garage partitions have lost quorum in talos-stpetersburg
+              description: >-
+                cluster_partitions_quorum is below cluster_partitions: some
+                partitions no longer have enough up nodes to serve. Under
+                consistencyMode=degraded reads come from a single replica and
+                may still succeed; writes to those partitions fail. Restore
+                the missing storage nodes.
+
+  # A short quorum dip must not page. Recovery before the five-minute hold
+  # clears the pending alert, preserving the distinction from a sustained
+  # unavailable-partition condition.
+  - interval: 1m
+    input_series:
+      - series: 'cluster_partitions{cluster="talos-ottawa"}'
+        values: "256+0x10"
+      - series: 'cluster_partitions_quorum{cluster="talos-ottawa"}'
+        values: "254+0x3 256+0x7"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: GarageClusterPartitionsWithoutQuorum
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: GarageClusterPartitionsWithoutQuorum
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -8,10 +8,11 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 # Mimir's native rule files require a top-level namespace, which promtool does
 # not understand. Keep each production rule as the source of truth and remove
 # only that Mimir wrapper in the temporary test copy.
-for rule in flux bhaiya-model; do
+for rule in flux bhaiya-model garage; do
   case "$rule" in
     flux) test_file=flux_test.yaml ;;
     bhaiya-model) test_file=bhaiya_model_test.yaml ;;
+    garage) test_file=garage_test.yaml ;;
   esac
   sed "/^namespace: ${rule}$/d" "$RULE_DIR/${rule}.yaml" >"$tmpdir/${rule}.yaml"
   sed "s#../${rule}.yaml#$tmpdir/${rule}.yaml#" \


### PR DESCRIPTION
## Summary

- add deterministic promtool coverage for `GarageClusterPartitionsWithoutQuorum`
- exercise sustained quorum loss independently for Ottawa, Robbinsdale, and St. Petersburg
- verify the five-minute hold prevents a transient quorum dip from firing
- run the existing Mimir rules harness against the new Garage fixture

## Evidence and scope

The production alert already exists in `kubernetes/apps/base/mimir/mimir-ottawa/rules/garage.yaml` as a critical five-minute alert using `cluster_partitions_quorum < cluster_partitions`; this PR adds the missing regression coverage rather than duplicating or tuning the alert.

The live ruler API reports this rule loaded and healthy in all three tenants. During the audit it was firing in Robbinsdale at 254/256 quorum. The alerting path consumes Garage exporter metrics (`cluster_healthy`, `cluster_partitions*`) and blackbox probe metrics; no rule in this path reads `GarageCluster.status`. Ottawa's contradictory CR status therefore cannot suppress this alert, though it remains an operator status-integrity defect for separate follow-up.

This covers the failure shape described in corp/bhaiya#725, where Garage remained serving while partition durability degraded. No live cluster mutation was performed.

## Validation

Pinned promtool 3.14.0:
`/tmp/cos-promtool.qAjD6j/prometheus-3.14.0.linux-amd64/promtool`

Focused harness under `flock -o -w3600 /workspace/briefs/cos-heavy-build.lock` with `CGO_ENABLED=0`: exit 0.
