### PR TITLE
feat(mimir): run two replicated store gateways

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -176,14 +176,16 @@ spec:
         "-ingester.ring.replication-factor": "1"
 
     store_gateway:
-      replicas: 1
+      # Two store-gateways and RF=2 keep the older-block query path available
+      # while one gateway is unavailable. This is independent of ingester HA.
+      replicas: 2
       zoneAwareReplication:
         enabled: false
       persistentVolume:
         enabled: true
         size: 2Gi
       extraArgs:
-        "-store-gateway.sharding-ring.replication-factor": "1"
+        "-store-gateway.sharding-ring.replication-factor": "2"
 
     compactor:
       replicas: 1


### PR DESCRIPTION
## Summary
- run two store-gateway replicas
- set the sharding ring replication factor to 2

This removes the single store-gateway availability point for older-block queries while remaining independent of ingester HA.

## Resource cost
- +1 store-gateway Pod
- +100m CPU request and +512Mi memory request (chart defaults)
- +1 persistent 2Gi PVC (logical; current store-gateway PVC size)
- no image, workload, or user-facing service change

This is a capacity-approved proposal. Do not merge until the ring is observed stable after rollout.