### PR TITLE
feat(monz): retain VictoriaLogs for 30 days

### DIFF
--- a/kubernetes/apps/base/monz/monz/app/vl-helmrelease.yaml
+++ b/kubernetes/apps/base/monz/monz/app/vl-helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
     server:
       persistentVolume:
         enabled: true
-        size: 50Gi
-      retentionPeriod: 90d
+        size: 100Gi
+      retentionPeriod: 30d
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary
- reduce VictoriaLogs retention from 90d to 30d
- increase its persistent volume from 50Gi to 100Gi

This makes the intended 30-day observability window explicit and provides approximately 100Gi of current log storage capacity.

The old 90d setting does not, by configuration alone, prove that 90 days could not fit; that requires measured ingest rate and occupancy. The change is therefore an intentional policy reduction plus capacity headroom, not an unsupported claim that the old retention was already impossible.

## Resource cost
- no additional Pod or CPU/memory request
- PVC expansion: +50Gi logical capacity, from 50Gi to 100Gi
- retention decreases from 90d to 30d; logs older than 30 days become eligible for deletion

The PVC expansion requires the storage class and underlying volume to support online expansion. This PR does not change Immich backup scheduling.