### PR TITLE
feat(mimir): alert on sustained node clock skew

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -40,6 +40,7 @@ configMapGenerator:
       - rules/mimir-queryable-window.yaml
       - rules/monitoring.yaml
       - rules/node-health.yaml
+      - rules/node-clock.yaml
       - rules/payments.yaml
       - rules/smartctl.yaml
       - rules/velero.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -50,6 +50,7 @@ spec:
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
+            - /rules/node-clock.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -87,6 +88,7 @@ spec:
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
+            - /rules/node-clock.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -120,6 +122,7 @@ spec:
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
+            - /rules/node-clock.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-clock.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-clock.yaml
@@ -1,0 +1,21 @@
+# Node-exporter exposes this metric by default through the existing
+# kube-prometheus-stack ServiceMonitor. Keep the threshold well above ordinary
+# NTP drift while detecting the kind of host fault that can invalidate TLS,
+# tokens, and backup retention decisions long before those consumers fail.
+namespace: node-clock
+groups:
+  - name: node-clock.rules
+    rules:
+      - alert: NodeClockSkew
+        expr: abs(node_timex_offset_seconds) > 300
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Node {{ $labels.instance }} has excessive clock skew
+          description: >-
+            Node {{ $labels.instance }} has reported more than five minutes of
+            clock offset for at least ten minutes
+            ({{ printf "%.0f" $value }} seconds). Check host time
+            synchronisation before investigating TLS, authentication, or
+            backup failures.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/node-clock_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/node-clock_test.yaml
@@ -1,0 +1,50 @@
+rule_files:
+  - ../node-clock.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'node_timex_offset_seconds{cluster="talos-ottawa",instance="10.0.0.1:9100",job="node-exporter"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NodeClockSkew
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'node_timex_offset_seconds{cluster="talos-robbinsdale",instance="10.0.0.2:9100",job="node-exporter"}'
+        values: "3900+0x20"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NodeClockSkew
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: NodeClockSkew
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              cluster: talos-robbinsdale
+              instance: 10.0.0.2:9100
+              job: node-exporter
+            exp_annotations:
+              summary: Node 10.0.0.2:9100 has excessive clock skew
+              description: >-
+                Node 10.0.0.2:9100 has reported more than five minutes of
+                clock offset for at least ten minutes (3900 seconds). Check
+                host time synchronisation before investigating TLS,
+                authentication, or backup failures.
+
+  - interval: 1m
+    input_series:
+      - series: 'node_timex_offset_seconds{cluster="talos-stpetersburg",instance="10.0.0.3:9100",job="node-exporter"}'
+        values: "600+0x4 0+0x16"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: NodeClockSkew
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: NodeClockSkew
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -9,8 +9,13 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 # not understand. Keep the production rule as the source of truth and remove
 # only that Mimir wrapper in the temporary test copy.
 sed '/^namespace: flux$/d' "$RULE_DIR/flux.yaml" >"$tmpdir/flux.yaml"
+sed '/^namespace: node-clock$/d' "$RULE_DIR/node-clock.yaml" >"$tmpdir/node-clock.yaml"
 sed "s#../flux.yaml#$tmpdir/flux.yaml#" \
   "$RULE_DIR/tests/flux_test.yaml" >"$tmpdir/flux_test.yaml"
+sed "s#../node-clock.yaml#$tmpdir/node-clock.yaml#" \
+  "$RULE_DIR/tests/node-clock_test.yaml" >"$tmpdir/node-clock_test.yaml"
 
 promtool check rules "$tmpdir/flux.yaml"
+promtool check rules "$tmpdir/node-clock.yaml"
 promtool test rules "$tmpdir/flux_test.yaml"
+promtool test rules "$tmpdir/node-clock_test.yaml"


### PR DESCRIPTION
## Summary

- Alert on sustained node clock offset using the existing node-exporter `node_timex_offset_seconds` metric.
- Load the native Mimir rule for Ottawa, Robbinsdale, and St. Petersburg tenants.
- Add promtool coverage for normal drift, a 65-minute skew, transient skew, and cluster labels.

## Design

The alert fires when absolute offset exceeds 300 seconds for 10 minutes. This is far above ordinary one- or two-second NTP drift, but catches a host clock failure well before a roughly 65-minute skew can break Kopia, TLS validity checks, token expiry, or time-based backup/alert behavior. The rule deliberately does not alert on `node_timex_sync_status` alone: a brief unsynchronized state can be noisy, while the measured offset is the actionable condition.

The existing kube-prometheus-stack node-exporter ServiceMonitor is enabled and stamps the existing `cluster` label; no instrumentation or PrometheusRule CR is added. The rule is in the shared Mimir native ruler ConfigMap and is passed to all three tenant loader containers.

## Verification

- `tools/check.sh`: exit 0; all three cluster renders passed.
- `tools/check-mimir-rules.sh`: exit 0; complete rule-to-loader path for all three tenants.
- `rules/tests/run.sh` with Prometheus 3.5.0 `promtool`: exit 0.
- `git diff --check`: exit 0.

The worktree did not have a local `promtool`, so the focused test used a temporary upstream Prometheus release binary; no repository or production state was changed.

No production objects were modified and this PR is not being merged here.
