### PR TITLE
revert(monz): restore legacy VictoriaLogs settings

### DIFF
--- a/kubernetes/apps/base/monz/monz/app/vl-helmrelease.yaml
+++ b/kubernetes/apps/base/monz/monz/app/vl-helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
     server:
       persistentVolume:
         enabled: true
-        size: 100Gi
-      retentionPeriod: 30d
+        size: 50Gi
+      retentionPeriod: 90d
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary
- Revert the merged #2795 monz VictoriaLogs values from 100Gi/30d to 50Gi/90d.
- Return the stalled HelmRelease to its prior desired state without forcing an immutable StatefulSet update.

## Why
#2795 targeted the legacy monz stack, while the active fleet log sink is monitoring/victoria-logs. Its four upgrade attempts failed on immutable volumeClaimTemplates and rolled back, leaving the HelmRelease Stalled=True and Ready=False; the live PVC remained 50Gi. This revert is intended to clear that failed desired-state delta. It does not delete or resize any live PVC.

## Validation
- `tools/check.sh talos-ottawa`: exit 0
- Scoped diff: one monz HelmRelease file, two values restored

Held for review; do not merge automatically.