### PR TITLE
feat(monitoring): retain VictoriaLogs for 30 days

### DIFF
--- a/kubernetes/apps/base/victoria-logs/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs/victoria-logs/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
       persistentVolume:
         enabled: true
         size: 50Gi
-      retentionPeriod: 7d
+      retentionPeriod: 30d
       resources:
         requests:
           cpu: 200m


### PR DESCRIPTION
## Summary
- Set the active monitoring VictoriaLogs retention period from 7d to 30d.
- Leave its 50Gi persistent volume declaration and all other chart values unchanged.

## Why
The fleet log sink is `victoria-logs-victoria-logs-single-server.monitoring:9428`; the earlier #2795 change targeted legacy `monz` instead. This PR applies the policy to the served monitoring stack.

## Immutability and rollout safety
This PR deliberately does not change `persistentVolume.size`, because this chart renders a StatefulSet volumeClaimTemplate and that field is immutable after creation. No capacity increase is claimed here, and no Helm force update is used. If Raj later approves capacity expansion, it must be a separate staged operation: change and deliver configuration first, verify the replacement Pod is running the new configuration, then perform a supported PVC/underlying-volume expansion; never mutate the existing volumeClaimTemplate or force the StatefulSet.

## Resource cost
- No new Pods or CPU/memory requests
- No PVC resize in this PR
- Retention policy changes from 7d to 30d

## Validation
- `tools/check.sh talos-ottawa`: exit 0
- Scoped diff: one monitoring HelmRelease file, retention only

Held for review; do not merge automatically.