### PR TITLE
fix(garage): pin restic cleanup image digest

### DIFF
--- a/kubernetes/apps/base/hermes/hermes/app/restic-orphan-cleanup.yaml
+++ b/kubernetes/apps/base/hermes/hermes/app/restic-orphan-cleanup.yaml
@@ -77,7 +77,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cleanup
-          image: docker.io/bitnami/kubectl:1.33.3
+          # alpine/k8s bundles kubectl, bash, and base64; pin the multi-arch index digest.
+          image: docker.io/alpine/k8s:1.33.3@sha256:47e4ea4c263fb4e14e51d7c5ca841da756673f18e2340f38c0cf1f7219d05e85
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/kubernetes/apps/base/home/home-robbinsdale/restic-orphan-cleanup.yaml
+++ b/kubernetes/apps/base/home/home-robbinsdale/restic-orphan-cleanup.yaml
@@ -77,7 +77,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cleanup
-          image: docker.io/bitnami/kubectl:1.33.3
+          # alpine/k8s bundles kubectl, bash, and base64; pin the multi-arch index digest.
+          image: docker.io/alpine/k8s:1.33.3@sha256:47e4ea4c263fb4e14e51d7c5ca841da756673f18e2340f38c0cf1f7219d05e85
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/kubernetes/apps/base/immich/immich/app/restic-orphan-cleanup.yaml
+++ b/kubernetes/apps/base/immich/immich/app/restic-orphan-cleanup.yaml
@@ -77,7 +77,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cleanup
-          image: docker.io/bitnami/kubectl:1.33.3
+          # alpine/k8s bundles kubectl, bash, and base64; pin the multi-arch index digest.
+          image: docker.io/alpine/k8s:1.33.3@sha256:47e4ea4c263fb4e14e51d7c5ca841da756673f18e2340f38c0cf1f7219d05e85
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/kubernetes/apps/base/media/media-ottawa/restic-orphan-cleanup.yaml
+++ b/kubernetes/apps/base/media/media-ottawa/restic-orphan-cleanup.yaml
@@ -77,7 +77,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cleanup
-          image: docker.io/bitnami/kubectl:1.33.3
+          # alpine/k8s bundles kubectl, bash, and base64; pin the multi-arch index digest.
+          image: docker.io/alpine/k8s:1.33.3@sha256:47e4ea4c263fb4e14e51d7c5ca841da756673f18e2340f38c0cf1f7219d05e85
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/kubernetes/apps/base/media/media-robbinsdale/restic-orphan-cleanup.yaml
+++ b/kubernetes/apps/base/media/media-robbinsdale/restic-orphan-cleanup.yaml
@@ -80,7 +80,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cleanup
-          image: docker.io/bitnami/kubectl:1.33.3
+          # alpine/k8s bundles kubectl, bash, and base64; pin the multi-arch index digest.
+          image: docker.io/alpine/k8s:1.33.3@sha256:47e4ea4c263fb4e14e51d7c5ca841da756673f18e2340f38c0cf1f7219d05e85
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Replace the unavailable `docker.io/bitnami/kubectl:1.33.3` image in the five km#2777 cleanup Jobs with the verified digest-pinned `docker.io/alpine/k8s:1.33.3`.

The live Ottawa Jobs are currently `ImagePullBackOff` because the Bitnami reference returns `not found`; none has executed the cleanup script. The replacement was checked from the published image: it contains `/usr/bin/kubectl`, `/bin/bash`, `/bin/sh`, and `/bin/base64`, and its multi-arch index digest is `sha256:47e4ea4c263fb4e14e51d7c5ca841da756673f18e2340f38c0cf1f7219d05e85`.

A repository-wide scan found no other `bitnami/` references and no existing kubectl-in-a-Job image to reuse.

## Verification

- `tools/check.sh` — all three clusters pass.
- Digest resolves to linux/amd64 and linux/arm64 manifests.
- Existing namespaced RBAC and `/keiretsu/` plus exact Garage endpoint runtime guards are unchanged.
- No live objects were edited manually.

The schema gate validates manifest structure, not registry image resolvability; this incident is recorded for Forgejo `corp/bhaiya#715`.