### PR TITLE
feat(alerts): detect stalled Flux HelmReleases

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
@@ -36,3 +36,22 @@ groups:
             Kustomization {{ $labels.name }} at {{ $labels.path }} has remained
             not ready for 15 minutes. Inspect its current condition and root
             dependency before investigating dependent resources.
+
+      - alert: FluxHelmReleaseNotReady
+        expr: |
+          max by (cluster, namespace, name) (
+            flux_resource_info{
+              kind="HelmRelease",
+              ready="False",
+              suspended="False"
+            } == 1
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Flux HelmRelease {{ $labels.namespace }}/{{ $labels.name }} is not ready
+          description: >-
+            HelmRelease {{ $labels.namespace }}/{{ $labels.name }} has remained
+            not ready for 15 minutes. Inspect its current conditions, including
+            whether it is stalled or has been rolled back.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/flux_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/flux_test.yaml
@@ -129,3 +129,37 @@ tests:
                 Kustomization shared-name at ./shared-name has remained not
                 ready for 15 minutes. Inspect its current condition and root
                 dependency before investigating dependent resources.
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="HelmRelease",name="mimir",namespace="mimir",reason="RetriesExceeded",suspended="False",ready="False"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: FluxHelmReleaseNotReady
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: FluxHelmReleaseNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              name: mimir
+              namespace: mimir
+            exp_annotations:
+              summary: Flux HelmRelease mimir/mimir is not ready
+              description: >-
+                HelmRelease mimir/mimir has remained not ready for 15 minutes.
+                Inspect its current conditions, including whether it is stalled
+                or has been rolled back.
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="HelmRelease",name="suspended",namespace="mimir",reason="RetriesExceeded",suspended="True",ready="False"}'
+        values: "1+0x20"
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="HelmRelease",name="healthy",namespace="mimir",reason="ReconciliationSucceeded",suspended="False",ready="True"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: FluxHelmReleaseNotReady
+        exp_alerts: []


### PR DESCRIPTION
## Summary
- Add a critical `FluxHelmReleaseNotReady` alert for sustained unsuspended HelmRelease `ready="False"`.
- Add deterministic promtool coverage for the 15-minute boundary, stalled-shaped failure, suspended exclusion, and healthy exclusion.

## Why
The Mimir upgrade and the earlier monz VictoriaLogs upgrade both rolled back after immutable StatefulSet changes and remained Stalled/NotReady without a dedicated alert. The rule uses the existing exported `flux_resource_info` signal and does not depend on the unavailable `gotk_reconcile_condition` metric.

## Validation
- Pinned promtool 3.14.0 focused suite: exit 0
- Log: `/workspace/briefs/cos-flux-helmrelease-stalled-alert-test-pinned.log`
- Two rule/test files changed

Held for review; do not merge automatically.