### PR TITLE
revert(mimir): restore last known ready topology

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/helmrelease.yaml
@@ -31,10 +31,6 @@ spec:
   upgrade:
     cleanupOnFail: true
     timeout: 25m
-    # Enabling chart-managed volumeClaimTemplates is an immutable StatefulSet
-    # change. Helm must replace the StatefulSet after the flush configuration
-    # has already been verified on the existing Pod; PVCs are retained.
-    force: true
     # Helm must not gate this release on Mimir readiness. Its ring components
     # (compactor/store-gateway/ingester) legitimately take 1-5m to join and the
     # ingester's graceful shutdown flushes its whole TSDB head (grace 1200s).
@@ -51,6 +47,27 @@ spec:
       # Timeouts alone were never the fix (see disableWait above); they are
       # kept as a backstop for a genuinely hung operation.
       retries: 2
+  postRenderers:
+    - kustomize:
+        patches:
+          # The chart's persistentVolume mode adds volumeClaimTemplates to the
+          # StatefulSet. That field cannot be added to the existing StatefulSet
+          # in place, so keep the chart's emptyDir mode and replace only the
+          # mutable pod-template volume with the separately managed claim.
+          # The test operation makes a chart volume-order change fail closed.
+          - target:
+              kind: StatefulSet
+              name: mimir-ingester
+            patch: |-
+              - op: test
+                path: /spec/template/spec/volumes/2/name
+                value: storage
+              - op: remove
+                path: /spec/template/spec/volumes/2/emptyDir
+              - op: add
+                path: /spec/template/spec/volumes/2/persistentVolumeClaim
+                value:
+                  claimName: storage-mimir-ingester-0
   values:
     rollout_operator:
       enabled: false
@@ -89,7 +106,7 @@ spec:
         ingester:
           push_grpc_method_enabled: true
           ring:
-            replication_factor: 2
+            replication_factor: 1
         store_gateway:
           sharding_ring:
             replication_factor: 1
@@ -147,31 +164,26 @@ spec:
           out_of_order_time_window: 10m
 
     ingester:
-      replicas: 2
+      replicas: 1
       zoneAwareReplication:
         enabled: false
       persistentVolume:
-        # Chart-managed volumeClaimTemplates create one claim per ordinal:
-        # storage-mimir-ingester-0 and storage-mimir-ingester-1. The existing
-        # -0 claim is retained and reused during the forced StatefulSet
-        # replacement; the separate manifest keeps its prune protection.
-        enabled: true
-        size: 20Gi
-        storageClass: ceph-block-replicated
+        # Adding chart-managed volumeClaimTemplates would be rejected as an
+        # immutable StatefulSet update. The PVC is managed beside this release
+        # and the post-renderer switches the pod template to it.
+        enabled: false
       extraArgs:
-        "-ingester.ring.replication-factor": "2"
+        "-ingester.ring.replication-factor": "1"
 
     store_gateway:
-      # Two store-gateways and RF=2 keep the older-block query path available
-      # while one gateway is unavailable. This is independent of ingester HA.
-      replicas: 2
+      replicas: 1
       zoneAwareReplication:
         enabled: false
       persistentVolume:
         enabled: true
         size: 2Gi
       extraArgs:
-        "-store-gateway.sharding-ring.replication-factor": "2"
+        "-store-gateway.sharding-ring.replication-factor": "1"
 
     compactor:
       replicas: 1


### PR DESCRIPTION
## Summary
- Revert merged #2793 and #2794 Mimir ingester/store-gateway topology changes.
- Restore one ingester and one store gateway with RF=1 and the existing externally managed ingester PVC design.

## Incident
The live `mimir/mimir` HelmRelease is Stalled=True, Ready=False, Released=False, Remediated=True. Flux reports three failed upgrades and rollback to `mimir.v87`; server-side apply rejects `mimir-ingester` because `volumeClaimTemplates` is immutable. Neither capacity change took effect.

This recovery does not force or delete a StatefulSet, resize a PVC, or mutate the cluster directly.

## Supported follow-up
Replica scaling itself is a mutable StatefulSet field, but this chart transition also changes the storage model. A safe HA design must stage flush/configuration first, verify the new Pod is running it, then perform an explicitly planned StatefulSet/PVC migration that preserves `storage-mimir-ingester-0` and provisions a distinct claim for ordinal 1. Do not rely on Helm force as a substitute for that migration.

## Validation
- `tools/check.sh talos-ottawa`: exit 0
- One HelmRelease file changed

Held for review; do not merge automatically.