### PR TITLE
feat(mimir): alert on sustained node clock skew

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -41,6 +41,7 @@ configMapGenerator:
       - rules/mimir-queryable-window.yaml
       - rules/monitoring.yaml
       - rules/node-health.yaml
+      - rules/node-clock.yaml
       - rules/payments.yaml
       - rules/smartctl.yaml
       - rules/velero.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -51,6 +51,7 @@ spec:
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
+            - /rules/node-clock.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -89,6 +90,7 @@ spec:
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
+            - /rules/node-clock.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -123,6 +125,7 @@ spec:
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
+            - /rules/node-clock.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-clock.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-clock.yaml
@@ -1,0 +1,21 @@
+# Node-exporter exposes this metric by default through the existing
+# kube-prometheus-stack ServiceMonitor. Keep the threshold well above ordinary
+# NTP drift while detecting the kind of host fault that can invalidate TLS,
+# tokens, and backup retention decisions long before those consumers fail.
+namespace: node-clock
+groups:
+  - name: node-clock.rules
+    rules:
+      - alert: NodeClockSkew
+        expr: abs(node_timex_offset_seconds) > 300
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Node {{ $labels.instance }} has excessive clock skew
+          description: >-
+            Node {{ $labels.instance }} has reported more than five minutes of
+            clock offset for at least ten minutes
+            ({{ printf "%.0f" $value }} seconds). Check host time
+            synchronisation before investigating TLS, authentication, or
+            backup failures.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/node-clock_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/node-clock_test.yaml
@@ -1,0 +1,50 @@
+rule_files:
+  - ../node-clock.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'node_timex_offset_seconds{cluster="talos-ottawa",instance="10.0.0.1:9100",job="node-exporter"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NodeClockSkew
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'node_timex_offset_seconds{cluster="talos-robbinsdale",instance="10.0.0.2:9100",job="node-exporter"}'
+        values: "3900+0x20"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NodeClockSkew
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: NodeClockSkew
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              cluster: talos-robbinsdale
+              instance: 10.0.0.2:9100
+              job: node-exporter
+            exp_annotations:
+              summary: Node 10.0.0.2:9100 has excessive clock skew
+              description: >-
+                Node 10.0.0.2:9100 has reported more than five minutes of
+                clock offset for at least ten minutes (3900 seconds). Check
+                host time synchronisation before investigating TLS,
+                authentication, or backup failures.
+
+  - interval: 1m
+    input_series:
+      - series: 'node_timex_offset_seconds{cluster="talos-stpetersburg",instance="10.0.0.3:9100",job="node-exporter"}'
+        values: "600+0x4 0+0x16"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: NodeClockSkew
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: NodeClockSkew
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -8,11 +8,12 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 # Mimir's native rule files require a top-level namespace, which promtool does
 # not understand. Keep each production rule as the source of truth and remove
 # only that Mimir wrapper in the temporary test copy.
-for rule in flux bhaiya-model garage; do
+for rule in flux bhaiya-model garage node-clock; do
   case "$rule" in
     flux) test_file=flux_test.yaml ;;
     bhaiya-model) test_file=bhaiya_model_test.yaml ;;
     garage) test_file=garage_test.yaml ;;
+    node-clock) test_file=node-clock_test.yaml ;;
   esac
   sed "/^namespace: ${rule}$/d" "$RULE_DIR/${rule}.yaml" >"$tmpdir/${rule}.yaml"
   sed "s#../${rule}.yaml#$tmpdir/${rule}.yaml#" \


### PR DESCRIPTION
## Summary

- Alert on sustained node clock offset using the existing node-exporter `node_timex_offset_seconds` metric.
- Load the native Mimir rule for Ottawa, Robbinsdale, and St. Petersburg tenants.
- Cover normal drift, a 65-minute skew, transient skew, and cluster-label propagation with promtool tests.

## Design

The alert fires when absolute offset exceeds 300 seconds for 10 minutes. This is well above ordinary one- or two-second NTP drift, but catches a host clock fault long before a roughly 65-minute skew can break Kopia, TLS validity checks, token expiry, or time-based backup/alert behavior. It intentionally does not alert on `node_timex_sync_status` alone because brief unsynchronized states can be noisy; measured offset is the actionable condition.

The existing kube-prometheus-stack node-exporter ServiceMonitor is enabled and stamps the `cluster` label. No new instrumentation or PrometheusRule CR is added. The rule is wired into the shared Mimir native ruler ConfigMap and all three tenant loader containers.

This branch is based on current `origin/main`; the earlier #2797 branch was based on a stale shared worktree and is being superseded.

## Verification

- `PATH=/tmp/cos-promtool.qAjD6j/prometheus-3.14.0.linux-amd64:$PATH kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh`: exit 0.
- `tools/check-mimir-rules.sh`: exit 0; 26 files, 3 tenant loaders, 25 unique namespaces.
- `git diff --check`: exit 0.

No production objects were modified and this PR is not being merged here.
