### PR TITLE
fix(velero): admit restores behind prepared queue

### DIFF
--- a/kubernetes/apps/base/velero/velero/node-agent-config.yaml
+++ b/kubernetes/apps/base/velero/velero/node-agent-config.yaml
@@ -7,7 +7,10 @@
 # which then times out and marks the whole backup PartiallyFailed. Two slots
 # keeps one stuck volume from taking the node's other volumes down with it.
 # Bound the prepared queue so repeated schedules cannot create an unlimited
-# number of idle data-mover pods behind a wedged operation.
+# number of idle data-mover pods behind a wedged operation. Velero applies this
+# threshold globally across PVB/PVR/DataUpload/DataDownload objects; it is not
+# the per-node execution limit below. Keep enough headroom for a restore to be
+# admitted while a backup has prepared work waiting.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,6 +20,6 @@ data:
     {
       "loadConcurrency": {
         "globalConfig": 2,
-        "prepareQueueLength": 8
+        "prepareQueueLength": 12
       }
     }


### PR DESCRIPTION
## Summary

Raise Velero's global prepared data-path queue from 8 to 12 so a PodVolumeRestore can be admitted while backup work is already prepared. The per-node execution limit remains `globalConfig: 2`; this change does not increase concurrent I/O.

## Root-cause verification

The live Ottawa node-agent runs Velero v1.18.2 with `loadConcurrency.globalConfig=2` and `prepareQueueLength=8`. The fenced restore evidence showed eight prepared PVBs occupying the queue, while the new PVR remained phase-empty with snapshot metadata and was requeued every five seconds before acceptance.

The v1.18.2 source confirms the behavior:

- `pkg/types/node_agent.go` defines `GlobalConfig` as the default concurrency applied per node, while `PrepareQueueLength` limits pending intermediate data-mover loads.
- `pkg/exposer/vgdp_counter.go` lists all labeled DataUpload, DataDownload, PodVolumeBackup, and PodVolumeRestore objects without a node filter, sums them, and treats the queue as constrained at the configured length.
- `pkg/controller/pod_volume_restore_controller.go` checks that counter before logging `Accepting PVR`; when constrained it requeues after five seconds.
- The upstream v1.18 documentation describes `prepareQueueLength` as applying to all four CR types and all node-agent pods.

This matches the observed empty-phase PVR and the eight prepared PVB occupants. The live node-agent was healthy, and an earlier restore had completed, so this was queue starvation rather than a broken snapshot or node-agent.

## Scope and limitation

This is controlled admission headroom, not cleanup of the existing wedged backup. Already-stuck prepared/in-progress PVBs still require the separate human-approved cancellation/recovery decision recorded in the restore evidence. Increasing the queue does not make those data paths healthy; it allows later restore work to pass the pre-admission gate when the queue has available capacity.

The evidence namespace `restore-proof-20260908-ha` was not modified or deleted.

## Verification

- `tools/check.sh`: exit 0; all three cluster renders passed.
- `git diff --check`: exit 0.
