### PR TITLE
fix(monitoring): detect Velero volume coverage regressions

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -8,12 +8,13 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 # Mimir's native rule files require a top-level namespace, which promtool does
 # not understand. Keep each production rule as the source of truth and remove
 # only that Mimir wrapper in the temporary test copy.
-for rule in flux bhaiya-model garage node-clock; do
+for rule in flux bhaiya-model garage node-clock velero-integrity; do
   case "$rule" in
     flux) test_file=flux_test.yaml ;;
     bhaiya-model) test_file=bhaiya_model_test.yaml ;;
     garage) test_file=garage_test.yaml ;;
     node-clock) test_file=node-clock_test.yaml ;;
+    velero-integrity) test_file=velero-integrity_test.yaml ;;
   esac
   sed "/^namespace: ${rule}$/d" "$RULE_DIR/${rule}.yaml" >"$tmpdir/${rule}.yaml"
   sed "s#../${rule}.yaml#$tmpdir/${rule}.yaml#" \

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -6,6 +6,8 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
+      # The warning/error series are intentionally absent for the previous
+      # successful Backup: kube-state-metrics emits them only when non-zero.
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-previous"}'
         values: "100+0x20"
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current"}'
@@ -14,28 +16,30 @@ tests:
         values: "1+0x20"
       - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current",phase="PartiallyFailed"}'
         values: "1+0x20"
-      - series: 'velero_cr_backup_warnings{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-previous"}'
-        values: "0+0x20"
-      - series: 'velero_cr_backup_warnings{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current"}'
-        values: "10+0x20"
       - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-1",node="asuka",phase="Completed"}'
         values: "1+0x20"
       - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-2",node="asuka",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-1",node="asuka"}'
-        values: "100+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-1",node="asuka"}'
-        values: "100+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-2",node="asuka"}'
-        values: "200+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-2",node="asuka"}'
-        values: "200+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-current",pod_volume_backup="current-pvb-1",node="asuka",phase="Completed"}'
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-3",node="asuka",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-current",pod_volume_backup="current-pvb-1",node="asuka"}'
-        values: "300+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-current",pod_volume_backup="current-pvb-1",node="asuka"}'
-        values: "300+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-current",pod_volume_backup="current-pvb-1",node="asuka",phase="Prepared"}'
+        values: "1+0x20"
+
+      # A different schedule has stable one-PVB coverage. Its series prove
+      # the comparison is per schedule, not a cluster-wide total.
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="home-backup",backup="home-backup-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="home-backup",backup="home-backup-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="home-backup",backup="home-backup-previous",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="home-backup",backup="home-backup-current",phase="PartiallyFailed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="home-backup-previous",pod_volume_backup="home-previous-pvb",node="rei",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="home-backup-current",pod_volume_backup="home-current-pvb",node="rei",phase="Prepared"}'
+        values: "1+0x20"
+
     alert_rule_test:
       - eval_time: 15m
         alertname: VeleroScheduleVolumeCoverageRegressed

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -1,0 +1,48 @@
+rule_files:
+  - ../velero-integrity.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-previous",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current",phase="PartiallyFailed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_warnings{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-previous"}'
+        values: "0+0x20"
+      - series: 'velero_cr_backup_warnings{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current"}'
+        values: "10+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-1",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-2",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-1",node="asuka"}'
+        values: "100+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-1",node="asuka"}'
+        values: "100+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-2",node="asuka"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-2",node="asuka"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-current",pod_volume_backup="current-pvb-1",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-current",pod_volume_backup="current-pvb-1",node="asuka"}'
+        values: "300+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-current",pod_volume_backup="current-pvb-1",node="asuka"}'
+        values: "300+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: bhaiya-backup
+              backup: bhaiya-backup-current
+              severity: critical

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -260,11 +260,13 @@ groups:
       # phase and item counters are not allowed to hide a volume gap.
       - record: velero_schedule_latest_backup_created_timestamp
         expr: |
-          topk by (cluster, namespace, schedule) (
-            1,
-            velero_cr_backup_created_timestamp{
-              namespace="velero-system",
-              schedule!=""
+          max by (cluster, namespace, schedule, backup) (
+            topk by (cluster, namespace, schedule) (
+              1,
+              velero_cr_backup_created_timestamp{
+                namespace="velero-system",
+                schedule!=""
+              }
             }
           )
 
@@ -306,12 +308,14 @@ groups:
 
       - record: velero_schedule_previous_successful_backup_created_timestamp
         expr: |
-          topk by (cluster, namespace, schedule) (
-            1,
-            (
-              velero_schedule_successful_backup_created_timestamp
-              unless on (cluster, namespace, schedule, backup)
-              velero_schedule_latest_backup_created_timestamp
+          max by (cluster, namespace, schedule, backup) (
+            topk by (cluster, namespace, schedule) (
+              1,
+              (
+                velero_schedule_successful_backup_created_timestamp
+                unless on (cluster, namespace, schedule, backup)
+                velero_schedule_latest_backup_created_timestamp
+              )
             )
           )
 

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -251,3 +251,139 @@ groups:
             one byte-complete PVB exists; it does not prove every expected PVC
             is covered or that a restore works. Clears when a later Backup has
             a Completed PVB with matching byte counters.
+
+      # Count coverage, not Kubernetes item coverage. A current Backup with
+      # one completed PVB can otherwise look healthy beside a prior run with
+      # 37 completed PVBs. The current run is the newest Backup for the
+      # schedule, while the baseline is the newest older Completed Backup with
+      # zero warnings. The alert deliberately observes the count while the
+      # Backup is queued/running; phase is not allowed to hide a volume gap.
+      - record: velero_schedule_latest_backup_created_timestamp
+        expr: |
+          topk by (cluster, namespace, schedule) (
+            1,
+            velero_cr_backup_created_timestamp{
+              namespace="velero-system",
+              schedule!=""
+            }
+          )
+
+      - record: velero_schedule_previous_successful_backup_created_timestamp
+        expr: |
+          topk by (cluster, namespace, schedule) (
+            1,
+            (
+              (
+                velero_cr_backup_created_timestamp{
+                  namespace="velero-system",
+                  schedule!=""
+                }
+                and on (cluster, namespace, schedule, backup)
+                (
+                  velero_cr_backup_info{
+                    namespace="velero-system",
+                    schedule!="",
+                    phase="Completed"
+                  }
+                  and on (cluster, namespace, schedule, backup)
+                  (
+                    velero_cr_backup_warnings{
+                      namespace="velero-system",
+                      schedule!=""
+                    } == 0
+                  )
+                )
+              )
+              unless on (cluster, namespace, schedule, backup)
+              velero_schedule_latest_backup_created_timestamp
+            )
+          )
+
+      - record: velero_backup_completed_byte_complete_pvb_count
+        expr: |
+          count by (cluster, namespace, backup) (
+            velero_cr_podvolumebackup_info{
+              namespace="velero-system",
+              phase="Completed"
+            }
+            and on (cluster, namespace, pod_volume_backup, backup, node)
+            (
+              velero_cr_podvolumebackup_bytes_done{
+                namespace="velero-system"
+              }
+              == on (cluster, namespace, pod_volume_backup, backup, node)
+              velero_cr_podvolumebackup_bytes_total{
+                namespace="velero-system"
+              }
+            )
+          )
+
+      - record: velero_schedule_latest_completed_byte_complete_pvb_count
+        expr: |
+          (
+            (
+              velero_backup_completed_byte_complete_pvb_count
+              * on (cluster, namespace, backup) group_left (schedule)
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_info{
+                  namespace="velero-system",
+                  schedule!=""
+                }
+              )
+            )
+            and on (cluster, namespace, schedule, backup)
+            velero_schedule_latest_backup_created_timestamp
+          )
+          or on (cluster, namespace, schedule, backup)
+          (
+            velero_schedule_latest_backup_created_timestamp * 0
+          )
+
+      - record: velero_schedule_previous_successful_completed_byte_complete_pvb_count
+        expr: |
+          (
+            (
+              velero_backup_completed_byte_complete_pvb_count
+              * on (cluster, namespace, backup) group_left (schedule)
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_info{
+                  namespace="velero-system",
+                  schedule!="",
+                  phase="Completed"
+                }
+                and on (cluster, namespace, schedule, backup)
+                (
+                  velero_cr_backup_warnings{
+                    namespace="velero-system",
+                    schedule!=""
+                  } == 0
+                )
+              )
+            )
+            and on (cluster, namespace, schedule, backup)
+            velero_schedule_previous_successful_backup_created_timestamp
+          )
+          or on (cluster, namespace, schedule, backup)
+          (
+            velero_schedule_previous_successful_backup_created_timestamp * 0
+          )
+
+      - alert: VeleroScheduleVolumeCoverageRegressed
+        expr: |
+          velero_schedule_latest_completed_byte_complete_pvb_count
+          < on (cluster, namespace, schedule)
+          velero_schedule_previous_successful_completed_byte_complete_pvb_count
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} volume coverage regressed
+          description: >-
+            The newest Backup {{ $labels.backup }} for schedule
+            {{ $labels.schedule }} has fewer completed byte-complete
+            PodVolumeBackups than its previous clean successful Backup. This
+            is a volume-coverage regression even when Kubernetes item counts
+            or the parent Backup phase look normal. Inspect the current and
+            previous Backup PVB populations and the node-agent queue; do not
+            treat this alert as restore proof. It clears only when the newest
+            run reaches the prior successful volume count.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -253,11 +253,11 @@ groups:
             a Completed PVB with matching byte counters.
 
       # Count coverage, not Kubernetes item coverage. A current Backup with
-      # one completed PVB can otherwise look healthy beside a prior run with
-      # 37 completed PVBs. The current run is the newest Backup for the
-      # schedule, while the baseline is the newest older Completed Backup with
-      # zero warnings. The alert deliberately observes the count while the
-      # Backup is queued/running; phase is not allowed to hide a volume gap.
+      # one PVB can otherwise look healthy beside a prior run with 37 PVBs.
+      # The current run is the newest Backup for the schedule, while the
+      # baseline is the newest older successful Backup. The alert deliberately
+      # observes the produced-PVB count while the Backup is queued/running;
+      # phase and item counters are not allowed to hide a volume gap.
       - record: velero_schedule_latest_backup_created_timestamp
         expr: |
           topk by (cluster, namespace, schedule) (
@@ -268,61 +268,71 @@ groups:
             }
           )
 
+      # kube-state-metrics emits these status counters only when they are
+      # non-zero. Absence therefore means zero; using `metric == 0` here would
+      # make every otherwise-clean Backup disappear from the baseline.
+      - record: velero_schedule_successful_backup_created_timestamp
+        expr: |
+          velero_cr_backup_created_timestamp{
+            namespace="velero-system",
+            schedule!=""
+          }
+          and on (cluster, namespace, schedule, backup)
+          (
+            max by (cluster, namespace, schedule, backup) (
+              velero_cr_backup_info{
+                namespace="velero-system",
+                schedule!="",
+                phase="Completed"
+              }
+            )
+            unless on (cluster, namespace, schedule, backup)
+            (
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_warnings{
+                  namespace="velero-system",
+                  schedule!=""
+                } > 0
+              )
+              or
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_errors{
+                  namespace="velero-system",
+                  schedule!=""
+                } > 0
+              )
+            )
+          )
+
       - record: velero_schedule_previous_successful_backup_created_timestamp
         expr: |
           topk by (cluster, namespace, schedule) (
             1,
             (
-              (
-                velero_cr_backup_created_timestamp{
-                  namespace="velero-system",
-                  schedule!=""
-                }
-                and on (cluster, namespace, schedule, backup)
-                (
-                  velero_cr_backup_info{
-                    namespace="velero-system",
-                    schedule!="",
-                    phase="Completed"
-                  }
-                  and on (cluster, namespace, schedule, backup)
-                  (
-                    velero_cr_backup_warnings{
-                      namespace="velero-system",
-                      schedule!=""
-                    } == 0
-                  )
-                )
-              )
+              velero_schedule_successful_backup_created_timestamp
               unless on (cluster, namespace, schedule, backup)
               velero_schedule_latest_backup_created_timestamp
             )
           )
 
-      - record: velero_backup_completed_byte_complete_pvb_count
+      # Count each PVB object once, regardless of phase. A Prepared PVB is
+      # still evidence that the Backup selected one volume; the separate
+      # stalled-PVB alert owns whether that selected volume makes progress.
+      - record: velero_backup_pod_volume_backup_count
         expr: |
           count by (cluster, namespace, backup) (
-            velero_cr_podvolumebackup_info{
-              namespace="velero-system",
-              phase="Completed"
-            }
-            and on (cluster, namespace, pod_volume_backup, backup, node)
-            (
-              velero_cr_podvolumebackup_bytes_done{
-                namespace="velero-system"
-              }
-              == on (cluster, namespace, pod_volume_backup, backup, node)
-              velero_cr_podvolumebackup_bytes_total{
+            max by (cluster, namespace, pod_volume_backup, backup) (
+              velero_cr_podvolumebackup_info{
                 namespace="velero-system"
               }
             )
           )
 
-      - record: velero_schedule_latest_completed_byte_complete_pvb_count
+      - record: velero_schedule_latest_pod_volume_backup_count
         expr: |
           (
             (
-              velero_backup_completed_byte_complete_pvb_count
+              velero_backup_pod_volume_backup_count
               * on (cluster, namespace, backup) group_left (schedule)
               max by (cluster, namespace, schedule, backup) (
                 velero_cr_backup_info{
@@ -339,25 +349,17 @@ groups:
             velero_schedule_latest_backup_created_timestamp * 0
           )
 
-      - record: velero_schedule_previous_successful_completed_byte_complete_pvb_count
+      - record: velero_schedule_previous_successful_pod_volume_backup_count
         expr: |
           (
             (
-              velero_backup_completed_byte_complete_pvb_count
+              velero_backup_pod_volume_backup_count
               * on (cluster, namespace, backup) group_left (schedule)
               max by (cluster, namespace, schedule, backup) (
                 velero_cr_backup_info{
                   namespace="velero-system",
-                  schedule!="",
-                  phase="Completed"
+                  schedule!=""
                 }
-                and on (cluster, namespace, schedule, backup)
-                (
-                  velero_cr_backup_warnings{
-                    namespace="velero-system",
-                    schedule!=""
-                  } == 0
-                )
               )
             )
             and on (cluster, namespace, schedule, backup)
@@ -370,9 +372,9 @@ groups:
 
       - alert: VeleroScheduleVolumeCoverageRegressed
         expr: |
-          velero_schedule_latest_completed_byte_complete_pvb_count
+          velero_schedule_latest_pod_volume_backup_count
           < on (cluster, namespace, schedule)
-          velero_schedule_previous_successful_completed_byte_complete_pvb_count
+          velero_schedule_previous_successful_pod_volume_backup_count
         for: 15m
         labels:
           severity: critical
@@ -380,10 +382,11 @@ groups:
           summary: Velero schedule {{ $labels.schedule }} volume coverage regressed
           description: >-
             The newest Backup {{ $labels.backup }} for schedule
-            {{ $labels.schedule }} has fewer completed byte-complete
-            PodVolumeBackups than its previous clean successful Backup. This
-            is a volume-coverage regression even when Kubernetes item counts
-            or the parent Backup phase look normal. Inspect the current and
-            previous Backup PVB populations and the node-agent queue; do not
-            treat this alert as restore proof. It clears only when the newest
+            {{ $labels.schedule }} has fewer PodVolumeBackups than its previous
+            successful Backup. Any lower PVB count is material because each
+            PVB represents one selected volume. This remains a coverage
+            regression even when Kubernetes item counts or the parent Backup
+            phase look normal. Inspect the current and previous Backup PVB
+            populations; stalled-path and node-saturation alerts are separate,
+            and this alert is not restore proof. It clears only when the newest
             run reaches the prior successful volume count.


### PR DESCRIPTION
## Summary

- compare the newest Backup's completed, byte-complete PodVolumeBackup count with the previous zero-warning Completed Backup for the same schedule
- alert while the current Backup is queued or incomplete, rather than clearing on item counts or parent phase
- add a Prometheus rule test fixture for a 1-of-2 regression

This catches the Bhaiya shape where 844/844 Kubernetes items and one completed PVB would otherwise look healthy beside the prior 37-volume run. It is separate from the node-agent concurrency change; this PR changes no live cluster state and no concurrency setting.

## Validation

- `tools/check.sh ot` — `✓ render OK: talos-ottawa`
- Prometheus rule tests are included but could not run locally because `promtool` is unavailable in the agent environment.