### PR TITLE
feat(mimir): alert on saturated Velero nodes

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -47,4 +47,5 @@ configMapGenerator:
       - rules/velero.yaml
       - rules/velero-integrity.yaml
       - rules/velero-volume-progress.yaml
+      - rules/velero-node-saturation.yaml
       - rules/zot.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -52,6 +52,7 @@ spec:
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
+            - /rules/velero-node-saturation.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -92,6 +93,7 @@ spec:
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
+            - /rules/velero-node-saturation.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -128,6 +130,7 @@ spec:
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
+            - /rules/velero-node-saturation.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_node_saturation_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_node_saturation_test.yaml
@@ -1,0 +1,75 @@
+rule_files:
+  - ../velero-node-saturation.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_backup="pvb-a",phase="InProgress"}'
+        values: "1+0x15"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_backup="pvb-b",phase="InProgress"}'
+        values: "1+0x15"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_backup="pvb-c",phase="Prepared"}'
+        values: "1+0x15"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: VeleroNodeDataPathSaturated
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: VeleroNodeDataPathSaturated
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              cluster: talos-ottawa
+              node: asuka
+            exp_annotations:
+              summary: Velero node asuka is saturated with queued volume work
+              description: >-
+                Node asuka in talos-ottawa has reached the two-path execution
+                ceiling with InProgress PVB/PVR objects and has Prepared work
+                waiting on that node for ten minutes. This is a node-local
+                saturation signal, not proof that a transfer is stalled.
+                Inspect PVB/PVR phase, bytesDone/totalBytes, and node-agent
+                logs; the separate per-kind recording series identify
+                contributors.
+
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_backup="pvb-a",phase="InProgress"}'
+        values: "1+0x15"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",node="rei",pod_volume_backup="pvb-b",phase="InProgress"}'
+        values: "1+0x15"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_backup="pvb-c",phase="Prepared"}'
+        values: "1+0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: VeleroNodeDataPathSaturated
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_backup="pvb-a",phase="InProgress"}'
+        values: "1+0x15"
+      - series: 'velero_cr_podvolumerestore_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_restore="pvr-a",phase="InProgress"}'
+        values: "1+0x15"
+      - series: 'velero_cr_podvolumerestore_info{cluster="talos-ottawa",namespace="velero-system",node="asuka",pod_volume_restore="pvr-b",phase="Prepared"}'
+        values: "1+0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: VeleroNodeDataPathSaturated
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              cluster: talos-ottawa
+              node: asuka
+            exp_annotations:
+              summary: Velero node asuka is saturated with queued volume work
+              description: >-
+                Node asuka in talos-ottawa has reached the two-path execution
+                ceiling with InProgress PVB/PVR objects and has Prepared work
+                waiting on that node for ten minutes. This is a node-local
+                saturation signal, not proof that a transfer is stalled.
+                Inspect PVB/PVR phase, bytesDone/totalBytes, and node-agent
+                logs; the separate per-kind recording series identify
+                contributors.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-node-saturation.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-node-saturation.yaml
@@ -2,6 +2,7 @@
 # monitoring-common/app/kube-state-metrics-config.yaml. The exporter must
 # provide the metric names and direct cluster/node/phase labels documented
 # there; without that deployment this rule is intentionally inert.
+namespace: velero-node-saturation
 groups:
   - name: velero-node-saturation.rules
     rules:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-node-saturation.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-node-saturation.yaml
@@ -1,0 +1,92 @@
+# Depends on the kube-state-metrics Velero CR contract in
+# monitoring-common/app/kube-state-metrics-config.yaml. The exporter must
+# provide the metric names and direct cluster/node/phase labels documented
+# there; without that deployment this rule is intentionally inert.
+groups:
+  - name: velero-node-saturation.rules
+    rules:
+      - record: velero_node_inprogress_pod_volume_backups
+        expr: |
+          count by (cluster, node) (
+            velero_cr_podvolumebackup_info{
+              namespace="velero-system",
+              phase="InProgress"
+            }
+          )
+
+      - record: velero_node_inprogress_pod_volume_restores
+        expr: |
+          count by (cluster, node) (
+            velero_cr_podvolumerestore_info{
+              namespace="velero-system",
+              phase="InProgress"
+            }
+          )
+
+      - record: velero_node_prepared_pod_volume_backups
+        expr: |
+          count by (cluster, node) (
+            velero_cr_podvolumebackup_info{
+              namespace="velero-system",
+              phase="Prepared"
+            }
+          )
+
+      - record: velero_node_prepared_pod_volume_restores
+        expr: |
+          count by (cluster, node) (
+            velero_cr_podvolumerestore_info{
+              namespace="velero-system",
+              phase="Prepared"
+            }
+          )
+
+      - record: velero_node_inprogress_data_paths
+        expr: |
+          sum by (cluster, node) (
+            velero_cr_podvolumebackup_info{
+              namespace="velero-system",
+              phase="InProgress"
+            }
+            or
+            velero_cr_podvolumerestore_info{
+              namespace="velero-system",
+              phase="InProgress"
+            }
+          )
+
+      - record: velero_node_prepared_data_paths
+        expr: |
+          sum by (cluster, node) (
+            velero_cr_podvolumebackup_info{
+              namespace="velero-system",
+              phase="Prepared"
+            }
+            or
+            velero_cr_podvolumerestore_info{
+              namespace="velero-system",
+              phase="Prepared"
+            }
+          )
+
+      - alert: VeleroNodeDataPathSaturated
+        expr: |
+          (
+            velero_node_inprogress_data_paths >= 2
+          )
+          and on (cluster, node)
+          (
+            velero_node_prepared_data_paths > 0
+          )
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Velero node {{ $labels.node }} is saturated with queued volume work
+          description: >-
+            Node {{ $labels.node }} in {{ $labels.cluster }} has reached the
+            two-path execution ceiling with InProgress PVB/PVR objects and
+            has Prepared work waiting on that node for ten minutes. This is a
+            node-local saturation signal, not proof that a transfer is stalled.
+            Inspect PVB/PVR phase, bytesDone/totalBytes, and node-agent logs;
+            the separate per-kind recording series identify contributors.


### PR DESCRIPTION
## Summary

- Add a per-node Velero data-path saturation alert with `for: 10m`.
- Count InProgress and Prepared PVB/PVR objects by `(cluster,node)`; never aggregate fleet-wide.
- Add focused promtool coverage for PVB-only, mixed PVB/PVR, and distributed fleet cases.

## Metric dependency

This rule consumes the kube-state-metrics custom-resource contract from km#2811:

- `velero_cr_podvolumebackup_info`
- `velero_cr_podvolumerestore_info`
- direct `node` and `phase` labels on both families

The exporter contract is now deployed and live. Ottawa Mimir exposes PVB data by node and phase, and now exposes PVR data as well (for example, `kaji` has one Completed PVR and `rei` has one Completed PVR). Exporter configuration and RBAC are not changed in this PR. The separate recording series preserve which resource kind contributes to saturation.

## Incident discrimination

A historical Ottawa range query showed `asuka` at exactly two InProgress PVBs for thirteen consecutive hourly samples, dropping to one after cancellation; `rei` stayed at one for the entire window. The rule would have identified the saturated node roughly thirteen hours before manual investigation, while not flagging the busy-but-not-saturated node.

This alert detects node-local capacity pressure and complements, rather than replaces, single-transfer stalled-progress detection.

## Deliberate scope boundary

A PVB/PVR with an empty phase is intentionally out of scope. Empty phase means the object has not been admitted/prepared and is not evidence of node saturation. Never-admitted restore starvation is a separate condition and requires separate coverage; this rule does not claim to detect it.

## Verification

- Focused promtool rule test: passed.
- Mimir rule load-path check: passed.
- Full serialized render gate after wiring: exit 0 for Ottawa, Robbinsdale, and St Petersburg.
