### PR TITLE
fix(bhaiya): redirect unauthenticated UI requests

### DIFF
--- a/kubernetes/apps/base/k8gb/k8gb-common/config/gslb-bhaiya.yaml
+++ b/kubernetes/apps/base/k8gb/k8gb-common/config/gslb-bhaiya.yaml
@@ -70,3 +70,31 @@ spec:
         - remote-email
         - remote-name
         - remote-groups
+---
+# Tinyauth returns 401 with x-tinyauth-location for unauthenticated requests.
+# Convert that ext_authz response into the browser redirect expected by the
+# public Bhaiya UI. This is route-scoped because the response filter must run
+# after the route's ext_authz check.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyExtensionPolicy
+metadata:
+  name: bhaiya-tinyauth-redirect
+  namespace: keiretsu-top
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: bhaiya-cdn
+  lua:
+    - inline: |
+        function envoy_on_response(response_handle)
+          local headers = response_handle:headers()
+          if headers:get(":status") == "401" then
+            local location = headers:get("x-tinyauth-location")
+            if location then
+              headers:replace(":status", "302")
+              headers:add("Location", location)
+              headers:remove("x-tinyauth-location")
+            end
+          end
+        end


### PR DESCRIPTION
## What changed

Add the route-scoped EnvoyExtensionPolicy keiretsu-top/bhaiya-tinyauth-redirect to bhaiya-cdn. TinyAuth returns a 401 with x-tinyauth-location; the Lua response filter converts that UI response to a 302 Location redirect. The primary https://bhaiya.keiretsu.top/ currently returns JSON 401, while the staging member route already redirects successfully; this copies that accepted policy shape.

## Security evidence

The live Gateway API schema documents that headersToBackend overrides coexisting client headers. TinyAuth therefore overwrites (rather than appends to) Remote-Email; an authenticated member cannot forge that identity header through the public route. API and OIDC routes retain their deliberate header stripping and are not changed here.

## Raj browser checklist (two minutes)

1. In an incognito window, open https://bhaiya.keiretsu.top/; confirm it redirects to TinyAuth and returns to the full Raj UI after login.
2. In an incognito window, open the staging member URL; confirm it redirects to TinyAuth and returns to the member workspace shell.
3. While authenticated as a member, try a client-supplied Remote-Email override and confirm the resulting identity remains the TinyAuth account (configuration already proves overwrite semantics).

## Verification

- kubectl kustomize kubernetes/apps/base/k8gb/k8gb-common/config, substituting COMMON_DOMAIN=keiretsu.top, piped to tools/kc.sh ot apply --dry-run=server -f - passed for the whole directory.
- No production mutation was performed.
- No browser session was available; the checklist above is the remaining human verification.