### PR TITLE
fix(mimir): close topk with a paren in velero-integrity

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -267,7 +267,7 @@ groups:
                 namespace="velero-system",
                 schedule!=""
               }
-            }
+            )
           )
 
       # kube-state-metrics emits these status counters only when they are


### PR DESCRIPTION
## Problem

`velero_schedule_latest_backup_created_timestamp` closes its `topk()` with a brace instead of a paren. mimirtool rejects the **entire file**, so the Mimir rule loader has been failing and **no rule changes are reaching the ruler at all** — not just the Velero ones.

Observed on Ottawa: job `mimir-rules-ccct7hgc2b` Running 0/1 with three pods in `Error`:

```
level=error msg="unable to parse rules file" file=/rules/velero-integrity.yaml
  err="262:15: group \"velero-integrity.rules\", rule 5,
  \"velero_schedule_latest_backup_created_timestamp\":
  could not parse expression: 8:3: parse error: unexpected character: '}'"
mimirtool: error: sync operation unsuccessful
```

## Fix

One character: `}` → `)` closing the `topk()`. Parens now balance 4/4 and braces 1/1.

## Why CI missed it

The `mimir-rule-load-path` check validates that a rule file declares a non-empty Mimir namespace and is registered in `loader-job.yaml` — it caught exactly that on #2810. It does **not** parse the PromQL expressions, so a syntactically invalid rule passes.

Worth a follow-up: run `promtool check rules` over the rule inputs in CI. This defect blocked every rule update cluster-wide while all checks were green.