### PR TITLE
feat(mimir): detect never-admitted Velero restores

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -48,4 +48,5 @@ configMapGenerator:
       - rules/velero-integrity.yaml
       - rules/velero-volume-progress.yaml
       - rules/velero-node-saturation.yaml
+      - rules/velero-restore-admission.yaml
       - rules/zot.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -53,6 +53,7 @@ spec:
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
+            - /rules/velero-restore-admission.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -94,6 +95,7 @@ spec:
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
+            - /rules/velero-restore-admission.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml
@@ -131,6 +133,7 @@ spec:
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
+            - /rules/velero-restore-admission.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
             - /rules/velero.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_restore_admission_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_restore_admission_test.yaml
@@ -1,0 +1,98 @@
+rule_files:
+  - ../velero-restore-admission.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # No PVRs means no left-hand timestamp series and therefore no alert.
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: VeleroPodVolumeRestoreNeverAdmitted
+        exp_alerts: []
+
+  # A creation timestamp proves that the object was observed. No _info series
+  # means status.phase is absent, the normal omitempty representation.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumerestore_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_volume_restore="pvr-empty",restore="restore-a",restore_uid="uid-a",source_namespace="home",volume="homeassistant-config"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: VeleroPodVolumeRestoreNeverAdmitted
+        exp_alerts: []
+      - eval_time: 21m
+        alertname: VeleroPodVolumeRestoreNeverAdmitted
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              namespace: velero-system
+              pod_volume_restore: pvr-empty
+              restore: restore-a
+              restore_uid: uid-a
+              source_namespace: home
+              volume: homeassistant-config
+            exp_annotations:
+              summary: Velero PodVolumeRestore pvr-empty was never admitted
+              description: >-
+                PodVolumeRestore pvr-empty for Restore restore-a has existed
+                for more than ten minutes without a non-empty Velero phase. It
+                may be blocking restore completion before admission; inspect
+                the PVR, parent Restore, and Velero controller/node-agent logs.
+                This is a restore-level admission signal, not node saturation,
+                and does not prove content failure.
+
+  # An explicitly empty phase is also covered; the non-empty phase matcher
+  # deliberately does not subtract phase="".
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumerestore_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_volume_restore="pvr-explicit-empty",restore="restore-b",restore_uid="uid-b",source_namespace="home",volume="homeassistant-config"}'
+        values: "0+0x30"
+      - series: 'velero_cr_podvolumerestore_info{cluster="talos-ottawa",namespace="velero-system",pod_volume_restore="pvr-explicit-empty",restore="restore-b",restore_uid="uid-b",source_namespace="home",volume="homeassistant-config",phase=""}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 21m
+        alertname: VeleroPodVolumeRestoreNeverAdmitted
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              namespace: velero-system
+              pod_volume_restore: pvr-explicit-empty
+              restore: restore-b
+              restore_uid: uid-b
+              source_namespace: home
+              volume: homeassistant-config
+            exp_annotations:
+              summary: Velero PodVolumeRestore pvr-explicit-empty was never admitted
+              description: >-
+                PodVolumeRestore pvr-explicit-empty for Restore restore-b has
+                existed for more than ten minutes without a non-empty Velero
+                phase. It may be blocking restore completion before admission;
+                inspect the PVR, parent Restore, and Velero controller/node-agent
+                logs. This is a restore-level admission signal, not node
+                saturation, and does not prove content failure.
+
+  # Any non-empty phase means the PVR has a lifecycle state and is excluded.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumerestore_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_volume_restore="pvr-completed",restore="restore-c",restore_uid="uid-c",source_namespace="home",volume="homeassistant-config"}'
+        values: "0+0x30"
+      - series: 'velero_cr_podvolumerestore_info{cluster="talos-ottawa",namespace="velero-system",pod_volume_restore="pvr-completed",restore="restore-c",restore_uid="uid-c",source_namespace="home",volume="homeassistant-config",phase="Completed"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: VeleroPodVolumeRestoreNeverAdmitted
+        exp_alerts: []
+
+  # A scrape gap removes the timestamp series before the alert can become
+  # pending; absence of observation is not treated as admission starvation.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumerestore_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_volume_restore="pvr-gap",restore="restore-d",restore_uid="uid-d",source_namespace="home",volume="homeassistant-config"}'
+        values: "0 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: VeleroPodVolumeRestoreNeverAdmitted
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-restore-admission.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-restore-admission.yaml
@@ -1,0 +1,35 @@
+# Depends on the kube-state-metrics Velero PVR contract adding
+# velero_cr_podvolumerestore_created_timestamp with the PVR identity labels.
+# A never-admitted PVR normally omits status.phase because Velero serializes the
+# field with omitempty, so podvolumerestore_info does not exist for it.
+namespace: velero-restore-admission
+groups:
+  - name: velero.restore-admission.rules
+    rules:
+      - alert: VeleroPodVolumeRestoreNeverAdmitted
+        expr: |
+          (
+            time() - velero_cr_podvolumerestore_created_timestamp{
+              namespace="velero-system"
+            } > 600
+          )
+          unless on (
+            cluster, namespace, pod_volume_restore, restore, restore_uid,
+            source_namespace, volume
+          )
+          velero_cr_podvolumerestore_info{
+            namespace="velero-system",
+            phase=~".+"
+          }
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero PodVolumeRestore {{ $labels.pod_volume_restore }} was never admitted
+          description: >-
+            PodVolumeRestore {{ $labels.pod_volume_restore }} for Restore
+            {{ $labels.restore }} has existed for more than ten minutes without
+            a non-empty Velero phase. It may be blocking restore completion
+            before admission; inspect the PVR, parent Restore, and Velero
+            controller/node-agent logs. This is a restore-level admission
+            signal, not node saturation, and does not prove content failure.


### PR DESCRIPTION
## Summary

Add a restore-level Mimir alert for a PodVolumeRestore that is observed but remains without a non-empty Velero phase for more than ten minutes. This targets the never-admitted restore condition seen in the fenced rehearsal, where the parent Restore stayed InProgress while the target pod waited indefinitely.

## Metric dependency / intentional staging

This rule intentionally depends on the finalized kube-state-metrics Velero PVR contract owned by cos-velero:

- Metric: `velero_cr_podvolumerestore_created_timestamp`
- Labels: `cluster`, `customresource_group`, `customresource_version`, `customresource_kind`, `namespace`, `pod_volume_restore`, `restore`, `restore_uid`, `source_namespace`, and `volume`
- `node` is optional and omitted when absent; the rule deliberately does not require it.

Until that exporter metric is deployed and rolled out, this rule is intentionally inert and must not be treated as coverage. The exporter configuration and RBAC are not changed here. The rule is registered in all three tenant loaders and is ready for the exporter rollout.

## Expression semantics

The left-hand creation timestamp is required, so zero PVRs produce no alert. A scrape gap removes the timestamp series before the alert can become pending, so absence of observation is not treated as starvation. The rule subtracts only PVRs with a non-empty `phase` label; an omitted phase (the normal `omitempty` representation) and an explicit `phase=""` remain candidates.

This is deliberately restore-level rather than node-level: an unadmitted PVR may have no `status.node`. It does not cover node saturation, InProgress data-path stalls, or content validity.

## Verification

- Whole rule file syntax: pinned Prometheus 3.14.0 `promtool check rules` passed after stripping only the Mimir-specific top-level `namespace` wrapper, which upstream promtool does not parse.
- Dedicated promtool tests: passed.
- Tests cover zero PVRs, absent phase, explicit empty phase, non-empty terminal phase, and scrape-gap absence.
- Mimir rule load-path registration is present for Ottawa, Robbinsdale, and St Petersburg.