### PR TITLE
feat(monitoring): expose Velero restore creation timestamps

### DIFF
--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -453,6 +453,18 @@ kube-state-metrics:
                   info:
                     labelsFromPath:
                       phase: [ status, phase ]
+              # An unadmitted PVR can have a snapshot reference but no phase
+              # or status.node. Keep its creation time observable so the
+              # restore-level starvation alert can detect presence without
+              # admission. The optional node label above is omitted by
+              # kube-state-metrics when status.node is absent; it does not
+              # suppress this metadata-backed series.
+              - name: "podvolumerestore_created_timestamp"
+                help: "Unix creation timestamp of a Velero PodVolumeRestore custom resource."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ metadata, creationTimestamp ]
               - name: "podvolumerestore_bytes_done"
                 help: "Bytes reported as restored by a Velero PodVolumeRestore."
                 each:


### PR DESCRIPTION
## Summary

- expose velero_cr_podvolumerestore_created_timestamp from PodVolumeRestore metadata.creationTimestamp
- retain the existing PVR identity labels; node remains optional because unadmitted PVRs may have no status.node
- support a restore-level alert for old PVRs that have no non-empty-phase info series

## Validation

- tools/check.sh talos-ottawa
- tools/check-mimir-rules.sh
- kube-state-metrics v2.20.0 source confirms missing labels are omitted while the metadata-backed Gauge remains emitted
- live Mimir series verification will follow Flux rollout; no live mutation or restore was performed

The exact configured identity labels are namespace, pod_volume_restore, restore, restore_uid, source_namespace, and volume, plus node when status.node exists. The deployed series also carries cluster and kube-state-metrics custom-resource GVK labels.