### PR TITLE
fix(monitoring): keep Velero coverage baseline through warnings

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -40,6 +40,22 @@ tests:
       - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="home-backup-current",pod_volume_backup="home-current-pvb",node="rei",phase="Prepared"}'
         values: "1+0x20"
 
+      # A warning-bearing Completed run is still a usable volume-count
+      # baseline. The warning is a separate integrity signal; it must not make
+      # this per-schedule regression comparison silently disappear.
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-previous",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-current",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_warnings{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-previous"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-stpetersburg",namespace="velero-system",backup="home-assistant-backup-previous",pod_volume_backup="home-assistant-previous-pvb",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+
     alert_rule_test:
       - eval_time: 15m
         alertname: VeleroScheduleVolumeCoverageRegressed
@@ -50,3 +66,47 @@ tests:
               schedule: bhaiya-backup
               backup: bhaiya-backup-current
               severity: critical
+            exp_annotations:
+              summary: Velero schedule bhaiya-backup volume coverage regressed
+              description: >-
+                The newest Backup bhaiya-backup-current for schedule
+                bhaiya-backup has fewer PodVolumeBackups than its previous
+                Completed baseline. Any lower PVB count is material because
+                each PVB represents one selected volume. This remains a
+                coverage regression even when Kubernetes item counts or the
+                parent Backup phase look normal. A warning-bearing Completed
+                Backup can still supply this count baseline; investigate its
+                warning separately. If no previous Completed baseline exists,
+                this alert is intentionally silent: that means no comparable
+                baseline, not proof of zero-volume health. Schedules that
+                never produce a successful nonzero-volume baseline require the
+                separate never/zero-volume coverage signal. Inspect the
+                current and previous Backup PVB populations; stalled-path and
+                node-saturation alerts are separate, and this alert is not
+                restore proof. It clears only when the newest run reaches the
+                prior baseline count.
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: velero-system
+              schedule: home-assistant-backup
+              backup: home-assistant-backup-current
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule home-assistant-backup volume coverage regressed
+              description: >-
+                The newest Backup home-assistant-backup-current for schedule
+                home-assistant-backup has fewer PodVolumeBackups than its
+                previous Completed baseline. Any lower PVB count is material
+                because each PVB represents one selected volume. This remains
+                a coverage regression even when Kubernetes item counts or the
+                parent Backup phase look normal. A warning-bearing Completed
+                Backup can still supply this count baseline; investigate its
+                warning separately. If no previous Completed baseline exists,
+                this alert is intentionally silent: that means no comparable
+                baseline, not proof of zero-volume health. Schedules that
+                never produce a successful nonzero-volume baseline require the
+                separate never/zero-volume coverage signal. Inspect the
+                current and previous Backup PVB populations; stalled-path and
+                node-saturation alerts are separate, and this alert is not
+                restore proof. It clears only when the newest run reaches the
+                prior baseline count.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -255,9 +255,12 @@ groups:
       # Count coverage, not Kubernetes item coverage. A current Backup with
       # one PVB can otherwise look healthy beside a prior run with 37 PVBs.
       # The current run is the newest Backup for the schedule, while the
-      # baseline is the newest older successful Backup. The alert deliberately
-      # observes the produced-PVB count while the Backup is queued/running;
-      # phase and item counters are not allowed to hide a volume gap.
+      # baseline is the newest older Completed Backup. For this independent
+      # volume-count comparison, a Completed run with warnings is still a
+      # useful observed baseline; VeleroScheduleLatestBackupHasWarnings owns
+      # the separate quality signal. The alert deliberately observes the
+      # produced-PVB count while the Backup is queued/running; phase and item
+      # counters are not allowed to hide a volume gap.
       - record: velero_schedule_latest_backup_created_timestamp
         expr: |
           max by (cluster, namespace, schedule, backup) (
@@ -272,7 +275,10 @@ groups:
 
       # kube-state-metrics emits these status counters only when they are
       # non-zero. Absence therefore means zero; using `metric == 0` here would
-      # make every otherwise-clean Backup disappear from the baseline.
+      # make a Completed Backup disappear from the baseline. "Successful" in
+      # this recording-rule name means parent phase=Completed for the count
+      # baseline. Warnings remain independently actionable and must not erase a
+      # known prior PVB count.
       - record: velero_schedule_successful_backup_created_timestamp
         expr: |
           velero_cr_backup_created_timestamp{
@@ -287,22 +293,6 @@ groups:
                 schedule!="",
                 phase="Completed"
               }
-            )
-            unless on (cluster, namespace, schedule, backup)
-            (
-              max by (cluster, namespace, schedule, backup) (
-                velero_cr_backup_warnings{
-                  namespace="velero-system",
-                  schedule!=""
-                } > 0
-              )
-              or
-              max by (cluster, namespace, schedule, backup) (
-                velero_cr_backup_errors{
-                  namespace="velero-system",
-                  schedule!=""
-                } > 0
-              )
             )
           )
 
@@ -377,7 +367,7 @@ groups:
       - alert: VeleroScheduleVolumeCoverageRegressed
         expr: |
           velero_schedule_latest_pod_volume_backup_count
-          < on (cluster, namespace, schedule)
+          < on (cluster, namespace, schedule) group_right(backup)
           velero_schedule_previous_successful_pod_volume_backup_count
         for: 15m
         labels:
@@ -387,10 +377,16 @@ groups:
           description: >-
             The newest Backup {{ $labels.backup }} for schedule
             {{ $labels.schedule }} has fewer PodVolumeBackups than its previous
-            successful Backup. Any lower PVB count is material because each
+            Completed baseline. Any lower PVB count is material because each
             PVB represents one selected volume. This remains a coverage
             regression even when Kubernetes item counts or the parent Backup
-            phase look normal. Inspect the current and previous Backup PVB
-            populations; stalled-path and node-saturation alerts are separate,
-            and this alert is not restore proof. It clears only when the newest
-            run reaches the prior successful volume count.
+            phase look normal. A warning-bearing Completed Backup can still
+            supply this count baseline; investigate its warning separately.
+            If no previous Completed baseline exists, this alert is
+            intentionally silent: that means no comparable baseline, not
+            proof of zero-volume health. Schedules that never produce a
+            successful nonzero-volume baseline require the separate
+            never/zero-volume coverage signal. Inspect the current and
+            previous Backup PVB populations; stalled-path and node-saturation
+            alerts are separate, and this alert is not restore proof. It
+            clears only when the newest run reaches the prior baseline count.


### PR DESCRIPTION
## Summary

- keep a `Completed` Backup as the per-schedule PVB-count baseline even when a separate warning metric is present;
- keep warning/quality detection in `VeleroScheduleLatestBackupHasWarnings` instead of erasing the volume baseline;
- preserve the current Backup label on `VeleroScheduleVolumeCoverageRegressed` alerts;
- document that no prior Completed baseline means “no comparison,” not healthy zero-volume coverage;
- add a St Petersburg-shaped regression fixture: prior warning-bearing Completed run with one PVB, current run with zero.

This addresses the silent baseline gap reported for `home-assistant-backup` while leaving never/zero-volume detection to the separate alerting work.

## Verification

- pinned Prometheus 3.14.0 `promtool` rule checks and focused tests pass;
- `tools/check.sh talos-ottawa` passes;
- no live cluster or Garage changes.
