### PR TITLE
feat(monitoring): alert on expected Velero volume gaps

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -183,6 +183,35 @@ tests:
         alertname: VeleroScheduleExpectedVolumeDataMissing
         exp_alerts: []
 
+  # A failed newest attempt is owned by the latest-backup failure alert. Do
+  # not fall back to an older empty Completed run and falsely page a schedule
+  # whose failed attempt selected real positive-volume PVBs.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-failed",phase="Enabled",paused="false",volume_data_required="true"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-failed",backup="expected-failed-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-failed",backup="expected-failed-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-failed",backup="expected-failed-previous",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-failed",backup="expected-failed-current",phase="PartiallyFailed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-failed-current",pod_volume_backup="expected-failed-pvb",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="expected-failed-current",pod_volume_backup="expected-failed-pvb",node="asuka"}'
+        values: "1234+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="expected-failed-current",pod_volume_backup="expected-failed-pvb",node="asuka"}'
+        values: "1234+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: VeleroScheduleExpectedVolumeDataMissing
+        exp_alerts: []
+
   # When a prior Completed run has selected a volume and the current count
   # drops, the relative rule owns the regression. The absolute rule must stay
   # quiet so one schedule does not produce two coverage pages.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -110,3 +110,125 @@ tests:
                 node-saturation alerts are separate, and this alert is not
                 restore proof. It clears only when the newest run reaches the
                 prior baseline count.
+
+  # A marked Schedule with completed zero-volume history must alert. The
+  # unmarked Schedule is deliberately identical otherwise and remains out of
+  # scope; expectation is metadata, never an inference from history.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-empty",phase="Enabled",paused="false",volume_data_required="true"}'
+        values: "1+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="unmarked-empty",phase="Enabled",paused="false"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-empty",backup="expected-empty-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-empty",backup="expected-empty-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-empty",backup="expected-empty-previous",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-empty",backup="expected-empty-current",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="unmarked-empty",backup="unmarked-empty-1"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="unmarked-empty",backup="unmarked-empty-1",phase="Completed"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: VeleroScheduleExpectedVolumeDataMissing
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: VeleroScheduleExpectedVolumeDataMissing
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: expected-empty
+              backup: expected-empty-current
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule expected-empty expected volume data but has none
+              description: >-
+                Schedule expected-empty is explicitly marked
+                keiretsu.top/volume-data-required=true, but its latest
+                Completed Backup expected-empty-current has no Completed
+                PodVolumeBackup with bytesDone equal to totalBytes and greater
+                than zero. This absolute signal catches schedules whose first
+                and every subsequent run was metadata-only, where the
+                relative rule has no volume-bearing baseline to compare. If
+                the shared relative coverage condition is active, that alert
+                owns the regression and this alert is suppressed to prevent
+                duplicate paging. Inspect the Schedule's volume-selection
+                contract and the Backup's PVB children; phase and object
+                replay do not establish volume data. Schedules without the
+                explicit marker are intentionally out of scope.
+
+  # A Completed PVB is evidence only when its progress is byte-positive and
+  # complete. A real positive PVB clears the absolute expectation alert.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-covered",phase="Enabled",paused="false",volume_data_required="true"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-covered",backup="expected-covered-1"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-covered",backup="expected-covered-1",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-covered-1",pod_volume_backup="expected-covered-pvb",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="expected-covered-1",pod_volume_backup="expected-covered-pvb",node="asuka"}'
+        values: "8192+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="expected-covered-1",pod_volume_backup="expected-covered-pvb",node="asuka"}'
+        values: "8192+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleExpectedVolumeDataMissing
+        exp_alerts: []
+
+  # When a prior Completed run has selected a volume and the current count
+  # drops, the relative rule owns the regression. The absolute rule must stay
+  # quiet so one schedule does not produce two coverage pages.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",phase="Enabled",paused="false",volume_data_required="true"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-previous",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-current",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-regressed-previous",pod_volume_backup="expected-regressed-pvb",node="asuka",phase="Prepared"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: expected-regressed
+              backup: expected-regressed-current
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule expected-regressed volume coverage regressed
+              description: >-
+                The newest Backup expected-regressed-current for schedule
+                expected-regressed has fewer PodVolumeBackups than its previous
+                Completed baseline. Any lower PVB count is material because
+                each PVB represents one selected volume. This remains a
+                coverage regression even when Kubernetes item counts or the
+                parent Backup phase look normal. A warning-bearing Completed
+                Backup can still supply this count baseline; investigate its
+                warning separately. If no previous Completed baseline exists,
+                this alert is intentionally silent: that means no comparable
+                baseline, not proof of zero-volume health. Schedules that
+                never produce a successful nonzero-volume baseline require the
+                separate never/zero-volume coverage signal. Inspect the
+                current and previous Backup PVB populations; stalled-path and
+                node-saturation alerts are separate, and this alert is not
+                restore proof. It clears only when the newest run reaches the
+                prior baseline count.
+      - eval_time: 15m
+        alertname: VeleroScheduleExpectedVolumeDataMissing
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -12,6 +12,12 @@
 # - VeleroScheduleLatestBackupMissingVolumes: Completed latest Backup with no
 #   completed, byte-complete PodVolumeBackup (metadata-only / unmounted PVC /
 #   opt-in miss / a child that never finished).
+# - VeleroScheduleExpectedVolumeDataMissing: an explicitly labelled Schedule's
+#   latest successful Backup has no completed, byte-positive PVB. This absolute
+#   assertion covers a schedule whose every historical run was empty; it does
+#   not infer the expectation from that history. Schedules that legitimately
+#   have no Velero-capturable volume data, such as StP homeassistant-config,
+#   must not carry the expectation label.
 # Both join on the newest Backup per schedule so they clear on recovery.
 #
 # Keep this namespace separate from rules/velero.yaml. Both files are synced by
@@ -296,6 +302,15 @@ groups:
             )
           )
 
+      - record: velero_schedule_latest_successful_backup_created_timestamp
+        expr: |
+          max by (cluster, namespace, schedule, backup) (
+            topk by (cluster, namespace, schedule) (
+              1,
+              velero_schedule_successful_backup_created_timestamp
+            )
+          )
+
       - record: velero_schedule_previous_successful_backup_created_timestamp
         expr: |
           max by (cluster, namespace, schedule, backup) (
@@ -364,11 +379,19 @@ groups:
             velero_schedule_previous_successful_backup_created_timestamp * 0
           )
 
-      - alert: VeleroScheduleVolumeCoverageRegressed
+      # Share the exact relative condition with the absolute expectation rule
+      # below. When a prior Completed run supplies a real count baseline and
+      # the current count drops, this signal owns the regression; the absolute
+      # rule is suppressed so one schedule does not double-page.
+      - record: velero_schedule_volume_coverage_regressed
         expr: |
           velero_schedule_latest_pod_volume_backup_count
           < on (cluster, namespace, schedule) group_right(backup)
           velero_schedule_previous_successful_pod_volume_backup_count
+
+      - alert: VeleroScheduleVolumeCoverageRegressed
+        expr: |
+          velero_schedule_volume_coverage_regressed
         for: 15m
         labels:
           severity: critical
@@ -390,3 +413,74 @@ groups:
             previous Backup PVB populations; stalled-path and node-saturation
             alerts are separate, and this alert is not restore proof. It
             clears only when the newest run reaches the prior baseline count.
+
+      # This is the complementary absolute assertion. It uses the same
+      # Completed-only baseline series as the relative rule (km#2819), but
+      # requires explicit Schedule intent and byte-positive PVB evidence. A
+      # schedule whose every Completed run has zero PVBs has no volume-bearing
+      # baseline for the relative comparison, so this rule catches it. When
+      # the shared relative condition is active, that rule owns the alert and
+      # this one is suppressed to avoid double-firing.
+      - alert: VeleroScheduleExpectedVolumeDataMissing
+        expr: |
+          (
+            (
+              velero_schedule_latest_successful_backup_created_timestamp
+              * on (cluster, namespace, schedule) group_left
+              max by (cluster, namespace, schedule) (
+                velero_cr_schedule_info{
+                  namespace="velero-system",
+                  phase="Enabled",
+                  paused!="true",
+                  volume_data_required="true"
+                }
+              )
+            )
+            unless on (cluster, namespace, schedule)
+            velero_schedule_volume_coverage_regressed
+          )
+          unless on (cluster, namespace, backup)
+          (
+            count by (cluster, namespace, backup) (
+              (
+                velero_cr_podvolumebackup_info{
+                  namespace="velero-system",
+                  phase="Completed"
+                }
+                and on (cluster, namespace, pod_volume_backup, backup, node)
+                (
+                  velero_cr_podvolumebackup_bytes_done{
+                    namespace="velero-system"
+                  }
+                  == on (cluster, namespace, pod_volume_backup, backup, node)
+                  velero_cr_podvolumebackup_bytes_total{
+                    namespace="velero-system"
+                  }
+                )
+                and on (cluster, namespace, pod_volume_backup, backup, node)
+                (
+                  velero_cr_podvolumebackup_bytes_done{
+                    namespace="velero-system"
+                  } > 0
+                )
+              )
+            ) > 0
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} expected volume data but has none
+          description: >-
+            Schedule {{ $labels.schedule }} is explicitly marked
+            keiretsu.top/volume-data-required=true, but its latest Completed
+            Backup {{ $labels.backup }} has no Completed PodVolumeBackup with
+            bytesDone equal to totalBytes and greater than zero. This absolute
+            signal catches schedules whose first and every subsequent run was
+            metadata-only, where the relative rule has no volume-bearing
+            baseline to compare. If the shared relative coverage condition is
+            active, that alert owns the regression and this alert is
+            suppressed to prevent duplicate paging. Inspect the Schedule's
+            volume-selection contract and the Backup's PVB children; phase
+            and object replay do not establish volume data. Schedules without
+            the explicit marker are intentionally out of scope.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -302,15 +302,6 @@ groups:
             )
           )
 
-      - record: velero_schedule_latest_successful_backup_created_timestamp
-        expr: |
-          max by (cluster, namespace, schedule, backup) (
-            topk by (cluster, namespace, schedule) (
-              1,
-              velero_schedule_successful_backup_created_timestamp
-            )
-          )
-
       - record: velero_schedule_previous_successful_backup_created_timestamp
         expr: |
           max by (cluster, namespace, schedule, backup) (
@@ -414,19 +405,31 @@ groups:
             alerts are separate, and this alert is not restore proof. It
             clears only when the newest run reaches the prior baseline count.
 
-      # This is the complementary absolute assertion. It uses the same
-      # Completed-only baseline series as the relative rule (km#2819), but
-      # requires explicit Schedule intent and byte-positive PVB evidence. A
-      # schedule whose every Completed run has zero PVBs has no volume-bearing
-      # baseline for the relative comparison, so this rule catches it. When
-      # the shared relative condition is active, that rule owns the alert and
-      # this one is suppressed to avoid double-firing.
+      # This is the complementary absolute assertion. The latest attempt must
+      # itself be Completed. A failed latest attempt is owned by
+      # VeleroScheduleLastBackupFailed; falling back to an older
+      # Completed Backup here would double-page and could call a current run
+      # with real PVBs empty (for example, a PartiallyFailed run with 25
+      # selected volumes). This still catches a schedule whose every
+      # Completed run has zero PVBs, because the latest Completed attempt is
+      # the one evaluated. When the shared relative condition is active, that
+      # rule owns the regression and this one is suppressed to avoid
+      # double-firing.
       - alert: VeleroScheduleExpectedVolumeDataMissing
         expr: |
           (
             (
-              velero_schedule_latest_successful_backup_created_timestamp
-              * on (cluster, namespace, schedule) group_left
+              velero_schedule_latest_backup_created_timestamp
+              and on (cluster, namespace, schedule, backup)
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_info{
+                  namespace="velero-system",
+                  schedule!="",
+                  phase="Completed"
+                }
+              )
+            )
+            * on (cluster, namespace, schedule) group_left
               max by (cluster, namespace, schedule) (
                 velero_cr_schedule_info{
                   namespace="velero-system",
@@ -435,7 +438,6 @@ groups:
                   volume_data_required="true"
                 }
               )
-            )
             unless on (cluster, namespace, schedule)
             velero_schedule_volume_coverage_regressed
           )

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -58,6 +58,7 @@ kube-state-metrics:
           - velero.io
         resources:
           - backups
+          - schedules
           - podvolumebackups
           - podvolumerestores
         verbs: [ "list", "watch" ]
@@ -349,6 +350,10 @@ kube-state-metrics:
             labelsFromPath:
               namespace: [ metadata, namespace ]
               schedule: [ metadata, name ]
+              # This is an explicit operator assertion, not an inference from
+              # a schedule's history. Missing means the schedule is outside
+              # the absolute volume-data expectation alert.
+              volume_data_required: [ metadata, labels, keiretsu.top/volume-data-required ]
             metrics:
               - name: "schedule_info"
                 help: "Phase and pause state of a Velero Schedule custom resource."

--- a/kubernetes/apps/ottawa/velero/schedules/bhaiya-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/bhaiya-backup.yaml
@@ -4,6 +4,8 @@ kind: Schedule
 metadata:
   name: bhaiya-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 8 * * *"
   template:

--- a/kubernetes/apps/ottawa/velero/schedules/cliproxy-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/cliproxy-backup.yaml
@@ -4,6 +4,8 @@ kind: Schedule
 metadata:
   name: cliproxy-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 9 * * *"
   template:

--- a/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/forgejo-backup.yaml
@@ -10,6 +10,8 @@ kind: Schedule
 metadata:
   name: forgejo-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 10 * * *"
   template:

--- a/kubernetes/apps/ottawa/velero/schedules/hermes-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/hermes-backup.yaml
@@ -4,6 +4,8 @@ kind: Schedule
 metadata:
   name: hermes-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 7 * * *"
   template:

--- a/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml
@@ -4,6 +4,8 @@ kind: Schedule
 metadata:
   name: home-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 9 * * *"
   template:

--- a/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
@@ -13,6 +13,8 @@ kind: Schedule
 metadata:
   name: media-config-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 6 * * *"
   template:

--- a/kubernetes/apps/robbinsdale/velero/schedules/home-backup.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/home-backup.yaml
@@ -4,6 +4,8 @@ kind: Schedule
 metadata:
   name: home-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 9 * * *"
   template:

--- a/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
@@ -13,6 +13,8 @@ kind: Schedule
 metadata:
   name: media-config-backup
   namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
 spec:
   schedule: "0 6 * * *"
   template:


### PR DESCRIPTION
## Summary

Closes the baseline-free zero-volume gap in `VeleroScheduleVolumeCoverageRegressed`.

- Adds the explicit Schedule contract label `keiretsu.top/volume-data-required: "true"` and exports it as `volume_data_required` on `velero_cr_schedule_info`.
- Grants kube-state-metrics read-only access to Velero `schedules`; without that RBAC, the Schedule family is absent and the Schedule-level rule is inert.
- Adds `VeleroScheduleExpectedVolumeDataMissing`, which checks the latest Backup only when that Backup is `Completed`, for an enabled, unpaused, explicitly marked Schedule, and requires at least one `Completed` PVB with `bytesDone == totalBytes > 0`.
- Preserves km#2819’s shared Completed-only baseline semantics, including warning-bearing Completed Backups.
- `VeleroScheduleVolumeCoverageRegressed` owns a genuine count drop when a prior Completed baseline exists. `VeleroScheduleExpectedVolumeDataMissing` owns an explicitly expected schedule whose latest Completed attempt has no positive completed volume data. The absolute rule suppresses itself while the relative regression recording is active, so one schedule cannot double-page.
- A failed latest Backup stays with `VeleroScheduleLastBackupFailed`; the absolute rule does not fall back to an older empty Completed run.
- Adds static expectation labels in Ottawa and Robbinsdale. St. Petersburg `home-assistant-backup` is intentionally unmarked because its local-path/hostPath volume cannot be captured by Velero.

Expectation is explicit metadata, never inferred from history. Dynamically created `bhaiya-*` workspace Schedules must receive the same label from corp/bhaiya; this manifests PR does not change that control-plane repo. Until that companion change lands, the new alert intentionally does not claim coverage for those dynamic Schedules.

## Live evidence

The current Ottawa data has exactly the intended raw zero-volume cases: `bhaiya-tailscale-engineering`, `bhaiya-test`, and `hermes-backup` each have latest PVB count `0`; `media-config-backup` has `25`. St. Petersburg `home-assistant-backup` has latest count `0` but a prior successful count `1`, and remains intentionally outside the absolute rule because its volume is structurally uncapturable.

A read-only shadow evaluation against current Ottawa data, substituting the intended expectation labels because this PR is not deployed yet, returned exactly `bhaiya-tailscale-engineering`, `bhaiya-test`, and `hermes-backup`. It returned no `media-config-backup`: its newest Backup is `PartiallyFailed` with 25 selected PVBs, so the absolute rule correctly leaves it to the failure alert instead of falling back to an older empty Completed run.

The Schedule expectation metric is not live before this PR rolls out (`velero_cr_schedule_info` currently has no series and the live Schedule objects have no marker yet). Therefore the final alert evaluation must be checked after merge and KSM/Flux rollout; this PR does not claim a pre-rollout alert result. No reconcile or restart was forced.

## Validation

- Pinned Prometheus 3.14.0 whole-repository PromQL parse: 29 rule files — pass.
- Pinned `promtool test rules` for the updated integrity tests — pass.
- `tools/check-mimir-rules.sh` — pass.
- `tools/check.sh talos-ottawa` — pass.
- `tools/check.sh robbinsdale` — pass.
- `tools/check.sh stpetersburg` — pass.

Do not merge until the post-rollout Mimir query confirms `velero_cr_schedule_info{volume_data_required="true"}` for the intended schedules and the alert returns exactly the expected set.