### PR TITLE
scratch: verify Mimir PromQL gate catches km2809

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -267,7 +267,7 @@ groups:
                 namespace="velero-system",
                 schedule!=""
               }
-            )
+            }
           )
 
       # kube-state-metrics emits these status counters only when they are

--- a/tools/check-mimir-promql.sh
+++ b/tools/check-mimir-promql.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Validate every Mimir rule input with one pinned Prometheus parser.
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+PROM_VERSION=3.14.0
+PROM_ARCHIVE="prometheus-${PROM_VERSION}.linux-amd64.tar.gz"
+PROM_SHA256=f665c6da19eb7ba399c915d30c7d9793c9b417bf8a749b504bc470678631478d
+CACHE_ROOT="${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}/cos-promtool/${PROM_VERSION}"
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "error: sha256sum or shasum is required to verify promtool" >&2
+    return 1
+  fi
+}
+
+promtool_path() {
+  if [ -n "${PROMTOOL_BIN:-}" ]; then
+    [ -x "$PROMTOOL_BIN" ] || {
+      echo "error: PROMTOOL_BIN is not executable: $PROMTOOL_BIN" >&2
+      return 1
+    }
+    "$PROMTOOL_BIN" --version 2>&1 | grep -F "version ${PROM_VERSION}" >/dev/null || {
+      echo "error: PROMTOOL_BIN must be Prometheus ${PROM_VERSION}" >&2
+      return 1
+    }
+    printf '%s\n' "$PROMTOOL_BIN"
+    return 0
+  fi
+
+  case "$(uname -s):$(uname -m)" in
+    Linux:x86_64|Linux:amd64) ;;
+    *)
+      echo "error: pinned promtool download supports Linux x86_64; set PROMTOOL_BIN to Prometheus ${PROM_VERSION} on this platform" >&2
+      return 1
+      ;;
+  esac
+
+  local archive="$CACHE_ROOT/$PROM_ARCHIVE"
+  local extracted="$CACHE_ROOT/prometheus-${PROM_VERSION}.linux-amd64/promtool"
+  mkdir -p "$CACHE_ROOT"
+  if [ ! -f "$archive" ] || [ "$(sha256 "$archive")" != "$PROM_SHA256" ]; then
+    local tmp="$archive.part.$$"
+    curl --fail --silent --show-error --location --retry 3 \
+      "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/${PROM_ARCHIVE}" \
+      -o "$tmp"
+    [ "$(sha256 "$tmp")" = "$PROM_SHA256" ] || {
+      echo "error: checksum mismatch for $PROM_ARCHIVE" >&2
+      rm -f "$tmp"
+      return 1
+    }
+    mv "$tmp" "$archive"
+  fi
+  if [ ! -x "$extracted" ]; then
+    tar -xzf "$archive" -C "$CACHE_ROOT"
+  fi
+  [ -x "$extracted" ] || {
+    echo "error: promtool was not found after extracting $archive" >&2
+    return 1
+  }
+  printf '%s\n' "$extracted"
+}
+
+PROMTOOL=$(promtool_path)
+RULE_DIR="$ROOT/kubernetes/apps/base/mimir/mimir-ottawa/rules"
+status=0
+
+rule_name() {
+  local file="$1" line="$2"
+  awk -v stop="$line" '
+    NR > stop { exit }
+    /^[[:space:]]*-[[:space:]]+(alert|record):[[:space:]]*/ {
+      name=$0
+      sub(/^[^:]*:[[:space:]]*/, "", name)
+      sub(/[[:space:]]*#.*/, "", name)
+    }
+    END { print (name == "" ? "(document-level)" : name) }
+  ' "$file"
+}
+
+while IFS= read -r file; do
+  # Mimir's native namespace wrapper is not part of Prometheus rulefmt. The
+  # temporary copy keeps production files authoritative without weakening the
+  # check applied to their groups and expressions.
+  temp=$(mktemp)
+  sed '/^namespace:[[:space:]][^[:space:]]*[[:space:]]*$/d' "$file" >"$temp"
+  output=""
+  if ! output=$("$PROMTOOL" check rules "$temp" 2>&1); then
+    relative=${file#"$ROOT/"}
+    line=$(printf '%s\n' "$output" | sed -n 's/.*:\([0-9][0-9]*\):.*/\1/p' | head -1)
+    if [ -n "$line" ]; then
+      context=$(rule_name "$file" "$line")
+    else
+      context="(document-level; no rule line reported)"
+    fi
+    echo "Mimir rule parse failed" >&2
+    echo "file: $relative" >&2
+    echo "rule: $context" >&2
+    echo "$output" >&2
+    status=1
+  fi
+  rm -f "$temp"
+done < <(find "$RULE_DIR" -maxdepth 1 -type f -name '*.yaml' -print | sort)
+
+if [ "$status" -ne 0 ]; then
+  exit 1
+fi
+echo "✓ Mimir PromQL valid: $(find "$RULE_DIR" -maxdepth 1 -type f -name '*.yaml' | wc -l | tr -d ' ') rule files (Prometheus ${PROM_VERSION})"

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -174,6 +174,7 @@ run_capped() {
   exit 1
 }
 
+run_capped "mimir-promql" tools/check-mimir-promql.sh
 run_capped "version-sync" tools/check-versions.sh
 run_capped "notification-scope" tools/check-notification-scope.sh
 run_capped "cliproxy-pi-bridge" tools/check-cliproxy-pi-bridge.sh


### PR DESCRIPTION
Scratch verification only. Reintroduces the exact km#2809 topk() closing-brace defect in velero_schedule_latest_backup_created_timestamp to confirm the CI gate fails. Do not merge.