### PR TITLE
fix(mimir): name invalid rule in parser diagnostics

### DIFF
--- a/tools/check-mimir-promql.sh
+++ b/tools/check-mimir-promql.sh
@@ -92,9 +92,15 @@ while IFS= read -r file; do
   output=""
   if ! output=$("$PROMTOOL" check rules "$temp" 2>&1); then
     relative=${file#"$ROOT/"}
-    line=$(printf '%s\n' "$output" | sed -n 's/.*:\([0-9][0-9]*\):.*/\1/p' | head -1)
+    # Prefer promtool's source-location line. A later expression location also
+    # contains numbers, so a greedy match would select that inner location and
+    # lose the rule's YAML line.
+    line=$(printf '%s\n' "$output" | sed -n 's#^[^:]*:[[:space:]]*\([0-9][0-9]*\):[0-9][0-9]*:.*#\1#p' | head -1)
     if [ -n "$line" ]; then
-      context=$(rule_name "$file" "$line")
+      # The parser line refers to the temporary copy, which intentionally has
+      # the Mimir namespace wrapper removed. Use that same copy for context so
+      # the reported rule line stays aligned.
+      context=$(rule_name "$temp" "$line")
     else
       context="(document-level; no rule line reported)"
     fi


### PR DESCRIPTION
The PromQL gate already rejects malformed expressions, but its explicit rule context could report document-level because the Mimir namespace wrapper is removed in a temporary copy and promtool emits both YAML and inner expression locations. Use the temporary-file YAML location and retain the embedded parser diagnostic.\n\nVerified with the exact km#2809 topk() brace defect: the gate exits 1 and reports velero-integrity.yaml, velero_schedule_latest_backup_created_timestamp, and the unexpected-character parse error. Normal all-29-file validation passes.