### PR TITLE
fix(garage): adopt recovery-fix operator in Robbinsdale

### DIFF
--- a/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install.yaml
+++ b/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: garage-operator-system-install
-  path: ./kubernetes/apps/base/garage-operator-system/garage-operator-system-install
+  path: ./kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/garage-operator-system/garage-operator-system-install
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: garage-operator
+      namespace: garage-operator-system
+    patch: |-
+      - op: add
+        path: /spec/values/image
+        value:
+          digest: sha256:4ed5db5a815b987af4b142e91453dcce50561687e2bd1c1a9ea6ae5205bc82d0


### PR DESCRIPTION
## Summary\n\n- Change only the Robbinsdale Flux wrapper to use a Robbinsdale-specific Kustomize overlay.\n- Keep the existing chart at 0.7.8 and pin the operator image by immutable digest:\n  ghcr.io/rajsinghtech/garage-operator@sha256:4ed5db5a815b987af4b142e91453dcce50561687e2bd1c1a9ea6ae5205bc82d0\n- Ottawa and St Petersburg continue to reconcile the shared base and remain on v0.7.8.\n\n## What the operator fix changes\n\nThe image contains merged PR #385 (commit a8cd0f8). Its layout-guard retry behavior keeps RPC-only connect-nodes requests eligible during safe layout and workload waits, and retains failed requests for retry with backoff instead of silently dropping them behind the layout guard.\n\nThe connect-nodes lifecycle is also observable: the operator logs when it observes the annotation, acts on it, reports an error when it cannot honor it, and processes/removes it after success.\n\n## What this change does not do\n\nThis PR only adopts the already-built operator image in Robbinsdale through Flux. It does not apply the connect-nodes annotation, mutate Garage layout, skip dead nodes, allow missing data, drop or retire any node/drive, or otherwise perform a Garage recovery action. It does not change Ottawa or St Petersburg.\n\n## Motivating failure\n\nThe exact live symptom was: the garage.rajsingh.info/connect-nodes annotation was applied, nothing reconnected, the annotation remained unconsumed, and the operator emitted no log line about it while separately discovering the same node every 60 seconds. The deployed image is intended to make that request actionable and make observed, acting, failed, and processed states explicit.\n\n## Validation\n\n- /bin/kustomize build kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install\n- git diff --check\n\nAfter merge, verification will be performed in this order: Flux revision, HelmRelease values, Deployment image digest, the running Pod image ID, and operator logs. The connect-nodes annotation will remain untouched until separately authorized.