### PR TITLE
scratch: verify deployed Mimir gate again

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -276,7 +276,7 @@ groups:
                 namespace="velero-system",
                 schedule!=""
               }
-            )
+            }
           )
 
       # kube-state-metrics emits these status counters only when they are


### PR DESCRIPTION
Scratch verification only. Reintroduces the exact km#2809 topk() brace defect. Do not merge.