### PR TITLE
docs(monitoring): state Velero zero-volume alert boundary

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -160,7 +160,12 @@ tests:
                 duplicate paging. Inspect the Schedule's volume-selection
                 contract and the Backup's PVB children; phase and object
                 replay do not establish volume data. Schedules without the
-                explicit marker are intentionally out of scope.
+                explicit marker are intentionally out of scope. This is a
+                zero-volume guard only: it cannot detect under-selection when
+                a run has a plausible nonzero count (for example, one PVB
+                when two volumes were expected). The relative coverage alert
+                catches a lower count only when a comparable prior baseline
+                exists; this rule does not infer expected counts.
 
   # A Completed PVB is evidence only when its progress is byte-positive and
   # complete. A real positive PVB clears the absolute expectation alert.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -17,7 +17,11 @@
 #   assertion covers a schedule whose every historical run was empty; it does
 #   not infer the expectation from that history. Schedules that legitimately
 #   have no Velero-capturable volume data, such as StP homeassistant-config,
-#   must not carry the expectation label.
+#   must not carry the expectation label. This is a zero-volume guard, not an
+#   expected-count guard: it cannot detect under-selection that leaves a
+#   plausible nonzero count (for example, one PVB when two volumes were
+#   expected). The relative coverage rule detects a lower count only when a
+#   comparable prior baseline exists.
 # Both join on the newest Backup per schedule so they clear on recovery.
 #
 # Keep this namespace separate from rules/velero.yaml. Both files are synced by
@@ -485,4 +489,9 @@ groups:
             suppressed to prevent duplicate paging. Inspect the Schedule's
             volume-selection contract and the Backup's PVB children; phase
             and object replay do not establish volume data. Schedules without
-            the explicit marker are intentionally out of scope.
+            the explicit marker are intentionally out of scope. This is a
+            zero-volume guard only: it cannot detect under-selection when a
+            run has a plausible nonzero count (for example, one PVB when two
+            volumes were expected). The relative coverage alert catches a
+            lower count only when a comparable prior baseline exists; this
+            rule does not infer expected counts.


### PR DESCRIPTION
## Summary

Document the boundary of `VeleroScheduleExpectedVolumeDataMissing` introduced by #2820. This is a documentation-and-test-expectation clarification; it does not change alert selection.

The rule catches an explicitly marked Schedule whose latest Completed Backup has zero Completed, byte-positive PodVolumeBackups. It does not catch under-selection when a run has a plausible nonzero count, such as one PVB when two volumes were expected. The relative coverage rule catches a lower count only when a comparable prior baseline exists; no rule here infers an expected count from history.

## Live verification

Against current Mimir data, the Ottawa latest PVB counts are:

- `bhaiya-tailscale-engineering`: 0
- `bhaiya-test`: 0
- `hermes-backup`: 0
- `media-config-backup`: 25 (excluded)
- `bhaiya-kartik-codes` and `bhaiya-raj-codes`: 1 each (not selected; plausible nonzero under-selection is outside this rule)

St. Petersburg `home-assistant-backup` is 0 but has no expectation marker and remains intentionally excluded because its local-path volume is structurally uncapturable.

The live shadow of the exact rule, with an explicit expectation vector for the three intended Ottawa schedules, selected exactly those three and no others. The deployed rule currently returns no alert because `velero_cr_schedule_info` is absent: live KSM still lacks the Schedule RBAC rule and logs `schedules.velero.io is forbidden`. The live Schedule objects for the three dynamically-created `bhaiya-*` schedules are also currently unmarked. This PR does not force a KSM rollout or modify another repository; after normal rollout and the required Schedule labels, re-run the same query and verify the real alert.

## Checks

- `tools/check-mimir-promql.sh`
- `tools/check-mimir-rules.sh`
- `tools/check.sh talos-ottawa`
- Full Mimir rule test suite with pinned Prometheus 3.14.0

No restore or live write was performed.