### PR TITLE
feat(mimir): alert on recent platform Job failures

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -38,6 +38,7 @@ configMapGenerator:
       - rules/k8gb-dns.yaml
       - rules/media.yaml
       - rules/mimir-loader.yaml
+      - rules/job-failures.yaml
       - rules/mimir-queryable-window.yaml
       - rules/monitoring.yaml
       - rules/node-health.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -48,6 +48,7 @@ spec:
             - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
+            - /rules/job-failures.yaml
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
@@ -90,6 +91,7 @@ spec:
             - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
+            - /rules/job-failures.yaml
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml
@@ -128,6 +130,7 @@ spec:
             - /rules/k8gb-dns.yaml
             - /rules/media.yaml
             - /rules/mimir-loader.yaml
+            - /rules/job-failures.yaml
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
             - /rules/node-health.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/job-failures.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/job-failures.yaml
@@ -1,0 +1,44 @@
+# Kube-state-metrics retains failed Job objects after their failure. Bound this
+# generic safety net to recently completed failures so history does not become
+# a permanent alert. Component-specific rules can provide a faster or richer
+# signal where one exists; the generic rule makes otherwise unowned failures
+# visible within minutes.
+namespace: job-failures
+groups:
+  - name: kubernetes.jobs.rules
+    rules:
+      - alert: KubernetesJobFailedRecently
+        expr: |
+          max by (cluster, namespace, job_name) (
+            kube_job_complete{
+              namespace=~"mimir|velero-system|rook-ceph|firefly|tailscale-system|kube-system|ai|speedtest|media",
+              job_name!~"qbittorrent(-pvt)?-portforward-probe-.*",
+              condition="false"
+            } == 1
+          )
+          and on (cluster, namespace, job_name)
+          max by (cluster, namespace, job_name) (
+            kube_job_status_failed{
+              namespace=~"mimir|velero-system|rook-ceph|firefly|tailscale-system|kube-system|ai|speedtest|media",
+              job_name!~"qbittorrent(-pvt)?-portforward-probe-.*"
+            } > 0
+          )
+          and on (cluster, namespace, job_name)
+          max by (cluster, namespace, job_name) (
+            time() - kube_job_status_completion_time{
+              namespace=~"mimir|velero-system|rook-ceph|firefly|tailscale-system|kube-system|ai|speedtest|media",
+              job_name!~"qbittorrent(-pvt)?-portforward-probe-.*"
+            } < 900
+          )
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Kubernetes Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
+          description: >-
+            Job {{ $labels.namespace }}/{{ $labels.job_name }} reached a failed
+            terminal condition within the last 15 minutes. This generic safety
+            net covers platform namespaces and excludes the expected
+            qBittorrent probe failures, which have a dedicated alert. Inspect
+            the Job, its Pods, and logs; component-specific alerts may provide
+            more context.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/job_failures_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/job_failures_test.yaml
@@ -1,0 +1,73 @@
+rule_files:
+  - ../job-failures.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # A recent terminal failed Job fires after the five-minute pending period.
+  - interval: 1m
+    input_series:
+      - series: 'kube_job_complete{cluster="talos-ottawa",namespace="rook-ceph",job_name="failed-job",condition="false"}'
+        values: "1+0x20"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",namespace="rook-ceph",job_name="failed-job"}'
+        values: "1+0x20"
+      - series: 'kube_job_status_completion_time{cluster="talos-ottawa",namespace="rook-ceph",job_name="failed-job"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: KubernetesJobFailedRecently
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: KubernetesJobFailedRecently
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              cluster: talos-ottawa
+              namespace: rook-ceph
+              job_name: failed-job
+            exp_annotations:
+              summary: Kubernetes Job rook-ceph/failed-job failed
+              description: >-
+                Job rook-ceph/failed-job reached a failed terminal condition
+                within the last 15 minutes. This generic safety net covers
+                platform namespaces and excludes the expected qBittorrent probe
+                failures, which have a dedicated alert. Inspect the Job, its
+                Pods, and logs; component-specific alerts may provide more
+                context.
+
+  # Retained history is not an alert, and a successful terminal condition wins
+  # over a non-zero retry/failure counter from an ultimately successful Job.
+  - interval: 1m
+    input_series:
+      - series: 'kube_job_complete{cluster="talos-ottawa",namespace="rook-ceph",job_name="old-job",condition="false"}'
+        values: "1+0x40"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",namespace="rook-ceph",job_name="old-job"}'
+        values: "1+0x40"
+      - series: 'kube_job_status_completion_time{cluster="talos-ottawa",namespace="rook-ceph",job_name="old-job"}'
+        values: "0+0x40"
+      - series: 'kube_job_complete{cluster="talos-ottawa",namespace="rook-ceph",job_name="retry-success",condition="false"}'
+        values: "0+0x40"
+      - series: 'kube_job_complete{cluster="talos-ottawa",namespace="rook-ceph",job_name="retry-success",condition="true"}'
+        values: "1+0x40"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",namespace="rook-ceph",job_name="retry-success"}'
+        values: "1+0x40"
+      - series: 'kube_job_status_completion_time{cluster="talos-ottawa",namespace="rook-ceph",job_name="retry-success"}'
+        values: "0+0x40"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: KubernetesJobFailedRecently
+        exp_alerts: []
+
+  # The qBittorrent probe has an intentional component-specific failure path.
+  - interval: 1m
+    input_series:
+      - series: 'kube_job_complete{cluster="talos-ottawa",namespace="media",job_name="qbittorrent-portforward-probe-123",condition="false"}'
+        values: "1+0x20"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",namespace="media",job_name="qbittorrent-portforward-probe-123"}'
+        values: "1+0x20"
+      - series: 'kube_job_status_completion_time{cluster="talos-ottawa",namespace="media",job_name="qbittorrent-portforward-probe-123"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KubernetesJobFailedRecently
+        exp_alerts: []


### PR DESCRIPTION
## Summary

Add a generic Mimir safety net for failed Kubernetes Jobs in the platform namespaces where an unowned failed Job currently has no alert. It is registered in the shared Mimir ConfigMap and all three tenant loader containers.

The rule requires:

- `kube_job_complete{condition="false"}` so retry failures that ultimately succeed do not alert;
- `kube_job_status_failed > 0`; and
- `kube_job_status_completion_time` within 15 minutes, so retained historical Jobs do not latch forever.

It then holds for 5 minutes, giving detection within roughly 20 minutes while keeping the signal bounded. Expected qBittorrent port-forward probe failures remain excluded because that component has a dedicated rule.

## Evidence and ranking

Live Mimir exposes `kube_job_status_failed`, `kube_job_complete`, `kube_job_status_completion_time`, and CronJob schedule metrics. Existing coverage was limited to Mimir rule-loader failures and the qBittorrent probe. The live inventory showed an old failed `rook-ceph-osd-prepare-tank` Job in Robbinsdale with no generic coverage, while no recent failed Jobs were currently present.

Highest-cost uncovered failures are platform Job failures in `velero-system`, `rook-ceph`, `mimir`, and control-plane namespaces: they can silently stop backup, storage, rule delivery, or maintenance workflows until a human inspects Job state. CronJob missed-run detection remains a separate gap because it needs schedule-specific lateness semantics rather than a failed-Job predicate.

## Verification

- Focused promtool syntax/tests: pass.
- Tests cover recent failure, retained history, retry-then-success, and excluded qBittorrent failures.
- Structural Mimir gate: pass (30 files, 3 tenant loaders, 29 unique namespaces).
- Whole pinned PromQL gate: pass (30 files).
- `tools/check.sh talos-ottawa`: pass.
