### PR TITLE
feat(mimir): alert on Garage federation connectivity loss

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/garage.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/garage.yaml
@@ -105,3 +105,25 @@ groups:
             storage nodes.
         labels:
           severity: critical
+
+      # Federation reachability is a separate fact from partition quorum.
+      # Keep the raw Garage target labels: cluster identifies the tenant and
+      # pod/instance identifies the vantage point that cannot see all peers.
+      # Aggregating this away would hide asymmetric views such as Ottawa 17/18
+      # versus Robbinsdale 16/18 while another vantage point still has quorum.
+      - alert: GarageFederationPeerConnectivityDegraded
+        expr: cluster_connected_nodes{job="garage",namespace="garage",endpoint="admin"} < 18
+        for: 15m
+        annotations:
+          summary: >-
+            Garage federation connectivity degraded from {{ $labels.pod }}
+            ({{ $labels.cluster }})
+          description: >-
+            This Garage admin vantage point sees {{ $value }} of the expected
+            18 federation peers. The count is per scrape target, not a fleet
+            aggregate; other sites may see a different subset. Check
+            inter-site RPC transport (DNS, TCP 3901, Tailscale, routing, and
+            policy) before treating partition quorum as proof of federation
+            health.
+        labels:
+          severity: warning

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/garage_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/garage_test.yaml
@@ -78,4 +78,95 @@ tests:
         exp_alerts: []
       - eval_time: 10m
         alertname: GarageClusterPartitionsWithoutQuorum
+  - interval: 1m
+    input_series:
+      - series: 'cluster_connected_nodes{cluster="talos-ottawa",container="garage",endpoint="admin",instance="10.3.0.1:3903",job="garage",namespace="garage",pod="garage-storage-local-700-ottawa",service="garage"}'
+        values: "17+0x20"
+      - series: 'cluster_connected_nodes{cluster="talos-robbinsdale",container="garage",endpoint="admin",instance="10.1.0.1:3903",job="garage",namespace="garage",pod="garage-storage-local-700-robbinsdale",service="garage"}'
+        values: "16+0x20"
+      - series: 'cluster_connected_nodes{cluster="talos-stpetersburg",container="garage",endpoint="admin",instance="10.5.0.1:3903",job="garage",namespace="garage",pod="garage-storage-local-200-stpetersburg",service="garage"}'
+        values: "17+0x20"
+      - series: 'cluster_connected_nodes{cluster="talos-ottawa",container="garage",endpoint="admin",instance="10.3.0.2:3903",job="garage",namespace="garage",pod="garage-storage-local-700-healthy",service="garage"}'
+        values: "18+0x20"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: GarageFederationPeerConnectivityDegraded
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: GarageFederationPeerConnectivityDegraded
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              container: garage
+              endpoint: admin
+              instance: 10.3.0.1:3903
+              job: garage
+              namespace: garage
+              pod: garage-storage-local-700-ottawa
+              service: garage
+              severity: warning
+            exp_annotations:
+              summary: >-
+                Garage federation connectivity degraded from
+                garage-storage-local-700-ottawa (talos-ottawa)
+              description: >-
+                This Garage admin vantage point sees 17 of the expected 18
+                federation peers. The count is per scrape target, not a fleet
+                aggregate; other sites may see a different subset. Check
+                inter-site RPC transport (DNS, TCP 3901, Tailscale, routing,
+                and policy) before treating partition quorum as proof of
+                federation health.
+          - exp_labels:
+              cluster: talos-robbinsdale
+              container: garage
+              endpoint: admin
+              instance: 10.1.0.1:3903
+              job: garage
+              namespace: garage
+              pod: garage-storage-local-700-robbinsdale
+              service: garage
+              severity: warning
+            exp_annotations:
+              summary: >-
+                Garage federation connectivity degraded from
+                garage-storage-local-700-robbinsdale (talos-robbinsdale)
+              description: >-
+                This Garage admin vantage point sees 16 of the expected 18
+                federation peers. The count is per scrape target, not a fleet
+                aggregate; other sites may see a different subset. Check
+                inter-site RPC transport (DNS, TCP 3901, Tailscale, routing,
+                and policy) before treating partition quorum as proof of
+                federation health.
+          - exp_labels:
+              cluster: talos-stpetersburg
+              container: garage
+              endpoint: admin
+              instance: 10.5.0.1:3903
+              job: garage
+              namespace: garage
+              pod: garage-storage-local-200-stpetersburg
+              service: garage
+              severity: warning
+            exp_annotations:
+              summary: >-
+                Garage federation connectivity degraded from
+                garage-storage-local-200-stpetersburg (talos-stpetersburg)
+              description: >-
+                This Garage admin vantage point sees 17 of the expected 18
+                federation peers. The count is per scrape target, not a fleet
+                aggregate; other sites may see a different subset. Check
+                inter-site RPC transport (DNS, TCP 3901, Tailscale, routing,
+                and policy) before treating partition quorum as proof of
+                federation health.
+
+  - interval: 1m
+    input_series:
+      - series: 'cluster_connected_nodes{cluster="talos-robbinsdale",container="garage",endpoint="admin",instance="10.1.0.1:3903",job="garage",namespace="garage",pod="garage-storage-local-700-robbinsdale",service="garage"}'
+        values: "16+0x5 18+0x15"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: GarageFederationPeerConnectivityDegraded
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: GarageFederationPeerConnectivityDegraded
         exp_alerts: []


### PR DESCRIPTION
## Summary

Add a per-vantage-point alert for Garage federation connectivity loss. Garage is one federated cluster of 18 peers spanning Ottawa, Robbinsdale, and St. Petersburg; the alert preserves the tenant cluster and the individual Garage pod/instance that reports the count.

## Why

Robbinsdale saw only 16/18 connected peers for approximately 19 hours with no alert. The underlying incident was TCP 3901 timing out to Garage peers in Ottawa and St. Petersburg, not a local Robbinsdale Garage failure. Ottawa and St. Petersburg independently saw 17/18, demonstrating why a fleet aggregate would hide the asymmetric facts.

`GarageFederationPeerConnectivityDegraded` fires when a Garage admin scrape target reports fewer than 18 connected peers for 15 minutes. It is warning severity and intentionally does not aggregate away `cluster`, `pod`, or `instance`.

## Validation

- Live `cluster_connected_nodes` series confirmed in all three tenants: Ottawa 17, Robbinsdale 16, St. Petersburg 17.
- `tools/check.sh talos-ottawa` passed.
- `tools/check-mimir-rules.sh` passed: 25 rule files, 3 tenant loaders.
- `git diff --check` passed.
- Focused promtool fixtures cover all three degraded viewpoints, healthy 18/18, the 15-minute pending boundary, and recovery.
- Local promtool validation was not possible: promtool is absent, Docker is unavailable, and the Nix bootstrap timed out with `rc=124`. The CI promtool gate is the authoritative syntax/test validation for this PR.

The existing `garage` namespace and all three loader entries were already present, so no loader production edit was required.
