### PR TITLE
fix(monitoring): alert on current Velero PVB target failures

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -4,6 +4,73 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
+  # A failed one-shot record must stop alerting when a newer attempt for the
+  # same workload target succeeds. The target key includes pod UID so a
+  # replacement pod is a distinct backup target; the age bound prevents old
+  # abandoned targets from paging forever.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji"}'
+        values: "100+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji",phase="Failed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji",phase="Completed"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroPodVolumeBackupFailed
+        exp_alerts: []
+
+  # A current failure still pages even when its parent Backup is no longer
+  # exported. This is the case the old parent-Backup join could miss.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="broken",pod_uid="pod-uid",volume="home",pod_volume_backup="broken-pvb",backup="broken-backup",node="asuka"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="broken",pod_uid="pod-uid",volume="home",pod_volume_backup="broken-pvb",backup="broken-backup",node="asuka",phase="Failed"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroPodVolumeBackupFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              pod_namespace: home
+              pod_name: broken
+              pod_uid: pod-uid
+              volume: home
+              pod_volume_backup: broken-pvb
+              backup: broken-backup
+              node: asuka
+              phase: Failed
+              severity: warning
+            exp_annotations:
+              summary: Velero PodVolumeBackup Failed for broken/home
+              description: >-
+                The newest PodVolumeBackup for target home/broken (UID pod-uid,
+                volume home) is Failed. It was created within the last 24 hours
+                and has remained in that state for at least five minutes. A
+                later successful PVB for the same target clears this signal;
+                older Failed/Canceled records are intentionally ignored. Inspect
+                the PVB status message, node-agent logs, and storage path before
+                treating the target as restorable.
+
+  # Once the newest failed PVB is older than the bounded horizon it is
+  # archaeological residue, not a current-state page.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="old",pod_uid="pod-uid",volume="home",pod_volume_backup="old-pvb",backup="old-backup",node="rei"}'
+        values: "100+0x1505"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="old",pod_uid="pod-uid",volume="home",pod_volume_backup="old-pvb",backup="old-backup",node="rei",phase="Failed"}'
+        values: "1+0x1505"
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: VeleroPodVolumeBackupFailed
+        exp_alerts: []
+
   - interval: 1m
     input_series:
       # The warning/error series are intentionally absent for the previous

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -3,8 +3,8 @@
 # are useful for newly observed events, but do not represent the persisted
 # phase of an individual Backup (a real Failed Backup kept last_status=1).
 #
-# #572 acceptance (Failed/PartiallyFailed latest Backup, Failed/Canceled PVB,
-# bytesDone!=totalBytes) is covered by the rules below after #2743.
+# #572 acceptance (Failed/PartiallyFailed latest Backup, current Failed/Canceled
+# PVB, bytesDone!=totalBytes) is covered by the rules below after #2743.
 #
 # Silent-skip / green-empty coverage (corp/bhaiya#695, #703):
 # - VeleroScheduleLatestBackupHasWarnings: hostPath skips leave phase=Completed
@@ -30,42 +30,58 @@ namespace: velero-integrity
 groups:
   - name: velero-integrity.rules
     rules:
-      # Failed/Canceled PVB CRs persist until TTL expiry. Matching every one
-      # latches for days after the parent Backup has already been superseded.
-      # Restrict to parents created in the last 24h so a recent failure still
-      # pages, while historical objects stop saturating the alert stream.
+      # Failed/Canceled PVB CRs are one-shot records and can outlive both their
+      # parent Backup and a later successful attempt. Select only the newest
+      # PVB for each workload target, so a later success clears a transient
+      # failure. Bound the selected record by its own creation time because
+      # parent Backups are routinely cleaned up while PVBs persist; without
+      # this bound an abandoned target would page forever.
       # Schedule-level paging for the newest Backup remains in
       # VeleroScheduleLastBackupFailed below.
       - alert: VeleroPodVolumeBackupFailed
         expr: |
-          (
-            max by (cluster, namespace, pod_volume_backup, backup, node, phase) (
-              velero_cr_podvolumebackup_info{
-                namespace="velero-system",
-                phase=~"Failed|Canceled"
-              }
-            ) > 0
-          )
-          and on (cluster, namespace, backup)
-          (
-            velero_cr_backup_created_timestamp{
-              namespace="velero-system"
-            } > time() - 24 * 3600
+          max by (
+            cluster, namespace, pod_namespace, pod_name, pod_uid, volume,
+            pod_volume_backup, backup, node, phase
+          ) (
+            (
+              topk by (
+                cluster, namespace, pod_namespace, pod_name, pod_uid, volume
+              ) (
+                1,
+                velero_cr_podvolumebackup_created_timestamp{
+                  namespace="velero-system"
+                }
+              )
+              * on (
+                cluster, namespace, pod_namespace, pod_name, pod_uid, volume,
+                pod_volume_backup, backup, node
+              ) group_left (phase)
+              max by (
+                cluster, namespace, pod_namespace, pod_name, pod_uid, volume,
+                pod_volume_backup, backup, node, phase
+              ) (
+                velero_cr_podvolumebackup_info{
+                  namespace="velero-system",
+                  phase=~"Failed|Canceled"
+                }
+              )
+            ) > time() - 24 * 3600
           )
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: Velero PodVolumeBackup {{ $labels.phase }} for {{ $labels.backup }}
+          summary: Velero PodVolumeBackup {{ $labels.phase }} for {{ $labels.pod_name }}/{{ $labels.volume }}
           description: >-
-            PodVolumeBackup {{ $labels.pod_volume_backup }} for Backup
-            {{ $labels.backup }} on node {{ $labels.node }} has remained
-            {{ $labels.phase }} for at least five minutes, and the parent
-            Backup was created within the last 24 hours. Older
-            Failed/Canceled PVB objects are intentionally ignored so a
-            recovered schedule stops paging. Inspect the PVB status message,
-            the parent Backup, node-agent logs, and the storage path before
-            treating the parent Backup as restorable.
+            The newest PodVolumeBackup for target {{ $labels.pod_namespace }}/{{ $labels.pod_name }}
+            (UID {{ $labels.pod_uid }}, volume {{ $labels.volume }}) is
+            {{ $labels.phase }}. It was created within the last 24 hours and
+            has remained in that state for at least five minutes. A later
+            successful PVB for the same target clears this signal; older
+            Failed/Canceled records are intentionally ignored. Inspect the
+            PVB status message, node-agent logs, and storage path before
+            treating the target as restorable.
 
       - alert: VeleroPodVolumeBackupBytesMismatch
         expr: |

--- a/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml
@@ -410,6 +410,10 @@ kube-state-metrics:
               namespace: [ metadata, namespace ]
               pod_volume_backup: [ metadata, name ]
               backup: [ metadata, labels, velero.io/backup-name ]
+              pod_namespace: [ spec, pod, namespace ]
+              pod_name: [ spec, pod, name ]
+              pod_uid: [ spec, pod, uid ]
+              volume: [ spec, volume ]
               node: [ spec, node ]
             metrics:
               - name: "podvolumebackup_info"
@@ -433,6 +437,12 @@ kube-state-metrics:
                   gauge:
                     path: [ status, progress ]
                     valueFrom: [ totalBytes ]
+              - name: "podvolumebackup_created_timestamp"
+                help: "Unix creation timestamp of a Velero PodVolumeBackup custom resource."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [ metadata, creationTimestamp ]
           # Velero's own server metrics expose restore counters but not the
           # per-object PodVolumeRestore phase or progress. Export the CR
           # status through kube-state-metrics so the Mimir ruler can detect a


### PR DESCRIPTION
## Summary

- Export PodVolumeBackup target identity (`pod_namespace`, `pod_name`, `pod_uid`, `volume`) and `velero_cr_podvolumebackup_created_timestamp` from kube-state-metrics.
- Make `VeleroPodVolumeBackupFailed` select the newest PVB for each workload target, rather than every historical Failed/Canceled object.
- Bound the selected PVB to 24 hours using its own creation timestamp. A later successful PVB for the same pod UID and volume clears the signal; old orphaned records cannot page forever.
- Reuse the existing `velero-integrity` namespace and loader registration; no new loader path is needed.

This addresses the observed Teaspoon failure: the 23:23 Garage error was followed by successful PVBs for the same pod UID and volumes, so the failure should no longer remain as a current-target alert. Parent Backup objects are routinely cleaned up while PVBs remain, so the alert no longer depends on the parent Backup metric.

## Evidence and scope

- Ottawa currently has 1,609 PVBs (1,595 Completed, 6 Failed, 13 Canceled) and no parent Backup objects. PVBs still reference 1,272 distinct deleted Backup names. No effective Velero orphan-PVB garbage collection was observed in the live object set or recent Velero logs; this PR does not attempt GC.
- Teaspoon PVBs have distinct Backup/PVB names and a roughly 2–3 minute creation cadence, including successful records after the failed one. That is repeated upstream backup creation/polling, not Velero retrying one one-shot PVB; this PR does not alter cadence or Bhaiya code.
- `VeleroPodVolumeBackupStalled`, `VeleroPodVolumeRestoreStalled`, and both progress-unavailable rules already require `phase="InProgress"`. Live Robbinsdale stalled alerts were all attached to InProgress objects, including one at bytesDone == totalBytes, so terminal objects are not changed here. The existing five-minute no-change lookback plus five-minute hold measures about ten minutes without observed progress, not total upload duration; a 40-minute transfer remains valid when bytes continue advancing.

## Validation

- `tools/check-mimir-promql.sh`
- `tools/check-mimir-rules.sh`
- pinned Prometheus 3.14.0 full Mimir rule tests
- `tools/check.sh talos-ottawa`

All pass. The live KSM/Mimir series for the new PVB labels and creation timestamp require the normal Flux/KSM rollout after merge; no reconcile, restart, restore, deletion, or Garage operation was performed.
