### PR TITLE
test(cnpg): prove fenced Tracearr recovery path

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -29,9 +29,9 @@ diagram in the [README](../../README.md#architecture).
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
 | `ottawa` | 4 | 58 | 121 |
-| `robbinsdale` | 3 | 43 | 87 |
+| `robbinsdale` | 3 | 44 | 88 |
 | `stpetersburg` | 3 | 40 | 83 |
-| **total** | **10** | **141** | **291** |
+| **total** | **10** | **142** | **292** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -215,6 +215,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Certificates and secrets | `cert-manager` | `cert-manager`, `cert-manager-common-issuers`, `cert-manager-issuers` |
 | Certificates and secrets | `external-secrets` | `external-secrets-config`, `external-secrets-install` |
 | Fleet management | `open-cluster-management-agent` | `ocm-agent` |
+| Application workloads | `cnpg-restore-proof` | `cnpg-restore-proof` → ns `cnpg-restore-proof-20260908-tracearr` |
 | Application workloads | `homer-operator` | `homer-operator-install` |
 | Application workloads | `immich` | `immich` |
 | Application workloads | `media` | `media-apps` |
@@ -225,6 +226,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Flux Kustomization | Pointer directory | Actual namespace |
 |---|---|---|
 | `actions-runner-controller-runners` | `arc-systems` | `arc-runners` |
+| `cnpg-restore-proof` | `cnpg-restore-proof` | `cnpg-restore-proof-20260908-tracearr` |
 | `csi-driver-smb` | `csi-driver-smb` | `kube-system` |
 | `tinyauth-egress` | `tinyauth-egress` | `tinyauth` |
 | `tuppr` | `tuppr` | `system-upgrade` |

--- a/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/cluster-secret-store.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/cluster-secret-store.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-media-cnpg-restore-proof
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: media
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: external-secrets
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: external-secrets-store
+          namespace: external-secrets

--- a/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/cluster.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/cluster.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: tracearr-restore-proof
+  namespace: cnpg-restore-proof-20260908-tracearr
+spec:
+  enableSuperuserAccess: true
+  instances: 1
+  bootstrap:
+    recovery:
+      source: keiretsu
+      database: tracearr
+      owner: tracearr
+  storage:
+    size: 20Gi
+  externalClusters:
+    - name: keiretsu
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: tracearr-s3-source
+          serverName: tracearr-postgres

--- a/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/external-secret.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/external-secret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tracearr-s3-backup
+  namespace: cnpg-restore-proof-20260908-tracearr
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kubernetes-media-cnpg-restore-proof
+    kind: ClusterSecretStore
+  target:
+    name: tracearr-s3-backup
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: tracearr-s3-backup
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: tracearr-s3-backup
+        property: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/kustomization.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cluster-secret-store.yaml
+  - external-secret.yaml
+  - objectstore.yaml
+  - cluster.yaml

--- a/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/namespace.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg-restore-proof-20260908-tracearr
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/objectstore.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof/objectstore.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: tracearr-s3-source
+  namespace: cnpg-restore-proof-20260908-tracearr
+spec:
+  configuration:
+    destinationPath: s3://tracearr-postgres/robbinsdale/
+    endpointURL: http://garage-gateway.garage.svc.cluster.local:3900
+    s3Credentials:
+      accessKeyId:
+        name: tracearr-s3-backup
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: tracearr-s3-backup
+        key: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
+++ b/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
@@ -81,6 +81,12 @@ exemptions:
       Demo/sandbox tsidp volumeClaimTemplate under tailscale-examples; not a
       production data plane.
 
+  - cluster: robbinsdale
+    namespace: cnpg-restore-proof-20260908-tracearr
+    reason: >-
+      Temporary fenced CNPG restore-proof target; the PVC is deleted after the
+      read-only recovery comparison and is not production state.
+
   # --- St Petersburg ---
   - cluster: stpetersburg
     namespace: ai

--- a/kubernetes/apps/robbinsdale/cnpg-restore-proof/cnpg-restore-proof.yaml
+++ b/kubernetes/apps/robbinsdale/cnpg-restore-proof/cnpg-restore-proof.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cnpg-restore-proof
+  namespace: flux-system
+spec:
+  targetNamespace: cnpg-restore-proof-20260908-tracearr
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-system
+    - name: external-secrets-config
+  path: ./kubernetes/apps/base/cnpg-restore-proof/tracearr-recovery-proof
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/robbinsdale/cnpg-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/cnpg-restore-proof/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cnpg-restore-proof.yaml

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
   - ./k8gb
   - ./node-feature-discovery
   - ./tailscale-examples
+  - ./cnpg-restore-proof
   - ./tailscale-system
 
   - ./tailscale


### PR DESCRIPTION
Temporary verification-only GitOps target for the authorized Robbinsdale Tracearr CNPG restore proof.

- creates an isolated scratch namespace and one-instance recovery Cluster
- reads the existing Barman source through an ExternalSecret/ObjectStore
- has no spec.plugins, spec.backup, or ScheduledBackup, so it cannot archive WAL
- will be removed after the bounded data comparison

This must not be merged as a durable application change.