### PR TITLE
Track Velero backup targets across pod replacement

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -84,18 +84,18 @@ tests:
         exp_alerts: []
 
   # A failed one-shot record must stop alerting when a newer attempt for the
-  # same workload target succeeds. The target key includes pod UID so a
-  # replacement pod is a distinct backup target; the age bound prevents old
+  # same workload target succeeds, even when the replacement pod has a new
+  # UID. The target key is pod name plus volume; the age bound prevents old
   # abandoned targets from paging forever.
   - interval: 1m
     input_series:
-      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji"}'
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="old-pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji"}'
         values: "100+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji",phase="Failed"}'
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="old-pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji",phase="Failed"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji"}'
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="new-pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji"}'
         values: "200+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji",phase="Completed"}'
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="new-pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji",phase="Completed"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 15m

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -36,6 +36,9 @@ groups:
       # failure. Bound the selected record by its own creation time because
       # parent Backups are routinely cleaned up while PVBs persist; without
       # this bound an abandoned target would page forever.
+      # Use pod name plus volume as the target identity. Pod UIDs change on
+      # routine workspace replacement; a PVC label would be more durable but
+      # is not present on the PVB CR or in the exported metric contract.
       # Schedule-level paging for the newest Backup remains in
       # VeleroScheduleLastBackupFailed below.
       - alert: VeleroPodVolumeBackupFailed
@@ -46,7 +49,7 @@ groups:
           ) (
             (
               topk by (
-                cluster, namespace, pod_namespace, pod_name, pod_uid, volume
+                cluster, namespace, pod_namespace, pod_name, volume
               ) (
                 1,
                 velero_cr_podvolumebackup_created_timestamp{


### PR DESCRIPTION
## Summary
- key VeleroPodVolumeBackupFailed's newest-attempt selection by pod namespace, pod name and volume instead of pod UID
- add a regression test where a Failed PVB from one pod UID is followed by a Completed PVB from a new UID with the same name and volume

## Identity tradeoff
Pod UID is not a durable workload identity: Bhaiya recreates `sandbox-<slug>` pods while retaining the workspace target, so UID-keyed selection leaves old failures behind. Pod name plus volume is the best identity available in the current PVB CR and metric contract, and is stable for Bhaiya's workspace pods. Generic workloads that reuse a pod name for a different incarnation could be conflated. A genuinely PVC-based identity would be stronger, but it requires exporter enrichment because the PVB CR and current exported metrics do not contain the PVC name.

## Verification
- focused pinned Prometheus 3.14.0 Velero rule tests pass
- complete 30-file Mimir PromQL gate passes
- Mimir load-path gate passes
- Ottawa render passes