### PR TITLE
fix(garage): deploy v0.7.9 operator to Robbinsdale

### DIFF
--- a/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/garage-operator-system/garage-operator-system-install/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
       - op: add
         path: /spec/values/image
         value:
-          digest: sha256:4ed5db5a815b987af4b142e91453dcce50561687e2bd1c1a9ea6ae5205bc82d0
+          digest: sha256:ab769000dd61e07fbb6c45fa544f03c16b50ff0c64fe23ef7d00cc060ec78389


### PR DESCRIPTION
## Summary

- update only the Robbinsdale Garage operator overlay to the released v0.7.9 image digest
- leave Ottawa and St Petersburg overlays unchanged

The chart was already v0.7.9, but the Robbinsdale-only overlay continued to override the image with the pre-release recovery digest `sha256:4ed5db5a815b987af4b142e91453dcce50561687e2bd1c1a9ea6ae5205bc82d0`. This changes it to the v0.7.9 release digest `sha256:ab769000dd61e07fbb6c45fa544f03c16b50ff0c64fe23ef7d00cc060ec78389`.

This is required to deploy the label-reconciliation backstop in Robbinsdale. It does not change Garage layout, membership, storage pods, or the stalled `garage-storage-local-700` rollout.
