### PR TITLE
fix(monitoring): exclude canceled PVBs from failure alert

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -133,9 +133,22 @@ tests:
                 volume home) is Failed. It was created within the last 24 hours
                 and has remained in that state for at least five minutes. A
                 later successful PVB for the same target clears this signal;
-                older Failed/Canceled records are intentionally ignored. Inspect
+                older Failed records are intentionally ignored. Inspect
                 the PVB status message, node-agent logs, and storage path before
                 treating the target as restorable.
+
+  # Cancellation is an operator action or a deliberate controller stop, not a
+  # failed backup. It must not page as VeleroPodVolumeBackupFailed.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="media",pod_name="overseerr",pod_uid="pod-uid",volume="config",pod_volume_backup="canceled-pvb",backup="config-backup",node="asuka"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="media",pod_name="overseerr",pod_uid="pod-uid",volume="config",pod_volume_backup="canceled-pvb",backup="config-backup",node="asuka",phase="Canceled"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroPodVolumeBackupFailed
+        exp_alerts: []
 
   # Once the newest failed PVB is older than the bounded horizon it is
   # archaeological residue, not a current-state page.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -3,7 +3,7 @@
 # are useful for newly observed events, but do not represent the persisted
 # phase of an individual Backup (a real Failed Backup kept last_status=1).
 #
-# #572 acceptance (Failed/PartiallyFailed latest Backup, current Failed/Canceled
+# #572 acceptance (Failed/PartiallyFailed latest Backup, current Failed
 # PVB, bytesDone!=totalBytes) is covered by the rules below after #2743.
 #
 # Silent-skip / green-empty coverage (corp/bhaiya#695, #703):
@@ -30,7 +30,7 @@ namespace: velero-integrity
 groups:
   - name: velero-integrity.rules
     rules:
-      # Failed/Canceled PVB CRs are one-shot records and can outlive both their
+      # Failed PVB CRs are one-shot records and can outlive both their
       # parent Backup and a later successful attempt. Select only the newest
       # PVB for each workload target, so a later success clears a transient
       # failure. Bound the selected record by its own creation time because
@@ -66,7 +66,7 @@ groups:
               ) (
                 velero_cr_podvolumebackup_info{
                   namespace="velero-system",
-                  phase=~"Failed|Canceled"
+                  phase="Failed"
                 }
               )
             ) > time() - 24 * 3600
@@ -82,7 +82,7 @@ groups:
             {{ $labels.phase }}. It was created within the last 24 hours and
             has remained in that state for at least five minutes. A later
             successful PVB for the same target clears this signal; older
-            Failed/Canceled records are intentionally ignored. Inspect the
+            Failed records are intentionally ignored. Inspect the
             PVB status message, node-agent logs, and storage path before
             treating the target as restorable.
 


### PR DESCRIPTION
## Summary

- Treat only Failed PodVolumeBackups as VeleroPodVolumeBackupFailed; Canceled is a deliberate terminal action, not a failure.
- Retain km#2834 tracking by pod name and volume so a newer successful record clears an older failure across pod replacement.
- Add a regression test proving a current Canceled PVB does not fire the failure alert.

## Investigation

- Live Ottawa Mimir still had all 11 alerts on the 2026-09-07 Canceled records, with no newer same-target PVBs yet.
- velero_cr_podvolumebackup_info exports no cancellation actor, reason, or user, so no operator-versus-Velero cancellation signal is added.
- Existing ruler namespace and mimir-rules loader registration already cover this file; no kustomization or loader wiring changes are needed.

## Verification

- tools/check.sh ot: ✓ render OK: talos-ottawa