### PR TITLE
fix(alerts): group notifications by incident identity

### DIFF
--- a/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
@@ -57,7 +57,8 @@ spec:
         receiver: blackhole
       # Group the Velero family by the object that actually failed. The live
       # baseline had 33 non-deliberate Velero alert instances, but these should
-      # collapse to roughly 11 backup/schedule incident groups. Keep backup in
+      # collapse to roughly 12 backup/schedule incident groups (nine concrete
+      # backups plus three schedule-only freshness groups). Keep backup in
       # the key so a later attempt is not merged into an older attempt.
       - matchers:
           - matchType: "=~"

--- a/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
@@ -55,6 +55,60 @@ spec:
         # The Gatus heartbeat endpoint was retired; retain the standard
         # liveness alert without repeatedly delivering it to a dead webhook.
         receiver: blackhole
+      # Group the Velero family by the object that actually failed. The live
+      # baseline had 33 non-deliberate Velero alert instances, but these should
+      # collapse to roughly 11 backup/schedule incident groups. Keep backup in
+      # the key so a later attempt is not merged into an older attempt.
+      - matchers:
+          - matchType: "=~"
+            name: alertname
+            value: VeleroPodVolumeBackup.*|VeleroScheduleLastBackupFailed|VeleroScheduleLatestBackup(HasWarnings|MissingVolumes)|VeleroScheduleVolumeCoverageRegressed
+        groupBy:
+          - cluster
+          - backup
+        receiver: discord
+      - matchers:
+          - matchType: "=~"
+            name: alertname
+            value: VeleroPodVolumeRestore.*|VeleroRestore.*
+        groupBy:
+          - cluster
+          - restore
+        receiver: discord
+      # Schedule-level freshness/event alerts do not carry a Backup label.
+      - matchers:
+          - matchType: "=~"
+            name: alertname
+            value: VeleroBackup(Stale|PartiallyFailed|Failed)|VeleroScheduleNeverBackedUp
+        groupBy:
+          - cluster
+          - schedule
+        receiver: discord
+      - matchers:
+          - matchType: "="
+            name: alertname
+            value: VeleroBackupRepositoryMaintenanceStale
+        groupBy:
+          - cluster
+          - repository
+          - volume_namespace
+        receiver: discord
+      - matchers:
+          - matchType: "="
+            name: alertname
+            value: VeleroBackupStorageLocationUnavailable
+        groupBy:
+          - cluster
+          - backup_location_name
+        receiver: discord
+      - matchers:
+          - matchType: "="
+            name: alertname
+            value: VeleroNodeDataPathSaturated
+        groupBy:
+          - cluster
+          - node
+        receiver: discord
       # All other alerts with severity go to Discord
       - matchers:
           - matchType: "=~"
@@ -86,7 +140,12 @@ spec:
               {{- end }}
             {{- end }}
           sendResolved: true
-          title: '[Alerts] [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.alertname }}'
+          title: >-
+            [Alerts] [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
+            {{- if .GroupLabels.backup }}backup: {{ .GroupLabels.backup }}
+            {{- else if .GroupLabels.schedule }}schedule: {{ .GroupLabels.schedule }}
+            {{- else if .GroupLabels.alertname }}{{ .GroupLabels.alertname }}
+            {{- else }}grouped alerts{{ end }}
       name: discord
   inhibitRules:
     - equal:


### PR DESCRIPTION
## Summary

- group Velero alerts by the concrete backup identity when `backup` is present
- group schedule-level freshness/event alerts by `cluster` and `schedule`
- keep restore, node, repository, storage, and infrastructure alerts on their own identity keys
- make Discord titles show `backup:` or `schedule:` when `alertname` is no longer a group label

## Expected effect

The current live baseline has 33 non-deliberate Velero alert instances. The proposed grouping should reduce those to roughly 12 Velero incident groups: nine concrete backup identities plus three schedule-only freshness groups. Including the infrastructure groups, the delivered channel should be roughly 16 groups instead of the current alertname-split groups.

The `backup` label is deliberately retained in the group key: a new attempt for the same schedule must not silently join the previous attempt’s incident.

## Verification

- `./tools/check.sh talos-ottawa`
- `./tools/check.sh talos-robbinsdale`
- `./tools/check.sh talos-stpetersburg`

All three render gates passed. The real Alertmanager grouping test is intentionally post-merge: the live config cannot change until Flux applies this GitOps PR. Before the change, the live media-config incident is split across `VeleroBackupStale`, `VeleroScheduleLastBackupFailed`, and `VeleroScheduleLatestBackupHasWarnings`; after reconciliation those backup-bearing alerts should share the same `cluster, backup` group.