### PR TITLE
fix(alerts): attach latest backup to stale schedules

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -23,6 +23,19 @@ for rule in flux bhaiya-model garage node-clock velero-integrity; do
   promtool test rules "$tmpdir/$test_file"
 done
 
+# VeleroBackupStale consumes the newest-backup recording rule from
+# velero-integrity.yaml. Test the two files together so the backup enrichment
+# and its one-alert-per-schedule cardinality are exercised as deployed.
+sed '/^namespace: velero-integrity$/d' "$RULE_DIR/velero-integrity.yaml" >"$tmpdir/velero-integrity.yaml"
+sed '/^namespace: velero-backups$/d' "$RULE_DIR/velero.yaml" >"$tmpdir/velero.yaml"
+sed \
+  -e "s#../velero.yaml#$tmpdir/velero.yaml#" \
+  -e "s#../velero-integrity.yaml#$tmpdir/velero-integrity.yaml#" \
+  "$RULE_DIR/tests/velero_stale_test.yaml" >"$tmpdir/velero_stale_test.yaml"
+promtool check rules "$tmpdir/velero.yaml"
+promtool check rules "$tmpdir/velero-integrity.yaml"
+promtool test rules "$tmpdir/velero_stale_test.yaml"
+
 sed '/^namespace: mimir-loader$/d' "$RULE_DIR/mimir-loader.yaml" >"$tmpdir/mimir-loader.yaml"
 sed "s#../mimir-loader.yaml#$tmpdir/mimir-loader.yaml#" \
   "$RULE_DIR/tests/mimir-loader_test.yaml" >"$tmpdir/mimir-loader_test.yaml"

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
@@ -1,0 +1,38 @@
+rule_files:
+  - ../velero-integrity.yaml
+  - ../velero.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Staleness is one alert per schedule. The latest-backup recording rule adds
+  # the backup identity only as a grouping label; it must not create one stale
+  # alert for every historical Backup.
+  - interval: 1m
+    input_series:
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",schedule="media-config-backup"}'
+        values: "-200000+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-backup-20260907060000"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-backup-20260906060000"}'
+        values: "50+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroBackupStale
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: media-config-backup
+              backup: media-config-backup-20260907060000
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule media-config-backup has no recent successful backup
+              description: >-
+                Schedule media-config-backup has not reported a successful
+                backup for more than 36 hours (the daily schedule's expected
+                period plus margin). Check the Schedule, BackupStorageLocation,
+                Velero server, and node-agent pods. This is a freshness/reporting
+                guard; it cannot detect a backup that completes while silently
+                missing data, and it also needs the Velero metric to remain
+                scrapeable.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
@@ -55,11 +55,18 @@ groups:
       - alert: VeleroBackupStale
         expr: |
           (
-            time()
-            - max by (cluster, schedule) (
-                velero_backup_last_successful_timestamp{schedule!=""}
-              )
-          ) > 129600
+            (
+              time()
+              - max by (cluster, schedule) (
+                  velero_backup_last_successful_timestamp{schedule!=""}
+                )
+            ) > bool 129600
+          )
+          * on (cluster, schedule) group_left (namespace, backup)
+          (
+            velero_schedule_latest_backup_created_timestamp > bool 0
+          )
+          > 0
         for: 15m
         labels:
           severity: critical

--- a/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
@@ -63,7 +63,7 @@ spec:
       - matchers:
           - matchType: "=~"
             name: alertname
-            value: VeleroPodVolumeBackup.*|VeleroScheduleLastBackupFailed|VeleroScheduleLatestBackup(HasWarnings|MissingVolumes)|VeleroScheduleVolumeCoverageRegressed
+            value: VeleroPodVolumeBackup.*|VeleroBackupStale|VeleroScheduleLastBackupFailed|VeleroScheduleLatestBackup(HasWarnings|MissingVolumes)|VeleroScheduleVolumeCoverageRegressed
         groupBy:
           - cluster
           - backup
@@ -80,7 +80,7 @@ spec:
       - matchers:
           - matchType: "=~"
             name: alertname
-            value: VeleroBackup(Stale|PartiallyFailed|Failed)|VeleroScheduleNeverBackedUp
+            value: VeleroBackup(PartiallyFailed|Failed)|VeleroScheduleNeverBackedUp
         groupBy:
           - cluster
           - schedule

--- a/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
@@ -57,7 +57,8 @@ spec:
         receiver: blackhole
       # Group the Velero family by the object that actually failed. The live
       # baseline had 33 non-deliberate Velero alert instances, but these should
-      # collapse to roughly 11 backup/schedule incident groups. Keep backup in
+      # collapse to roughly 12 backup/schedule incident groups (nine concrete
+      # backups plus three schedule-only freshness groups). Keep backup in
       # the key so a later attempt is not merged into an older attempt.
       - matchers:
           - matchType: "=~"

--- a/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/monitoring/monitoring-common/config/alertmanagerconfig.yaml
@@ -55,6 +55,60 @@ spec:
         # The Gatus heartbeat endpoint was retired; retain the standard
         # liveness alert without repeatedly delivering it to a dead webhook.
         receiver: blackhole
+      # Group the Velero family by the object that actually failed. The live
+      # baseline had 33 non-deliberate Velero alert instances, but these should
+      # collapse to roughly 11 backup/schedule incident groups. Keep backup in
+      # the key so a later attempt is not merged into an older attempt.
+      - matchers:
+          - matchType: "=~"
+            name: alertname
+            value: VeleroPodVolumeBackup.*|VeleroScheduleLastBackupFailed|VeleroScheduleLatestBackup(HasWarnings|MissingVolumes)|VeleroScheduleVolumeCoverageRegressed
+        groupBy:
+          - cluster
+          - backup
+        receiver: discord
+      - matchers:
+          - matchType: "=~"
+            name: alertname
+            value: VeleroPodVolumeRestore.*|VeleroRestore.*
+        groupBy:
+          - cluster
+          - restore
+        receiver: discord
+      # Schedule-level freshness/event alerts do not carry a Backup label.
+      - matchers:
+          - matchType: "=~"
+            name: alertname
+            value: VeleroBackup(Stale|PartiallyFailed|Failed)|VeleroScheduleNeverBackedUp
+        groupBy:
+          - cluster
+          - schedule
+        receiver: discord
+      - matchers:
+          - matchType: "="
+            name: alertname
+            value: VeleroBackupRepositoryMaintenanceStale
+        groupBy:
+          - cluster
+          - repository
+          - volume_namespace
+        receiver: discord
+      - matchers:
+          - matchType: "="
+            name: alertname
+            value: VeleroBackupStorageLocationUnavailable
+        groupBy:
+          - cluster
+          - backup_location_name
+        receiver: discord
+      - matchers:
+          - matchType: "="
+            name: alertname
+            value: VeleroNodeDataPathSaturated
+        groupBy:
+          - cluster
+          - node
+        receiver: discord
       # All other alerts with severity go to Discord
       - matchers:
           - matchType: "=~"
@@ -86,7 +140,12 @@ spec:
               {{- end }}
             {{- end }}
           sendResolved: true
-          title: '[Alerts] [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.alertname }}'
+          title: >-
+            [Alerts] [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
+            {{- if .GroupLabels.backup }}backup: {{ .GroupLabels.backup }}
+            {{- else if .GroupLabels.schedule }}schedule: {{ .GroupLabels.schedule }}
+            {{- else if .GroupLabels.alertname }}{{ .GroupLabels.alertname }}
+            {{- else }}grouped alerts{{ end }}
       name: discord
   inhibitRules:
     - equal:


### PR DESCRIPTION
## Summary

- enrich `VeleroBackupStale` with the existing `velero_schedule_latest_backup_created_timestamp` recording rule
- keep the alert at one series per `cluster, schedule`; only the newest backup identity is attached
- route stale alerts through the existing `cluster, backup` grouping
- add a pinned-promtool test with two historical backups proving one stale alert and the newest backup label

This completes the grouping follow-up from #2842: stale, failed, and warning alerts for one backup can now share one incident group without merging different backup attempts.

## Verification

- `PATH=/tmp/cos-promtool.qAjD6j/prometheus-3.14.0.linux-amd64:$PATH kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh`
- `./tools/check.sh talos-ottawa`
- `./tools/check.sh talos-robbinsdale`
- `./tools/check.sh talos-stpetersburg`

The live Alertmanager observation before this change showed the Ottawa media backup split into a schedule group for `VeleroBackupStale` and a backup group for the failed/warning alerts. After merge and Flux reconciliation, the discriminating test is one `cluster, backup` group containing all three alerts.
