### PR TITLE
test(cnpg): prove fenced Robbinsdale Immich recovery

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -29,9 +29,9 @@ diagram in the [README](../../README.md#architecture).
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
 | `ottawa` | 4 | 58 | 121 |
-| `robbinsdale` | 3 | 43 | 87 |
+| `robbinsdale` | 3 | 44 | 88 |
 | `stpetersburg` | 3 | 40 | 83 |
-| **total** | **10** | **141** | **291** |
+| **total** | **10** | **142** | **292** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -215,6 +215,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Certificates and secrets | `cert-manager` | `cert-manager`, `cert-manager-common-issuers`, `cert-manager-issuers` |
 | Certificates and secrets | `external-secrets` | `external-secrets-config`, `external-secrets-install` |
 | Fleet management | `open-cluster-management-agent` | `ocm-agent` |
+| Application workloads | `cnpg-restore-proof` | `cnpg-restore-proof` → ns `cnpg-restore-proof-20260908-immich` |
 | Application workloads | `homer-operator` | `homer-operator-install` |
 | Application workloads | `immich` | `immich` |
 | Application workloads | `media` | `media-apps` |
@@ -225,6 +226,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Flux Kustomization | Pointer directory | Actual namespace |
 |---|---|---|
 | `actions-runner-controller-runners` | `arc-systems` | `arc-runners` |
+| `cnpg-restore-proof` | `cnpg-restore-proof` | `cnpg-restore-proof-20260908-immich` |
 | `csi-driver-smb` | `csi-driver-smb` | `kube-system` |
 | `tinyauth-egress` | `tinyauth-egress` | `tinyauth` |
 | `tuppr` | `tuppr` | `system-upgrade` |

--- a/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/cluster-secret-store.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/cluster-secret-store.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-immich-cnpg-restore-proof
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: immich
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: external-secrets
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: external-secrets-store
+          namespace: external-secrets

--- a/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/cluster.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/cluster.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-restore-proof
+  namespace: cnpg-restore-proof-20260908-immich
+spec:
+  enableSuperuserAccess: true
+  instances: 1
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:15-0.3.0
+  postgresql:
+    shared_preload_libraries:
+      - "vchord.so"
+  bootstrap:
+    recovery:
+      source: keiretsu
+      database: immich
+      owner: immich
+  storage:
+    size: 40Gi
+    storageClass: ceph-block-replicated-nvme
+  externalClusters:
+    - name: keiretsu
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: immich-s3-source
+          serverName: immich-postgres

--- a/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/external-secret.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/external-secret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-s3-backup
+  namespace: cnpg-restore-proof-20260908-immich
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kubernetes-immich-cnpg-restore-proof
+    kind: ClusterSecretStore
+  target:
+    name: immich-s3-backup
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: immich-s3-backup
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: immich-s3-backup
+        property: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/kustomization.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cluster-secret-store.yaml
+  - external-secret.yaml
+  - objectstore.yaml
+  - cluster.yaml

--- a/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/namespace.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg-restore-proof-20260908-immich
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/objectstore.yaml
+++ b/kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof/objectstore.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: immich-s3-source
+  namespace: cnpg-restore-proof-20260908-immich
+spec:
+  configuration:
+    destinationPath: s3://immich-postgres/robbinsdale/
+    endpointURL: http://garage-gateway.garage.svc.cluster.local:3900
+    s3Credentials:
+      accessKeyId:
+        name: immich-s3-backup
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: immich-s3-backup
+        key: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
+++ b/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
@@ -76,6 +76,12 @@ exemptions:
       backed up."
 
   - cluster: robbinsdale
+    namespace: cnpg-restore-proof-20260908-immich
+    reason: >-
+      Temporary fenced CNPG Immich restore-proof target; its PVC is removed
+      after the read-only recovery comparison and is not production state.
+
+  - cluster: robbinsdale
     namespace: tailscale-examples
     reason: >-
       Demo/sandbox tsidp volumeClaimTemplate under tailscale-examples; not a

--- a/kubernetes/apps/robbinsdale/cnpg-restore-proof/cnpg-restore-proof.yaml
+++ b/kubernetes/apps/robbinsdale/cnpg-restore-proof/cnpg-restore-proof.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cnpg-restore-proof
+  namespace: flux-system
+spec:
+  targetNamespace: cnpg-restore-proof-20260908-immich
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-system
+    - name: external-secrets-config
+  path: ./kubernetes/apps/base/cnpg-restore-proof/immich-recovery-proof
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/robbinsdale/cnpg-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/cnpg-restore-proof/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cnpg-restore-proof.yaml

--- a/kubernetes/apps/robbinsdale/kustomization.yaml
+++ b/kubernetes/apps/robbinsdale/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./arc-systems
   - ./cloudflare
   - ./cnpg-system
+  - ./cnpg-restore-proof
   - ./dragonfly-operator-system
   - ./fluent-bit
   - ./garage-operator-system


### PR DESCRIPTION
## Purpose

Create a temporary, isolated Robbinsdale CNPG recovery target for the fresh Immich backup `immich-postgres-20260908020056` (`20260908T020057`, timeline 18). The target is for a read-only data comparison and is not an application deployment.

## Fencing

- new namespace `cnpg-restore-proof-20260908-immich`
- one 40Gi `ceph-block-replicated-nvme` PVC
- exact PG15 VectorChord image and `vchord.so` preload
- `bootstrap.recovery` only
- `externalClusters[].plugin.isWALArchiver: false` explicitly set
- no `spec.backup`, `spec.plugins`, ScheduledBackup, application, or route
- source credentials are read-only via a target-namespace ObjectStore
- cleanup will remove the GitOps path and verify all target resources disappear

The source namespace and target namespace are distinct; the live Robbinsdale Immich Cluster is not modified. After merge/reconciliation I will compare table names, representative rows/timestamps, system ID, recovery LSN, and measured RPO before teardown.