### PR TITLE
feat(monitoring): add absolute St Petersburg Spark memory bands

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -41,6 +41,7 @@ configMapGenerator:
       - rules/job-failures.yaml
       - rules/mimir-queryable-window.yaml
       - rules/monitoring.yaml
+      - rules/stpetersburg-memory.yaml
       - rules/node-health.yaml
       - rules/node-clock.yaml
       - rules/payments.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -51,6 +51,7 @@ spec:
             - /rules/job-failures.yaml
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
+            - /rules/stpetersburg-memory.yaml
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
@@ -94,6 +95,7 @@ spec:
             - /rules/job-failures.yaml
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
+            - /rules/stpetersburg-memory.yaml
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
@@ -133,6 +135,7 @@ spec:
             - /rules/job-failures.yaml
             - /rules/mimir-queryable-window.yaml
             - /rules/monitoring.yaml
+            - /rules/stpetersburg-memory.yaml
             - /rules/node-health.yaml
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/monitoring.yaml
@@ -219,7 +219,14 @@ groups:
 
       - alert: NodeHighMemoryUsage
         expr: |
-          (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 90
+          (
+            (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 90
+          )
+          unless on (cluster, instance)
+          (
+            node_memory_MemTotal_bytes{cluster="talos-stpetersburg"}
+            > 100 * 1024 * 1024 * 1024
+          )
         for: 15m
         annotations:
           summary: >-

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/stpetersburg-memory.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/stpetersburg-memory.yaml
@@ -1,0 +1,61 @@
+# Unified-memory model nodes need absolute host-memory bands. A percentage
+# alert cannot distinguish a tolerable post-rollout cushion from an imminent
+# host OOM on a 128 GiB GB10 node.
+namespace: stpetersburg-memory
+groups:
+  - name: stpetersburg-memory.rules
+    rules:
+      # The two bands are mutually exclusive: at 3 GiB this is the warning;
+      # at 300 MiB only the critical alert below is active.
+      - alert: StPetersburgSparkMemoryAvailableLow
+        expr: |
+          (
+            node_memory_MemAvailable_bytes{cluster="talos-stpetersburg"}
+            < 8 * 1024 * 1024 * 1024
+          )
+          and on (cluster, instance)
+          (
+            node_memory_MemAvailable_bytes{cluster="talos-stpetersburg"}
+            >= 2 * 1024 * 1024 * 1024
+          )
+          and on (cluster, instance)
+          (
+            node_memory_MemTotal_bytes{cluster="talos-stpetersburg"}
+            > 100 * 1024 * 1024 * 1024
+          )
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            St. Petersburg Spark node {{ $labels.instance }} has 2–8 GiB of
+            host memory available.
+          description: >-
+            This is the tight-memory band for a GB10 unified-memory node.
+            The node remains below the 8 GiB early-warning cushion but above
+            the critical 2 GiB band; correlate MemAvailable with the GB10
+            allocation and vLLM serving state.
+
+      - alert: StPetersburgSparkMemoryAvailableCritical
+        expr: |
+          (
+            node_memory_MemAvailable_bytes{cluster="talos-stpetersburg"}
+            < 2 * 1024 * 1024 * 1024
+          )
+          and on (cluster, instance)
+          (
+            node_memory_MemTotal_bytes{cluster="talos-stpetersburg"}
+            > 100 * 1024 * 1024 * 1024
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: >-
+            St. Petersburg Spark node {{ $labels.instance }} has under 2 GiB
+            of host memory available.
+          description: >-
+            The GB10 unified-memory host is in the critical absolute-memory
+            band. An OOM can kill a vLLM rank even while Kubernetes
+            MemoryPressure remains False; protect the model endpoint and
+            investigate immediately.


### PR DESCRIPTION
## Summary

- add mutually exclusive 2–8 GiB warning and <2 GiB critical absolute MemAvailable alerts for St Petersburg Spark-class nodes
- exclude those nodes from the generic percentage memory alert to avoid duplicate paging
- include the new rule in the generated rules ConfigMap and all three Mimir tenant loader containers

## Verification

- `tools/check.sh` passes for Ottawa, Robbinsdale, and St. Petersburg
- no live cluster state was changed
- Qwen route was independently verified with a real CLIProxy completion during this investigation

The Mimir loader Job should be checked after merge.