### PR TITLE
fix(stpetersburg): match kopiur mover to HA file owner

### DIFF
--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshotpolicy.yaml
@@ -24,20 +24,16 @@ spec:
     keepWeekly: 4
     keepMonthly: 3
   mover:
-    # Live /config has root-owned 0600 files under .storage/ (auth, etc.).
-    # Default mover UID 65532 would Succeed with 0 files — a silent empty
-    # backup. inheritSecurityContextFrom cannot help: HA's pod spec pins no
-    # runAsUser (image USER only), so inheritance would fall back to 65532
-    # (InheritPinnedNoUid). Explicit root is required to READ.
-    #
-    # privilegedMode is the CRD's namespace-gated elevation flag (pairs with
-    # kopiur.home-operations.com/privileged-movers on the Namespace). It alone
-    # does not set UID 0 for backup reads — docs pair it with runAsUser: 0
-    # (and use privilegedMode especially so restores can preserve ownership).
-    privilegedMode: true
+    # The live source has one owner-only file under .storage/:
+    # 10000:10000, mode 0600. A root mover with the hardened capabilities.drop
+    # [ALL] still lacks CAP_DAC_OVERRIDE and therefore cannot read it (the
+    # previous UID-0 run failed on .storage/core.uuid). Match the file owner
+    # instead; this keeps the mover unprivileged and leaves the live PVC
+    # read-only. The remaining source files are root-owned or world-readable.
     securityContext:
-      runAsUser: 0
-      runAsNonRoot: false
+      runAsUser: 10000
+      runAsGroup: 10000
+      runAsNonRoot: true
     # Do NOT put tolerations here — SnapshotPolicy.spec.mover has no
     # tolerations field (schema reject / Flux dry-run fail). Scheduling onto
     # tainted orin-0 is handled by Repository.sourceColocation Auto (default):

--- a/kubernetes/apps/stpetersburg/home-assistant/namespace.yaml
+++ b/kubernetes/apps/stpetersburg/home-assistant/namespace.yaml
@@ -8,8 +8,3 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
-  annotations:
-    # Root mover required to READ root-owned 0600 files under /config/.storage
-    # (auth, etc.). Direct mount stays readOnly:true — this opt-in is for UID 0
-    # on the mover Job only, not for writing the live PVC.
-    kopiur.home-operations.com/privileged-movers: "true"


### PR DESCRIPTION
The Home Assistant Kopiur Direct mover failed opening .storage/core.uuid, owned 10000:10000 mode 0600. The policy requested UID 0, but Kopiur preserves the hardened capabilities.drop=[ALL], so that root process lacks CAP_DAC_OVERRIDE. Match the mover to the file owner with runAsUser/runAsGroup 10000 and runAsNonRoot=true; the source remains read-only. Remove the now-unneeded privileged namespace opt-in. The St. Petersburg render gate passes: tools/check.sh sp.