### PR TITLE
test(stpetersburg): prove Kopiur Home Assistant capture

### DIFF
--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kustomization.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./repository.yaml
   - ./snapshotpolicy.yaml
   - ./snapshotschedule.yaml
+  - ./snapshot-proof-20260908.yaml

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshot-proof-20260908.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshot-proof-20260908.yaml
@@ -1,0 +1,11 @@
+---
+# One-shot GitOps proof that the Kopiur Direct mover can read the live HA PVC.
+# Retain the repository snapshot if this verification object is ever removed.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: homeassistant-config-proof-20260908
+spec:
+  deletionPolicy: Retain
+  policyRef:
+    name: homeassistant-config


### PR DESCRIPTION
Git-managed one-shot proof for the merged Kopiur identity fix. Adds a fixed Snapshot for homeassistant-config with deletionPolicy: Retain so Flux triggers a real Direct capture and the repository snapshot survives if the proof object is later retired. The proof is complete only when the Snapshot reaches Succeeded with non-zero file statistics and a Kopia snapshot ID.