### PR TITLE
test(stpetersburg): capture live Home Assistant config

### DIFF
--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kustomization.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./snapshotpolicy.yaml
   - ./snapshotschedule.yaml
   - ./snapshot-proof-20260908.yaml
+  - ./snapshot-live-20260908.yaml

--- a/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshot-live-20260908.yaml
+++ b/kubernetes/apps/base/home-assistant/home-assistant/kopiur/snapshot-live-20260908.yaml
@@ -1,0 +1,11 @@
+---
+# One-shot live capture of the scheduled Home Assistant source after the
+# mover-identity fix (#2849). Retain the remote snapshot as recovery material.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: homeassistant-config-20260908034331
+spec:
+  deletionPolicy: Retain
+  policyRef:
+    name: homeassistant-config


### PR DESCRIPTION
Add one retained, policy-backed Kopiur Snapshot for the live homeassistant-config PVC after the merged mover identity fix.

The existing proof Snapshot established the identity mechanism; this captures the actual scheduled source under its normal homeassistant-config timestamped name. The object is retained as recovery material and will be verified to Succeeded with non-zero statistics.