### PR TITLE
test(stpetersburg): add Kopiur Home Assistant restore proof

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -30,8 +30,8 @@ diagram in the [README](../../README.md#architecture).
 |---|---:|---:|---:|
 | `ottawa` | 4 | 58 | 121 |
 | `robbinsdale` | 3 | 43 | 87 |
-| `stpetersburg` | 3 | 40 | 83 |
-| **total** | **10** | **141** | **291** |
+| `stpetersburg` | 3 | 41 | 84 |
+| **total** | **10** | **142** | **292** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -304,6 +304,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Application workloads | `home-assistant` | `home-assistant` |
 | Application workloads | `homer-operator` | `homer-operator-install` |
 | Application workloads | `kopiur` | `home-assistant-kopiur` → ns `home-assistant`, `kopiur` → ns `kopiur-system` |
+| Application workloads | `kopiur-restore-proof` | `kopiur-restore-proof` → ns `kopiur-restore-proof-20260908-ha` |
 
 Pointers whose objects land outside their directory's namespace — use the right-hand column with `kubectl -n`:
 
@@ -312,6 +313,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | `actions-runner-controller-runners` | `arc-systems` | `arc-runners` |
 | `home-assistant-kopiur` | `kopiur` | `home-assistant` |
 | `kopiur` | `kopiur` | `kopiur-system` |
+| `kopiur-restore-proof` | `kopiur-restore-proof` | `kopiur-restore-proof-20260908-ha` |
 | `rdma-shared-dp` | `rdma-shared-dp` | `rdma-system` |
 | `tinyauth-egress` | `tinyauth-egress` | `tinyauth` |
 | `tuppr` | `tuppr` | `system-upgrade` |

--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-restore-proof-20260908-ha
+resources:
+  - namespace.yaml
+  - restore.yaml

--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/namespace.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-restore-proof-20260908-ha
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    kopiur.home-operations.com/privileged-movers: "true"

--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore.yaml
@@ -1,0 +1,45 @@
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: homeassistant-config-restore-proof
+  namespace: kopiur-restore-proof-20260908-ha
+spec:
+  # Pin the exact Snapshot CR; do not resolve a moving SnapshotPolicy.
+  source:
+    snapshotRef:
+      name: homeassistant-config-20260908034331
+      namespace: home-assistant
+  repository:
+    kind: Repository
+    name: kopiur-stpetersburg
+    namespace: home-assistant
+  target:
+    pvc:
+      name: homeassistant-config-restore
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+      storageClassName: local-path
+  mover:
+    # Use the UID/GID/fsGroup recorded by the source Snapshot, not the live
+    # workload (which does not pin a UID in its PodSpec).
+    inheritSecurityContextFrom:
+      snapshot: {}
+    privilegedMode: true
+  options:
+    enableFileDeletion: false
+    ignoreErrors: false
+    ignorePermissionErrors: false
+    parallel: 1
+    skipExisting: false
+    skipOwners: false
+    skipPermissions: false
+    skipTimes: false
+    writeFilesAtomically: true
+  policy:
+    onMissingSnapshot: Fail
+    waitTimeout: 5m
+  failurePolicy:
+    backoffLimit: 0
+    activeDeadlineSeconds: 1800
+    podStartupDeadlineSeconds: 300

--- a/kubernetes/apps/stpetersburg/kopiur-restore-proof/kopiur-restore-proof.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur-restore-proof/kopiur-restore-proof.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-restore-proof
+  namespace: flux-system
+spec:
+  targetNamespace: kopiur-restore-proof-20260908-ha
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kopiur-restore-proof
+  dependsOn:
+    - name: kopiur
+    - name: home-assistant-kopiur
+  path: ./kubernetes/apps/base/kopiur/kopiur-restore-proof
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/stpetersburg/kopiur-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur-restore-proof/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kopiur-restore-proof.yaml

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./home
   - ./home-assistant
   - ./kopiur
+  - ./kopiur-restore-proof
   - ./homer-operator
   - ./kro-system
   - ./kube-system


### PR DESCRIPTION
## What

Adds a fenced, GitOps-delivered Kopiur Restore target for the non-empty Home Assistant configuration Snapshot. It uses a new scratch namespace and PVC, pins the exact Snapshot and Repository, has no application, Service, route, target Repository, backup, or schedule, and bounds mover failure/retry behavior. The source remains read-only and untouched.

This PR only creates the proof target after merge; no live restore target has been created from this branch yet.

## Evidence target

- Snapshot: `homeassistant-config-20260908034331`
- Kopia snapshot ID: `487b1b9a40fcd6678b544b835a106336`
- Source evidence: 208 files and 14,501,307 bytes
- Acceptance: Restore completion plus positive files/bytes and source/target manifest and content comparison

## Validation limitation

Direct rendering of the new leaf succeeds, and rendering with `FLATE_BASE=HEAD` succeeds. The committed-branch changed-resource check was also run with `KMAN_CHECK_TIMEOUT=300`, but Flate fails before manifest parsing while resolving the new path against `origin/main`:

`flux-system/kopiur-restore-proof`

`kustomization path is not a directory: ./kubernetes/apps/base/kopiur/kopiur-restore-proof`

This is a Flate changed-resource baseline/path-resolution limitation for a new Flux path, not a manifest parse failure. The full gate was not retried after this was isolated; the limitation is stated here so review does not mistake it for a bad manifest.