### PR TITLE
test(kopiur): prove restore from Velero Kopia history

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -28,10 +28,10 @@ diagram in the [README](../../README.md#architecture).
 
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
-| `ottawa` | 4 | 58 | 121 |
+| `ottawa` | 4 | 60 | 123 |
 | `robbinsdale` | 3 | 43 | 87 |
 | `stpetersburg` | 3 | 41 | 84 |
-| **total** | **10** | **142** | **292** |
+| **total** | **10** | **144** | **294** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -119,6 +119,8 @@ diagram in the [README](../../README.md#architecture).
 | Application workloads | `hermes` | `hermes` |
 | Application workloads | `homer-operator` | `homer-operator-install` |
 | Application workloads | `immich` | `immich` |
+| Application workloads | `kopiur` | `kopiur` → ns `kopiur-system` |
+| Application workloads | `kopiur-velero-home-restore-proof` | `kopiur-velero-home-restore-proof` → ns `velero-system` |
 | Application workloads | `media` | `media-apps` |
 | Application workloads | `searxng` | `searxng` |
 | Application workloads | `tempvm` | `tempvm` |
@@ -134,6 +136,8 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | `k8gb-monitoring` | `k8gb` | `keiretsu-top` |
 | `k8gb-prometheus` | `k8gb` | `keiretsu-top` |
 | `k8s-gpu-dra-driver` | `k8s-gpu-dra-driver` | `kube-system` |
+| `kopiur` | `kopiur` | `kopiur-system` |
+| `kopiur-velero-home-restore-proof` | `kopiur-velero-home-restore-proof` | `velero-system` |
 | `teslamate-secret-sync` | `teslamate` | `monitoring` |
 | `tinyauth` | `auth` | `tinyauth` |
 | `tinyauth-killinit` | `auth` | `tinyauth` |

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repository.yaml

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof/namespace.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-velero-home-restore-20260908
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    kopiur.home-operations.com/privileged-movers: "true"

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof/repository.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof/repository.yaml
@@ -1,0 +1,35 @@
+---
+# Read-only Kopiur view of Ottawa Velero's existing Home repository.
+# Velero remains the only writer, maintenance owner, and retention owner.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: velero-home-ottawa-readonly
+  namespace: velero-system
+spec:
+  backend:
+    s3:
+      bucket: velero
+      prefix: ottawa/kopia/home/
+      endpoint: garage-gateway.garage.svc.cluster.local:3900
+      region: garage
+      tls:
+        disableTls: true
+      auth:
+        secretRef:
+          name: velero-credentials-rotation-2
+  encryption:
+    passwordSecretRef:
+      name: velero-repo-credentials
+      key: repository-password
+  mode: ReadOnly
+  create:
+    enabled: false
+  catalog:
+    adoption: Ignore
+    periodicRefresh: false
+    retain:
+      perIdentity: 50
+      maxAgeDays: 30
+  maintenance:
+    enabled: false

--- a/kubernetes/apps/ottawa/kopiur-velero-home-restore-proof/kopiur-velero-home-restore-proof.yaml
+++ b/kubernetes/apps/ottawa/kopiur-velero-home-restore-proof/kopiur-velero-home-restore-proof.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-velero-home-restore-proof
+  namespace: flux-system
+spec:
+  targetNamespace: velero-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kopiur-velero-home-restore-proof
+      app.kubernetes.io/part-of: kopiur
+  dependsOn:
+    - name: kopiur
+  path: ./kubernetes/apps/base/kopiur/velero-home-restore-proof
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/ottawa/kopiur/kopiur.yaml
+++ b/kubernetes/apps/ottawa/kopiur/kopiur.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+  namespace: flux-system
+spec:
+  targetNamespace: kopiur-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kopiur
+      app.kubernetes.io/part-of: kopiur
+  path: ./kubernetes/apps/base/kopiur/kopiur
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -55,6 +55,8 @@ resources:
   - ./k8s-gpu-dra-driver
   - ./rook-ceph
   - ./velero
+  - ./kopiur
+  - ./kopiur-velero-home-restore-proof
   - ./vpa-system
   - ./victoria-logs
   - ./victoria-logs/victoria-logs.yaml


### PR DESCRIPTION
## Summary
- add a temporary Ottawa Kopiur controller deployment for the proof
- connect Kopiur read-only to the existing Ottawa Velero Home Kopia repository
- keep Velero as the sole writer, maintenance owner, and retention owner
- prepare the isolated scratch namespace for the pinned restore proof

The source is the completed Velero PVB `home-backup-20260906090000-j99h6`, snapshot `a126fed51f156946923a8ff195c9d144`, identity `default@default`, path `/72c70d3d-e5a3-4ae4-9d8f-2ffac9fe1bef`. No Restore is created in this stage; it will be added only after the read-only repository reaches Ready and the exact catalog/source identity is observed.

The branch also contains the previously reviewed St Petersburg Kopiur restore-proof manifest. All test resources are temporary and will be removed through GitOps after evidence is recorded; a failed restore will be left standing.
