### PR TITLE
feat(monitoring): alert on workspace Services without endpoints

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya.yaml
@@ -91,6 +91,22 @@ groups:
       description: The active {{ $labels.deployment }} Deployment has desired replicas but
         none are ready. Check the Deployment events, pod readiness probes, and the most recent
         rollout before traffic is lost.
+  - alert: BhaiyaWorkspaceServiceNoReadyEndpoints
+    expr: |
+      bhaiya_workspace_service_endpoint_state{
+        state=~"not-ready|missing"
+      } == 1
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: Workspace {{ $labels.workspace }} Service has no ready endpoints
+      description: >-
+        Bhaiya reports that the primary Service for workspace {{ $labels.workspace }} has
+        no ready EndpointSlice backend for ten minutes (state={{ $labels.state }}). The
+        workspace lifecycle state can still say Ready because that probe does not prove
+        that the primary Service reaches the session; inspect the Service selector,
+        EndpointSlices, and workspace Pod conditions.
   - alert: BhaiyaScrapeTargetDown
     expr: up{namespace="bhaiya"} == 0
     for: 5m


### PR DESCRIPTION
Adds the Mimir ruler alert for bhaiya_workspace_service_endpoint_state.

The alert fires after 10 minutes when a Bhaiya-owned primary workspace Service reports not-ready or missing EndpointSlice backends. It is intentionally scoped to Bhaiya workspace Services and would NOT have caught the motivating asuka Garage incident; Garage is outside Bhaiya's namespace and ownership.

Dependency and rollout order:
- Depends on corp/bhaiya PR #799, which adds and emits the metric.
- This rule is intentionally inert until #799 is deployed.
- bhaiya.yaml is already loaded by rules-ottawa, rules-robbinsdale, and rules-stpetersburg.

The alert also explicitly covers the misleading case where the workspace lifecycle says Ready while the primary Service has no ready endpoints.

Verification: tools/check.sh passed for all three tenants.