### PR TITLE
fix(kopiur): pass Velero repository password to read-only probe

### DIFF
--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - password.sops.yaml
   - repository.yaml

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof/password.sops.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof/password.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: velero-home-ottawa-kopia-password
+    namespace: velero-system
+type: Opaque
+data:
+    KOPIA_PASSWORD: ENC[AES256_GCM,data:6tkeoSeqCHej+m+kRlkM9NepttQ=,iv:sSvt0TfqZpTAP7jA+5nc2n2oKS532roBJn21oqwrvKs=,tag:0F03JG99uUix5XnQmrTMJg==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-09-08T06:09:43Z"
+    mac: ENC[AES256_GCM,data:mNmLtDZUAZX8NyKSGKKweZZ0CEs5FQSrIO+DRRW8eTf8CcjsV79Oz1DHn9pM6+tljUAT1b+hc+kpuT5eMFWTWOrqe9ZSOO/L2Rd3v8adofGLBplfAsCaW25fyBBsBhnDXrf7XItnMm6yqM3mE7EyOUGkcD5J/5Q9WsDuP6OIY5M=,iv:wTkY3x1WmRjWVerfSWgWIEkP4gEOSf9bqsn+94QQtJk=,tag:SCBXqHsEcr8JGvUqCs1s5Q==,type:str]
+    pgp:
+        - created_at: "2026-09-08T06:09:42Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0HSi2TJaWveARAAhORJsJoLmKb5q6nk9DeIPp/33C3CURrujxhZNNcn2q7l
+            FhBYmNxF/U+pRO0Demdq0HfQAyV218KlvvTtf2reJqu/fcgElesmpvm+3KfZiQLN
+            YPRj67M0m/3K9v1TAfjVRxhCWOSkQndVru+m5qFkI0lHUY4Y+UIWSNKjwPellLOk
+            pcGHX5keDozcZf0aoU7tJht7+31PRK9w8ssdORUA/5exsfxUY7xMe7MIm8gpyVbD
+            XRc79G45QxktytEcOUj5kRhTKV0MuR28WGq1/cG5DR2B907eQdBWSlsaLq62zsBa
+            jC+g/twTok+SQWBZSbYJO97/hDbJIeW28oIcAUpMqeWe+4KBhntWKSkmxpjm0Dh/
+            0tZI3s2C7oKv+7x4vhhVVao2AiTp9EClqxiomqkZ6+tj3prxZdqEPDfJ+l4cSNCb
+            eMbwceyFzpAqL6FQLUCEFNKK8p3+abvFem3+6s1ldvdsUf+A98Hu8maZ0/QBmcjB
+            WeQJrRMAvfzZlOryULmKiJlu7TXRxRRYdXKZ7/h0Mx+ejFInJQzEalBMYhI4XpL9
+            /52KqNUYuStmZo94M2gprg4eHJW14+giicTOKAkBEHZNqbD7J/QKijsZ+g/irYdw
+            zxPwIM87FijIWyY9gMVRpy4jhyC278wBBno+7XUlEPJKJMxIp+l2L4VGRCnEiu3S
+            XAHNKS15oy9dcDiK86aaupp+krzjuepn3bHpUmbahmYoUfgO7Hr+Hi4+9iHvx+pv
+            bCSdkOUTftqILcHqn5eCMkn8ObFHz2PZr00kwggZ1joNOvfaavlYLKt8nLSi
+            =fAnl
+            -----END PGP MESSAGE-----
+          fp: FAC8E7C3A2BC7DEE58A01C5928E1AB8AF0CF07A5
+    version: 3.13.3

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof/repository.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof/repository.yaml
@@ -20,8 +20,8 @@ spec:
           name: velero-credentials-rotation-2
   encryption:
     passwordSecretRef:
-      name: velero-repo-credentials
-      key: repository-password
+      name: velero-home-ottawa-kopia-password
+      key: KOPIA_PASSWORD
   mode: ReadOnly
   create:
     enabled: false


### PR DESCRIPTION
The read-only Kopiur Repository could not connect because the mover uses envFrom and did not receive Velero's repository-password key as KOPIA_PASSWORD.

This adds a temporary SOPS-encrypted Secret containing the same password under the mover's expected key. It does not modify Velero's Secret or enable Kopiur creation/maintenance: the Repository remains mode ReadOnly, create.enabled false, and maintenance.enabled false.

Validation: tools/check.sh ot passed. The source namespace remains absent and no Restore object is included.