### PR TITLE
test(kopiur): restore a data-bearing Velero snapshot

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -28,10 +28,10 @@ diagram in the [README](../../README.md#architecture).
 
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
-| `ottawa` | 4 | 60 | 123 |
+| `ottawa` | 4 | 61 | 124 |
 | `robbinsdale` | 3 | 43 | 87 |
 | `stpetersburg` | 3 | 41 | 84 |
-| **total** | **10** | **144** | **294** |
+| **total** | **10** | **145** | **295** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -121,6 +121,7 @@ diagram in the [README](../../README.md#architecture).
 | Application workloads | `immich` | `immich` |
 | Application workloads | `kopiur` | `kopiur` → ns `kopiur-system` |
 | Application workloads | `kopiur-velero-home-restore-proof` | `kopiur-velero-home-restore-proof` → ns `velero-system` |
+| Application workloads | `kopiur-velero-home-restore-proof-target` | `kopiur-velero-home-restore-proof-target` → ns `kopiur-velero-home-restore-20260908` |
 | Application workloads | `media` | `media-apps` |
 | Application workloads | `searxng` | `searxng` |
 | Application workloads | `tempvm` | `tempvm` |
@@ -138,6 +139,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | `k8s-gpu-dra-driver` | `k8s-gpu-dra-driver` | `kube-system` |
 | `kopiur` | `kopiur` | `kopiur-system` |
 | `kopiur-velero-home-restore-proof` | `kopiur-velero-home-restore-proof` | `velero-system` |
+| `kopiur-velero-home-restore-proof-target` | `kopiur-velero-home-restore-proof-target` | `kopiur-velero-home-restore-20260908` |
 | `teslamate-secret-sync` | `teslamate` | `monitoring` |
 | `tinyauth` | `auth` | `tinyauth` |
 | `tinyauth-killinit` | `auth` | `tinyauth` |

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - restore.yaml

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/namespace.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-velero-home-restore-20260908
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    kopiur.home-operations.com/privileged-movers: "true"

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/restore.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/restore.yaml
@@ -1,0 +1,52 @@
+---
+# First Kopiur restore from a data-bearing Velero-owned Kopia repository.
+# The identity and snapshot ID are deliberately raw and exact: do not resolve
+# a moving SnapshotPolicy or "latest" while this proof is in flight.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: velero-home-ottawa-restore-proof
+  namespace: kopiur-velero-home-restore-20260908
+spec:
+  source:
+    identity:
+      username: default
+      hostname: default
+      sourcePath: /72c70d3d-e5a3-4ae4-9d8f-2ffac9fe1bef
+      snapshotID: a126fed51f156946923a8ff195c9d144
+  repository:
+    kind: Repository
+    name: velero-home-ottawa-readonly
+    namespace: velero-system
+  target:
+    pvc:
+      name: home-config-restored
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+      storageClassName: ceph-block-replicated
+  credentialProjection:
+    # The repository credentials live in velero-system; the mover runs in this
+    # isolated namespace and must receive a projected copy to connect.
+    enabled: true
+  mover:
+    # The target namespace is explicitly privileged for Kopiur movers. The
+    # target PVC is newly created by this Restore; no live PVC is referenced.
+    privilegedMode: true
+  options:
+    enableFileDeletion: false
+    ignoreErrors: false
+    ignorePermissionErrors: false
+    parallel: 1
+    skipExisting: false
+    skipOwners: false
+    skipPermissions: false
+    skipTimes: false
+    writeFilesAtomically: true
+  policy:
+    onMissingSnapshot: Fail
+    waitTimeout: 5m
+  failurePolicy:
+    backoffLimit: 0
+    activeDeadlineSeconds: 1800
+    podStartupDeadlineSeconds: 300

--- a/kubernetes/apps/ottawa/kopiur-velero-home-restore-proof-target/kopiur-velero-home-restore-proof-target.yaml
+++ b/kubernetes/apps/ottawa/kopiur-velero-home-restore-proof-target/kopiur-velero-home-restore-proof-target.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-velero-home-restore-proof-target
+  namespace: flux-system
+spec:
+  targetNamespace: kopiur-velero-home-restore-20260908
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kopiur-velero-home-restore-proof-target
+      app.kubernetes.io/part-of: kopiur
+  dependsOn:
+    - name: kopiur
+    - name: kopiur-velero-home-restore-proof
+  path: ./kubernetes/apps/base/kopiur/velero-home-restore-proof-target
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 30m

--- a/kubernetes/apps/ottawa/kopiur-velero-home-restore-proof-target/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kopiur-velero-home-restore-proof-target/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kopiur-velero-home-restore-proof-target.yaml

--- a/kubernetes/apps/ottawa/kustomization.yaml
+++ b/kubernetes/apps/ottawa/kustomization.yaml
@@ -57,6 +57,7 @@ resources:
   - ./velero
   - ./kopiur
   - ./kopiur-velero-home-restore-proof
+  - ./kopiur-velero-home-restore-proof-target
   - ./vpa-system
   - ./victoria-logs
   - ./victoria-logs/victoria-logs.yaml


### PR DESCRIPTION
This is the second stage, intentionally separate from the repository-discovery stage.

It creates a privileged, isolated scratch namespace and a Kopiur Restore with an operator-created fresh 10Gi PVC. The source is pinned to Velero PVB home-backup-20260906090000-j99h6, Kopia identity default@default, source path /72c70d3d-e5a3-4ae4-9d8f-2ffac9fe1bef, and snapshot a126fed51f156946923a8ff195c9d144.

The Repository remains Velero-owned and read-only; no maintenance or retention settings change. Credential projection is limited to the scratch mover namespace. There is no application, route, or live PVC reference.

Validation: tools/check.sh ot and tools/check-diagram.sh pass. The repository stage is Ready with mode ReadOnly, create=false, maintenance=false, and no Kopiur Maintenance object.