### PR TITLE
fix(kopiur): allow isolated Velero restore credential projection

### DIFF
--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/clusterrepository.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/clusterrepository.yaml
@@ -1,0 +1,43 @@
+---
+# Cluster-scoped read-only view used only to authorize credential projection
+# into the fenced Restore namespace. Velero remains the repository's writer,
+# maintenance owner, and retention owner.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: velero-home-ottawa-restore-readonly
+spec:
+  allowedNamespaces:
+    list:
+      - kopiur-velero-home-restore-20260908
+  credentialProjection:
+    allowed: true
+  backend:
+    s3:
+      bucket: velero
+      prefix: ottawa/kopia/home/
+      endpoint: garage-gateway.garage.svc.cluster.local:3900
+      region: garage
+      tls:
+        disableTls: true
+      auth:
+        secretRef:
+          name: velero-credentials-rotation-2
+          namespace: velero-system
+  encryption:
+    passwordSecretRef:
+      name: velero-home-ottawa-kopia-password
+      namespace: velero-system
+      key: KOPIA_PASSWORD
+  mode: ReadOnly
+  create:
+    enabled: false
+  catalog:
+    adoption: Ignore
+    periodicRefresh: false
+    retain:
+      perIdentity: 50
+      maxAgeDays: 30
+  maintenance:
+    enabled: false
+  onNamespaceDelete: Orphan

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - clusterrepository.yaml
   - namespace.yaml
   - restore.yaml

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/restore.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/restore.yaml
@@ -15,9 +15,8 @@ spec:
       sourcePath: /72c70d3d-e5a3-4ae4-9d8f-2ffac9fe1bef
       snapshotID: a126fed51f156946923a8ff195c9d144
   repository:
-    kind: Repository
-    name: velero-home-ottawa-readonly
-    namespace: velero-system
+    kind: ClusterRepository
+    name: velero-home-ottawa-restore-readonly
   target:
     pvc:
       name: home-config-restored


### PR DESCRIPTION
The first Velero-repository Restore stage correctly reached the target and created a fresh PVC, but Kopiur refused to start the mover because cross-namespace credential projection requires an explicit repository-owner grant.

This adds a separate ClusterRepository read-only view for the same Velero-owned repository, allows projection only into kopiur-velero-home-restore-20260908, and keeps create=false, maintenance=false, and mode=ReadOnly. The Restore now references that view. Velero remains the only writer, maintenance owner, and retention owner.

The existing namespaced read-only Repository remains unchanged for discovery. No live PVC or application is referenced.

Validation: tools/check.sh ot and tools/check-diagram.sh pass.