### PR TITLE
fix(kopiur): enable credential projection for fenced restore

### DIFF
--- a/kubernetes/apps/base/kopiur/kopiur/helmrelease.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/helmrelease.yaml
@@ -30,6 +30,15 @@ spec:
     # this fleet — see PR body.
     installScope: cluster
 
+    # Temporary proof support: the Velero-owned repository credentials live in
+    # velero-system while the fenced Restore mover runs in its scratch
+    # namespace. The ClusterRepository grant remains namespace-scoped; this
+    # feature flag supplies only the operator RBAC needed to project that
+    # explicitly allowed copy.
+    features:
+      credentialProjection:
+        enabled: true
+
     # PIN controller image digest (from oci chart 0.10.7 values). Digest wins
     # over tag so a re-pulled :0.10.7 cannot change bits under us.
     image:


### PR DESCRIPTION
The pinned Restore passed repository admission but Kopiur reported HTTP 403 when creating its projected credential Secret.

Enable the chart's explicit credentialProjection feature flag so the operator has the required Secret create/patch/delete RBAC. The CR-level ClusterRepository grant still allows projection only into kopiur-velero-home-restore-20260908; the repository remains ReadOnly, create=false, and maintenance=false. This is required only for the reversible proof and will be disabled during successful cleanup.

Validation: tools/check.sh ot passes.