### PR TITLE
test(kopiur): prove Velero restore with ownership-preserving mover

### DIFF
--- a/kubernetes/apps/base/kopiur/kopiur/helmrelease.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/helmrelease.yaml
@@ -30,6 +30,15 @@ spec:
     # this fleet — see PR body.
     installScope: cluster
 
+    # Temporary proof support: the Velero-owned repository credentials live in
+    # velero-system while the fenced Restore mover runs in its scratch
+    # namespace. The ClusterRepository grant remains namespace-scoped; this
+    # feature flag supplies only the operator RBAC needed to project that
+    # explicitly allowed copy.
+    features:
+      credentialProjection:
+        enabled: true
+
     # PIN controller image digest (from oci chart 0.10.7 values). Digest wins
     # over tag so a re-pulled :0.10.7 cannot change bits under us.
     image:

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - restore.yaml
+  - restore-r2.yaml

--- a/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/restore-r2.yaml
+++ b/kubernetes/apps/base/kopiur/velero-home-restore-proof-target/restore-r2.yaml
@@ -1,0 +1,54 @@
+# Second attempt after the first attempt proved repository access but failed
+# while restoring original ownership as the hardened non-root mover.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: velero-home-ottawa-restore-proof-r2
+  namespace: kopiur-velero-home-restore-20260908
+spec:
+  source:
+    identity:
+      username: default
+      hostname: default
+      sourcePath: /72c70d3d-e5a3-4ae4-9d8f-2ffac9fe1bef
+      snapshotID: a126fed51f156946923a8ff195c9d144
+  repository:
+    kind: ClusterRepository
+    name: velero-home-ottawa-restore-readonly
+  target:
+    pvc:
+      name: home-config-restored-r2
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+      storageClassName: ceph-block-replicated
+  credentialProjection:
+    # The repository credentials live in velero-system; the mover runs in this
+    # isolated namespace and must receive a projected copy to connect.
+    enabled: true
+  mover:
+    # Preserve the source snapshot's arbitrary UID/GID ownership. The namespace
+    # carries kopiur.home-operations.com/privileged-movers=true and the
+    # privilegedMode gate remains explicit.
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      runAsNonRoot: false
+    privilegedMode: true
+  options:
+    enableFileDeletion: false
+    ignoreErrors: false
+    ignorePermissionErrors: false
+    parallel: 1
+    skipExisting: false
+    skipOwners: false
+    skipPermissions: false
+    skipTimes: false
+    writeFilesAtomically: true
+  policy:
+    onMissingSnapshot: Fail
+    waitTimeout: 5m
+  failurePolicy:
+    backoffLimit: 0
+    activeDeadlineSeconds: 1800
+    podStartupDeadlineSeconds: 300


### PR DESCRIPTION
Retry the fenced Kopiur restore from the Velero-owned Ottawa repository.

The original Restore remains intact as evidence: repository access and exact snapshot resolution succeeded, then a hardened non-root mover failed chown on /restore/tts. This adds a new Restore and fresh PVC, pinned to the same snapshot, with the documented root ownership context (runAsUser: 0, runAsNonRoot: false, privilegedMode: true).

The namespace is scratch-only and the repository remains ReadOnly with creation and maintenance disabled. No live PVC or workload is referenced.

Validation: tools/check.sh talos-ottawa passed.