### PR TITLE
fix(alerts): clear deleted Velero accumulators and detect Flux Unknown

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml
@@ -37,6 +37,26 @@ groups:
             not ready for 15 minutes. Inspect its current condition and root
             dependency before investigating dependent resources.
 
+      - alert: FluxKustomizationUnknown
+        expr: |
+          max by (cluster, namespace, name, path) (
+            flux_resource_info{
+              kind="Kustomization",
+              ready="Unknown",
+              suspended="False"
+            } == 1
+          )
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: Flux Kustomization {{ $labels.name }} has unknown readiness
+          description: >-
+            Kustomization {{ $labels.name }} at {{ $labels.path }} has remained
+            in an unknown readiness state for 30 minutes. Inspect its current
+            condition and root dependency before investigating dependent
+            resources.
+
       - alert: FluxHelmReleaseNotReady
         expr: |
           max by (cluster, namespace, name) (

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/flux_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/flux_test.yaml
@@ -58,6 +58,48 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="unknown",namespace="flux-system",path="./unknown",reason="Progressing",revision="main@sha1:unknown",source_name="kubernetes-manifests",suspended="False",ready="Unknown"}'
+        values: "1+0x40"
+    alert_rule_test:
+      - eval_time: 29m
+        alertname: FluxKustomizationUnknown
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: FluxKustomizationUnknown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: talos-ottawa
+              name: unknown
+              namespace: flux-system
+              path: ./unknown
+            exp_annotations:
+              summary: Flux Kustomization unknown has unknown readiness
+              description: >-
+                Kustomization unknown at ./unknown has remained in an unknown
+                readiness state for 30 minutes. Inspect its current condition
+                and root dependency before investigating dependent resources.
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="recovering",namespace="flux-system",path="./recovering",reason="Progressing",revision="main@sha1:recovering",source_name="kubernetes-manifests",suspended="False",ready="Unknown"}'
+        values: "1+0x10 _x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: FluxKustomizationUnknown
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="suspended-unknown",namespace="flux-system",path="./suspended-unknown",reason="Suspended",revision="main@sha1:suspended",source_name="kubernetes-manifests",suspended="True",ready="Unknown"}'
+        values: "1+0x40"
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: FluxKustomizationUnknown
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
       - series: 'flux_resource_info{cluster="talos-ottawa",kind="Kustomization",name="media-apps",namespace="flux-system",path="./kubernetes/apps/base/media/media-apps",reason="DependencyNotReady",revision="main@sha1:dep",source_name="kubernetes-manifests",suspended="False",ready="False"}'
         values: "1+0x20"
     alert_rule_test:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -4,6 +4,56 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
+  # Missing volume data on an active schedule is actionable, but a deleted or
+  # paused schedule must not leave its last Backup as a permanent accumulator.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="active-backup",backup="active-backup-latest"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="active-backup",backup="active-backup-latest",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="active-backup",phase="Enabled",paused="false"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="paused-backup",backup="paused-backup-latest"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="paused-backup",backup="paused-backup-latest",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="paused-backup",phase="Enabled",paused="true"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="deleted-backup",backup="deleted-backup-latest"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="deleted-backup",backup="deleted-backup-latest",phase="Completed"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: VeleroScheduleLatestBackupMissingVolumes
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: VeleroScheduleLatestBackupMissingVolumes
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: active-backup
+              backup: active-backup-latest
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule active-backup latest Completed backup has no completed volume data
+              description: >-
+                The newest Backup for schedule active-backup is
+                active-backup-latest, phase=Completed, and has no Completed
+                PodVolumeBackup with bytesDone equal to totalBytes. That is not
+                volume-data evidence: Kubernetes objects may be present while
+                durable PVCs were never selected or never mounted, or a child
+                may still be incomplete (corp/bhaiya#703). Confirm with
+                `kubectl -n velero-system get podvolumebackup -l
+                velero.io/backup-name=active-backup-latest` and the live pod
+                volume mounts — do not trust the Backup phase or the existence
+                of a PVB object. This alert only establishes that one
+                byte-complete PVB exists; it does not prove every expected PVC
+                is covered or that a restore works. Clears when a later Backup
+                has a Completed PVB with matching byte counters.
+
   # A completed PVB with mismatched byte counters is a current target signal,
   # but a later clean attempt for the same pod and volume must clear the old
   # one-shot record.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -291,6 +291,14 @@ groups:
               )
             ) > 0
           )
+          and on (cluster, namespace, schedule)
+          max by (cluster, namespace, schedule) (
+            velero_cr_schedule_info{
+              namespace="velero-system",
+              phase="Enabled",
+              paused!="true"
+            }
+          )
         for: 15m
         labels:
           severity: critical


### PR DESCRIPTION
## Summary

This PR intentionally ships the unblocked alert work separately from the Bhaiya-dependent workspace metrics. The second PR will follow only after the endpoint and volume metric families are queried after #830 rolls.

- Gate `VeleroScheduleLatestBackupMissingVolumes` on an enabled, unpaused schedule. This clears the two deleted-schedule accumulators (`hermes-backup` and `bhaiya-tailscale-engineering`) that have been firing for roughly 12 hours, while preserving coverage for active schedules and the accepted St Petersburg `home-assistant-backup` case.
- Add `FluxKustomizationUnknown` for unsuspended Kustomizations remaining `ready="Unknown"` for 30 minutes. The existing explicit `ready="False"` alert remains at 15 minutes.
- Add Prometheus fixtures covering active/deleted/paused Velero schedules and Flux Unknown at 29m, 30m, recovery, and suspension.

The disappeared-series Flux predicate is deliberately deferred: without an independent expected-object inventory it cannot distinguish intentional GitOps deletion from exporter loss and could become another accumulator.

Validation: pinned Prometheus rule checks and focused rule tests pass; `tools/check.sh` passes for all three clusters.