### PR TITLE
feat(alerts): monitor workspace image delivery gaps

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-image.yaml
@@ -119,3 +119,68 @@ groups:
             failure without evidence. Fleet drift remains on
             bhaiya_workspace_image_adoption_workspace_count and does not
             page through this alert.
+
+      # The release observer distinguishes a terminal tag-pipeline failure
+      # from a release input that never queued. Keep these as separate alerts:
+      # they have different causes and runbooks, even though one incident may
+      # produce both signals.
+      - alert: BhaiyaWorkspaceImageReleasePipelineFailed
+        expr: |
+          max by (cluster, image) (
+            bhaiya_workspace_image_release_status{
+              status="failed"
+            } == 1
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Workspace image release pipeline failed
+          description: >-
+            The newest durable workspace-image tag pipeline for {{ $labels.image }}
+            has remained in a terminal failed state for at least five minutes.
+            Inspect the release pipeline and its runbook first; query the
+            release-status metric for the affected version. A separate
+            not-queued alert may identify a newer release input that never
+            reached a tag pipeline.
+
+      - alert: BhaiyaWorkspaceImageReleaseNotQueued
+        expr: |
+          max by (cluster, image) (
+            bhaiya_workspace_image_release_status{
+              status="not_queued"
+            } == 1
+          )
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: Workspace image release was not queued
+          description: >-
+            Bhaiya observed a workspace-image release input for {{ $labels.image }}
+            that remained unqueued for at least the observer's 3-minute grace
+            plus this 2-minute alert hold. The effective source-to-alert delay
+            is approximately 3m grace + up to 5m observation interval + 2m
+            hold, or about 10 minutes before scrape/evaluation jitter. Inspect
+            the main-push dispatcher before treating a healthy 28–29 minute
+            tag pipeline as stalled; query the release-status metric for the
+            affected version.
+
+      - alert: BhaiyaWorkspaceImageLatestRollback
+        expr: |
+          max by (cluster, image) (
+            bhaiya_workspace_image_latest_alignment_status{
+              status="mismatch"
+            } == 1
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Workspace image latest tag does not match the newest release
+          description: >-
+            The {{ $labels.image }} latest tag has not matched the highest
+            published semantic release for at least five minutes. This may
+            indicate a rollback or an incomplete promotion; inspect the
+            alignment status and immutable registry manifests before changing
+            any tag.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_workspace_image_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_workspace_image_test.yaml
@@ -1,0 +1,83 @@
+rule_files:
+  - ../bhaiya-workspace-image.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_workspace_image_release_status{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/corp/workspace",version="0.3.299",status="failed"}'
+        values: "1+0x20"
+      - series: 'bhaiya_workspace_image_release_status{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/corp/workspace",version="0.3.300",status="not_queued"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: BhaiyaWorkspaceImageReleasePipelineFailed
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: BhaiyaWorkspaceImageReleasePipelineFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              image: oci.cdn.keiretsu.top/corp/workspace
+              severity: critical
+            exp_annotations:
+              summary: Workspace image release pipeline failed
+              description: >-
+                The newest durable workspace-image tag pipeline for
+                oci.cdn.keiretsu.top/corp/workspace has remained in a terminal
+                failed state for at least five minutes. Inspect the release
+                pipeline and its runbook first; query the release-status metric
+                for the affected version. A separate not-queued alert may
+                identify a newer release input that never reached a tag
+                pipeline.
+      - eval_time: 1m
+        alertname: BhaiyaWorkspaceImageReleaseNotQueued
+        exp_alerts: []
+      - eval_time: 2m
+        alertname: BhaiyaWorkspaceImageReleaseNotQueued
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              image: oci.cdn.keiretsu.top/corp/workspace
+              severity: critical
+            exp_annotations:
+              summary: Workspace image release was not queued
+              description: >-
+                Bhaiya observed a workspace-image release input for
+                oci.cdn.keiretsu.top/corp/workspace that remained unqueued for
+                at least the observer's 3-minute grace plus this 2-minute
+                alert hold. The effective source-to-alert delay is
+                approximately 3m grace + up to 5m observation interval + 2m
+                hold, or about 10 minutes before scrape/evaluation jitter.
+                Inspect the main-push dispatcher before treating a healthy
+                28–29 minute tag pipeline as stalled; query the release-status
+                metric for the affected version.
+
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_workspace_image_latest_alignment_status{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/corp/workspace",status="aligned"}'
+        values: "0+0x20"
+      - series: 'bhaiya_workspace_image_latest_alignment_status{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/corp/workspace",status="mismatch"}'
+        values: "1+0x20"
+      - series: 'bhaiya_workspace_image_latest_alignment_status{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/corp/workspace",status="unknown"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: BhaiyaWorkspaceImageLatestRollback
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: BhaiyaWorkspaceImageLatestRollback
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              image: oci.cdn.keiretsu.top/corp/workspace
+              severity: critical
+            exp_annotations:
+              summary: Workspace image latest tag does not match the newest release
+              description: >-
+                The oci.cdn.keiretsu.top/corp/workspace latest tag has not
+                matched the highest published semantic release for at least
+                five minutes. This may indicate a rollback or an incomplete
+                promotion; inspect the alignment status and immutable registry
+                manifests before changing any tag.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -8,13 +8,14 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 # Mimir's native rule files require a top-level namespace, which promtool does
 # not understand. Keep each production rule as the source of truth and remove
 # only that Mimir wrapper in the temporary test copy.
-for rule in flux bhaiya-model garage node-clock velero-integrity; do
+for rule in flux bhaiya-model garage node-clock velero-integrity bhaiya-workspace-image; do
   case "$rule" in
     flux) test_file=flux_test.yaml ;;
     bhaiya-model) test_file=bhaiya_model_test.yaml ;;
     garage) test_file=garage_test.yaml ;;
     node-clock) test_file=node-clock_test.yaml ;;
     velero-integrity) test_file=velero-integrity_test.yaml ;;
+    bhaiya-workspace-image) test_file=bhaiya_workspace_image_test.yaml ;;
   esac
   sed "/^namespace: ${rule}$/d" "$RULE_DIR/${rule}.yaml" >"$tmpdir/${rule}.yaml"
   sed "s#../${rule}.yaml#$tmpdir/${rule}.yaml#" \


### PR DESCRIPTION
## Summary

This is intentionally split from the Bhaiya endpoint/volume rules. The source metric families are live; endpoint health remains held until #830 is carried by the control-plane image and queried with real states.

Adds three alerts to the existing Bhaiya workspace-image rule namespace:

- `BhaiyaWorkspaceImageReleasePipelineFailed`: terminal `status="failed"`, for 5m.
- `BhaiyaWorkspaceImageReleaseNotQueued`: `status="not_queued"`, for 2m. The observer has a 3m queue grace and a 5m polling interval, so the effective source-to-alert delay is approximately 3m grace + up to 5m observation + 2m hold = about 10m before scrape/evaluation jitter. This is distinct from the normal 28–29m tag pipeline runtime.
- `BhaiyaWorkspaceImageLatestRollback`: `status="mismatch"`, for 5m. `unknown` is not treated as rollback evidence.

The delivery predicates remain separate because a failed tag pipeline and a release that never queued have different causes and runbooks. Aggregation is by cluster and image, avoiding one alert per changing version.

Live gate before this PR: `bhaiya_workspace_image_release_status` emitted 4 series and `bhaiya_workspace_image_latest_alignment_status` emitted 6 series in Mimir. Endpoint and volume rules are not included because endpoint state was still nine `unknown` series pending the #830 rollout.

Validation: focused Prometheus rule tests pass and `tools/check.sh` passes for all three clusters.