### PR TITLE
feat(alerts): surface workspace services without ready endpoints

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
       - rules/bhaiya-sandbox-telemetry.yaml
       - rules/bhaiya-velero-coverage.yaml
       - rules/bhaiya-workspace-image.yaml
+      - rules/bhaiya-workspace-endpoints.yaml
       - rules/blackbox.yaml
       - rules/ceph.yaml
       - rules/cnpg-backup-coverage.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -39,6 +39,7 @@ spec:
             - /rules/bhaiya-sandbox-telemetry.yaml
             - /rules/bhaiya-velero-coverage.yaml
             - /rules/bhaiya-workspace-image.yaml
+            - /rules/bhaiya-workspace-endpoints.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/cnpg-backup-coverage.yaml
@@ -83,6 +84,7 @@ spec:
             - /rules/bhaiya-sandbox-telemetry.yaml
             - /rules/bhaiya-velero-coverage.yaml
             - /rules/bhaiya-workspace-image.yaml
+            - /rules/bhaiya-workspace-endpoints.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/cnpg-backup-coverage.yaml
@@ -123,6 +125,7 @@ spec:
             - /rules/bhaiya-sandbox-telemetry.yaml
             - /rules/bhaiya-velero-coverage.yaml
             - /rules/bhaiya-workspace-image.yaml
+            - /rules/bhaiya-workspace-endpoints.yaml
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/cnpg-backup-coverage.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-endpoints.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-workspace-endpoints.yaml
@@ -1,0 +1,31 @@
+# Bhaiya exports endpoint observations for every non-terminal workspace, but
+# does not currently export per-workspace desired lifecycle intent. A stopped
+# or idle workspace can therefore legitimately have no ready endpoint. Keep
+# this as a warning until that join exists; do not pretend not-ready alone is
+# a critical serving guarantee.
+namespace: bhaiya-workspace-endpoints
+groups:
+  - name: bhaiya-workspace-endpoints.rules
+    rules:
+      - alert: BhaiyaWorkspaceServiceNoReadyEndpoints
+        expr: |
+          max by (cluster, workspace) (
+            bhaiya_workspace_service_endpoint_state{
+              state=~"not-ready|missing"
+            } == 1
+          )
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Workspace Service has no ready endpoints
+          description: >-
+            Bhaiya reports that the primary Service for workspace
+            {{ $labels.workspace }} has been not-ready or missing ready
+            endpoints for at least 10 minutes. This covers the empty
+            EndpointSlice failure shape, including a Service that still
+            resolves while its port cannot be reached. Bhaiya does not yet
+            export per-workspace desired lifecycle intent, so stopped or idle
+            workspaces can also match; confirm the workspace should be serving
+            before escalating. Only the leader's observation is required; a
+            non-emitting replica does not suppress this signal.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_workspace_endpoints_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_workspace_endpoints_test.yaml
@@ -1,0 +1,65 @@
+rule_files:
+  - ../bhaiya-workspace-endpoints.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # An endpoint observation with no ready backend is the Garage-shaped failure
+  # this metric was created to expose. The metric contract has no separate
+  # desired-running label, so the fixture names the workspace as serving but
+  # cannot encode that intent in PromQL yet.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_workspace_service_endpoint_state{cluster="talos-ottawa",workspace="serving-workspace",state="not-ready"}'
+        values: "1+0x20"
+      - series: 'bhaiya_workspace_service_endpoint_state{cluster="talos-ottawa",workspace="healthy-workspace",state="ready"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: BhaiyaWorkspaceServiceNoReadyEndpoints
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BhaiyaWorkspaceServiceNoReadyEndpoints
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              workspace: serving-workspace
+              severity: warning
+            exp_annotations:
+              summary: Workspace Service has no ready endpoints
+              description: >-
+                Bhaiya reports that the primary Service for workspace
+                serving-workspace has been not-ready or missing ready
+                endpoints for at least 10 minutes. This covers the empty
+                EndpointSlice failure shape, including a Service that still
+                resolves while its port cannot be reached. Bhaiya does not yet
+                export per-workspace desired lifecycle intent, so stopped or
+                idle workspaces can also match; confirm the workspace should
+                be serving before escalating. Only the leader's observation
+                is required; a non-emitting replica does not suppress this
+                signal.
+
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_workspace_service_endpoint_state{cluster="talos-ottawa",workspace="empty-slice",state="missing"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BhaiyaWorkspaceServiceNoReadyEndpoints
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              workspace: empty-slice
+              severity: warning
+            exp_annotations:
+              summary: Workspace Service has no ready endpoints
+              description: >-
+                Bhaiya reports that the primary Service for workspace
+                empty-slice has been not-ready or missing ready endpoints for
+                at least 10 minutes. This covers the empty EndpointSlice
+                failure shape, including a Service that still resolves while
+                its port cannot be reached. Bhaiya does not yet export
+                per-workspace desired lifecycle intent, so stopped or idle
+                workspaces can also match; confirm the workspace should be
+                serving before escalating. Only the leader's observation is
+                required; a non-emitting replica does not suppress this signal.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -8,7 +8,7 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 # Mimir's native rule files require a top-level namespace, which promtool does
 # not understand. Keep each production rule as the source of truth and remove
 # only that Mimir wrapper in the temporary test copy.
-for rule in flux bhaiya-model garage node-clock velero-integrity bhaiya-workspace-image; do
+for rule in flux bhaiya-model garage node-clock velero-integrity bhaiya-workspace-image bhaiya-workspace-endpoints; do
   case "$rule" in
     flux) test_file=flux_test.yaml ;;
     bhaiya-model) test_file=bhaiya_model_test.yaml ;;
@@ -16,6 +16,7 @@ for rule in flux bhaiya-model garage node-clock velero-integrity bhaiya-workspac
     node-clock) test_file=node-clock_test.yaml ;;
     velero-integrity) test_file=velero-integrity_test.yaml ;;
     bhaiya-workspace-image) test_file=bhaiya_workspace_image_test.yaml ;;
+    bhaiya-workspace-endpoints) test_file=bhaiya_workspace_endpoints_test.yaml ;;
   esac
   sed "/^namespace: ${rule}$/d" "$RULE_DIR/${rule}.yaml" >"$tmpdir/${rule}.yaml"
   sed "s#../${rule}.yaml#$tmpdir/${rule}.yaml#" \


### PR DESCRIPTION
## Summary

Bhaiya #830 is now deployed and the endpoint metric is live: 8 workspaces report `state="ready"` and 1 reports `state="not-ready"`. Only one replica emits the observation, so the rule aggregates the metric directly by `cluster,workspace`; it does not require both replicas to contribute.

Add `BhaiyaWorkspaceServiceNoReadyEndpoints` for `state="not-ready"` or `state="missing"` held for 10 minutes. The test fixture reproduces the motivating empty-EndpointSlice shape: a workspace Service remains observed but has no ready backend, and the rule fires after the hold.

Important limitation: the metric currently covers every non-terminal workspace and Bhaiya exports no per-workspace desired-running/serving signal. Idle or stopped workspaces can therefore match `not-ready`; this is warning-level backstop coverage, and the annotation/runbook requires confirming the workspace should be serving before escalation. It is not presented as a critical alert on not-ready alone. A future per-workspace intent metric can make this predicate selective.

The rule is loaded into the ConfigMap and all three Mimir loader containers, with regression fixtures for not-ready, missing, ready, and the 10-minute boundary.

Validation: focused Prometheus rule tests pass and `tools/check.sh` passes for all three clusters.