### PR TITLE
fix(velero): clear stale alerts for deleted schedules

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
@@ -12,6 +12,8 @@ tests:
     input_series:
       - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",schedule="media-config-backup"}'
         values: "-200000+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",phase="Enabled",paused="false"}'
+        values: "1+0x20"
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-backup-20260907060000"}'
         values: "100+0x20"
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-backup-20260906060000"}'
@@ -36,3 +38,17 @@ tests:
                 guard; it cannot detect a backup that completes while silently
                 missing data, and it also needs the Velero metric to remain
                 scrapeable.
+
+  # A deleted or paused Schedule must clear stale metrics from historical
+  # Backup objects. Otherwise this alert becomes a permanent orphaned
+  # incident after workspace or schedule cleanup.
+  - interval: 1m
+    input_series:
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",schedule="deleted-schedule"}'
+        values: "-200000+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="deleted-schedule",backup="deleted-schedule-20260907020000"}'
+        values: "100+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroBackupStale
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
@@ -66,6 +66,16 @@ groups:
           (
             velero_schedule_latest_backup_created_timestamp > bool 0
           )
+          and on (cluster, namespace, schedule)
+          (
+            max by (cluster, namespace, schedule) (
+              velero_cr_schedule_info{
+                namespace="velero-system",
+                phase="Enabled",
+                paused!="true"
+              }
+            )
+          )
           > 0
         for: 15m
         labels:
@@ -80,7 +90,9 @@ groups:
             it cannot detect a backup that completes while silently missing
             data, and it also needs the Velero metric to remain scrapeable.
 
-      # VeleroBackupStale requires a last_successful_timestamp series. A Schedule
+      # VeleroBackupStale requires a last_successful_timestamp series and a
+      # currently enabled, unpaused Schedule. A historical Backup metric must
+      # not keep an alert alive after its Schedule is deleted or paused. A Schedule
       # that is Enabled but has never produced a Backup (forgejo-backup after
       # #2732 had status.lastBackup unset) creates no such series and stays
       # invisible. Page from the Schedule CR once it is older than 36h without


### PR DESCRIPTION
## Why

VeleroBackupStale remained critical for the deleted `bhaiya-tailscale-engineering` schedule after the live Schedule was garbage-collected. The rule joined historical backup metrics and the latest-backup recording rule, but never required the Schedule to still exist.

## Change

Require a current `velero_cr_schedule_info` series with `phase="Enabled"` and `paused!="true"` before firing `VeleroBackupStale`. Historical Backup metrics can no longer keep an orphaned or paused schedule alert alive.

Added a regression fixture proving a deleted schedule with stale historical metrics produces no alert. The existing positive fixture now includes the required live Schedule series.

## Evidence

- Live `bhaiya-tailscale-engineering` Schedule was absent.
- It was not declared in current `main`, so Flux cannot recreate it.
- The stale alert still exposed backup `bhaiya-tailscale-engineering-20260907020000`.
- `tools/check.sh talos-ottawa` passed.
- The focused rule test could not run locally because `promtool` is not installed in this workspace; CI has the required tool.