### PR TITLE
feat(monitoring): detect incomplete Mimir rule sync

### DIFF
--- a/docs/agent-knowledge/alert-coverage-audit-20260908.md
+++ b/docs/agent-knowledge/alert-coverage-audit-20260908.md
@@ -1,0 +1,55 @@
+# Alert coverage replay — 2026-09-08
+
+This is a read-only replay of existing Bhaiya and infrastructure alerts against
+the incidents that motivated them. No alert rules were changed.
+
+## Results
+
+| Alert | Result | Evidence and qualification |
+| --- | --- | --- |
+| `KubernetesJobFailedRecently` | **Can fire** | The current #2833 predicate uses `kube_job_status_failed` and recent start time. In the #2809-shaped Mimir-loader failure, `BackoffLimitExceeded` became true around 20:50 UTC and the expression would have fired around 20:55 with its five-minute `for`. The old #2828 predicate required series the failed Job did not expose. The positive fixture passes separately, but `job_failures_test.yaml` is not registered in the normal test runner. |
+| `VeleroScheduleVolumeCoverageRegressed` | **Can fire** | The 3-to-1 completed-run PVB fixture fires after its 15-minute `for`; the recording series exists in all three tenants. The alert is currently firing for the corresponding persistent under-selection shape. |
+| `VeleroPodVolumeBackupFailed` | **Can fire** | The positive `phase="Failed"` fixture fires, a newer success clears an older failure, and `phase="Canceled"` does not fire. A genuine Failed-PVB alert remains live in Robbinsdale. |
+| `GarageClusterUnhealthy` | **Would have fired** | `cluster_healthy == 0` held through the roughly four-and-a-half-hour #725 incident, well beyond its 15-minute `for`; seven-day history also shows the alert firing in Ottawa and Robbinsdale. This is a historical replay, not a unit-tested result: `garage_test.yaml` has no fixture for this exact alert, and St. Petersburg history was unavailable because of a Mimir store-consistency block. |
+| `BhaiyaSSHSessionTerminationErrors` | **Cannot fire for #661** | The live public-path drops exposed `cause="client"` and `reason="connection_closed"`. The rule requires transport/error signals, so its predicate was false and its timer never started. |
+| `BhaiyaSSHUnexpectedDisconnect` | **Cannot fire for #661** | The legacy rule likewise requires `bhaiya_ssh_session_disconnects_total{cause="transport"}` or terminal/error reasons. The same live drops had no transport increase, so this predicate was also false. |
+
+The SSH result is a real coverage blind spot, not a missing metric name. Bhaiya
+SSH metrics exist in Ottawa; the issue is that the current raw termination
+telemetry does not classify an abortive public-path reset.
+
+## The #808 dependency
+
+Do **not** repair the SSH rules by matching `client_close` or
+`reason="connection_closed"` directly. A normal clean user disconnect produces
+the same raw close class. Such a widened rule would alert on ordinary session
+ends and become noise immediately.
+
+The safe predicate already identified during #661 is classified, not raw:
+
+```text
+termination_reason = client_close
+AND transport_close_source = read_eof
+AND gateway_to_client_bytes >= 500,000
+AND since_last_gateway_byte_ms <= 100
+```
+
+It must be emitted once per transport, with trusted route attribution and a
+bounded metric label set. The required classified counter does not exist today.
+That makes corp/bhaiya **#808**—trusted Envoy-to-bhaiya connection identity and
+route propagation—the prerequisite for these SSH alerts to detect #661 at all,
+not merely an observability convenience. #808 supplies the join and trusted
+route boundary needed to emit the classification honestly; only then should a
+Mimir predicate be built around it. Tailscale remains a known workaround, not
+the proposed solution to the public-path failure.
+
+## Verification notes
+
+- Pinned Prometheus 3.14.0 passed the Mimir PromQL and rule-loader checks.
+- The existing rule-test runner passed; `job_failures_test.yaml` also passes
+  when invoked directly but is not included by that runner.
+- No rule, loader, namespace, or kustomization files were modified for this
+  audit.
+
+References: corp/bhaiya #808 (instrumentation prerequisite) and #661 (live
+public-path failure).

--- a/docs/agent-knowledge/alert-coverage-audit-20260908.md
+++ b/docs/agent-knowledge/alert-coverage-audit-20260908.md
@@ -18,6 +18,154 @@ The SSH result is a real coverage blind spot, not a missing metric name. Bhaiya
 SSH metrics exist in Ottawa; the issue is that the current raw termination
 telemetry does not classify an abortive public-path reset.
 
+## Stopped-delivery replay: Woodpecker #797
+
+The push-to-main outage was also a coverage blind spot, but the precise claim
+is **zero direct delivery-path coverage**, not literally zero related signal.
+Pipeline 3237 (#799) succeeded at 06:26 UTC. Pipeline 3240 (#797) entered
+Woodpecker `error` at 06:40 UTC with `event=push` and no workflows or steps;
+the missing `woodpecker_ci_token` was therefore a scheduler/admission error
+before any step-level failure could be exported. Every observed push pipeline
+after that also entered `error`, while pull-request pipelines continued to
+pass. Pipeline 3303 later succeeded after #825, but that recovery does not
+change what could have detected the outage.
+
+The all-tenant Mimir sweep found:
+
+- no Woodpecker, CI, or pipeline alert rule;
+- no Woodpecker/CI exporter, ServiceMonitor, public metrics series, or
+  `woodpecker_pipeline_status`/`ci_pipeline_status` series in Ottawa,
+  Robbinsdale, or St. Petersburg; and
+- no `bhaiya_workspace_image_release_status` series during the incident
+  window. That observer's series first appeared in Ottawa after recovery,
+  around 11:24 UTC, and no corresponding ruler alert exists yet.
+
+### Currency did not mean “last successful deploy”
+
+`bhaiya_deployment_currency_status` is not a last-successful-deploy gauge. The
+implementation compares the running binary's immutable source SHA with
+Forgejo's effective `main` SHA, skipping the bounded set of bookkeeping
+commits. The deployed binary can therefore equal the last successful release
+and still be reported `behind` when `main` advances.
+
+In the incident window, Ottawa had two `status="behind"` series at 05:30,
+05:51, 06:26, and 06:40 UTC. `BhaiyaDeploymentCurrencyStale` had an active
+timer beginning at 05:51:44 UTC and a 75-minute hold, so it was an older
+source/deployed divergence that would have become firing around 07:06—not a
+new transition caused by the first failed push at 06:40. It could have told an
+operator that the control plane was stale, but it could not identify or time
+the stopped Woodpecker path. If the baseline had been current before the
+outage, this broad guard could eventually have noticed main moving ahead; it
+is not a direct pipeline-status detector.
+
+The same rule is loaded in all three tenants, but only Ottawa has Bhaiya
+currency samples. Robbinsdale and St. Petersburg had no
+`bhaiya_deployment_currency_status` series and no firing currency alert.
+
+### Workspace-image and Flux signals
+
+`BhaiyaWorkspaceImageAdoptionStale` was a delayed downstream signal in
+Ottawa. At 06:40 the queued image was `0.3.295`, published and matching the
+template; by 08:11 the queued `0.3.296` was missing and unknown. Its 75-minute
+hold made it actionable around 09:27, long after the pipeline admission error,
+and it says nothing about ordinary main pushes that do not affect the
+workspace image. `BhaiyaWorkspaceImagePublicationStale` did not represent the
+initial failure because its intended version still had a published registry
+probe.
+
+Flux was silent for the affected Ottawa path: `kubernetes-apps` was
+`ReconciliationSucceeded` at both 06:26 and 06:40. St. Petersburg was also
+ready. Robbinsdale had unrelated Garage dependency churn (`Unknown` /
+`Progressing`) at those samples, not a Woodpecker delivery symptom, and the
+`FluxKustomizationNotReady` predicate only matches `ready="False"` anyway.
+Flux cannot observe a push workflow that fails before a new Git revision
+reaches it.
+
+The honest fleet-level conclusion is therefore: **no alert would have directly
+detected “push-to-main pipelines are failing before execution.”** The fleet
+had a broad, already-stale currency warning in Ottawa and a later
+workspace-image consequence, but zero discriminating coverage for a stopped
+delivery path. The incident was found by manually checking Woodpecker. This is
+the same failure pattern as the SSH pair above: an apparently relevant signal
+exists, but its predicate does not represent the incident that operators need
+to catch.
+
+## End-state snapshot — 2026-09-08 11:48 UTC
+
+A fresh Mimir sweep across all three tenants found 24 firing instances, or 21
+after excluding one `Watchdog` per tenant. That is below the fleet's earlier
+mid-30s count. The per-tenant baseline was:
+
+| Tenant | Firing instances | Excluding `Watchdog` | What was firing |
+| --- | ---: | ---: | --- |
+| Ottawa | 8 | 7 | `ProbeFailed` (JetKVM); `FluxKustomizationNotReady` (`kopiur-velero-home-restore-proof-target`); `KubeAPIErrorsHigh` (APPLY restores); `VeleroScheduleLatestBackupHasWarnings` (`media-config-backup`); `VeleroScheduleLatestBackupMissingVolumes` (`hermes-backup`, `bhaiya-tailscale-engineering`); `VeleroScheduleVolumeCoverageRegressed` (`bhaiya-backup`); `Watchdog` |
+| Robbinsdale | 10 | 9 | `SmartDeviceHighTemperature`; `SmartDeviceTestFailed` (3 instances); `VeleroBackupStale` (`media-config-backup`); `VeleroPodVolumeBackupFailed` (`kometa-29814120-jdtzq/config`); `VeleroScheduleLastBackupFailed` (`media-config-backup`); `VeleroScheduleLatestBackupHasWarnings` (`media-config-backup`); `VeleroScheduleVolumeCoverageRegressed` (`home-backup`); `Watchdog` |
+| St. Petersburg | 6 | 5 | `NodeHighMemoryUsage` (`192.168.73.248`); `NodeSchedulableMemoryHeadroomLow` (`orin-0`); `StPetersburgSparkMemoryAvailableLow` (`192.168.73.206`); `VeleroScheduleLatestBackupHasWarnings` (`home-assistant-backup`); `VeleroScheduleLatestBackupMissingVolumes` (`home-assistant-backup`); `Watchdog` |
+
+No newly added alert was firing on healthy state. The new
+`StPetersburgSparkMemoryAvailableLow` instance is a true positive: about 3.0
+GiB is available out of 128.5 GiB, inside its intended 2–8 GiB warning band.
+The new `BhaiyaWorkspaceServiceNoReadyEndpoints` alert was not firing and had
+neither `not-ready` nor `missing` series; that is currently an observability
+gap because the collector could not read `discovery/v1` EndpointSlices. #830
+fixes the scheme and is in CI, so this alert needs a follow-up once real
+endpoint data begins to populate. No rollback or Woodpecker alert was firing.
+The St. Petersburg `NodeHighMemoryUsage` condition was also genuine at about
+93% use, not a newly introduced false positive.
+
+The known accumulator remained live: both Ottawa
+`VeleroScheduleLatestBackupMissingVolumes` instances were still active from
+2026-09-07 23:58 UTC for the same deleted-schedule Backup records
+(`hermes-backup-20260907070001` and
+`bhaiya-tailscale-engineering-20260907020000`). Its fix is still queued in
+cos-hostclaims' batched rules PR, gated on #830 and endpoint-series
+population. This is queued work, not a cleared signal.
+
+## Implemented: detect an incomplete successful rule sync
+
+The loader's two existing alerts cover a failed Job and a loader that has gone
+stale. They do not cover the more deceptive case from km#2809: the loader Job
+completes successfully, but a declared rule file or group is omitted from the
+sync, so the ruler is healthy while the intended alert is absent. This is a
+failure that produces success.
+
+The detector is now a dedicated monitoring Deployment outside the Mimir loader
+Kustomization. For each tenant it compares the expected `file/namespace` plus
+group-name set in `expected-groups.tsv` with the live Mimir ruler API. A
+declared group missing from the ruler is the km#2809 signature. Missing groups
+are sent directly to Alertmanager as `MimirRuleGroupIncomplete`; group names
+remain annotation data, not unbounded labels. Ruler API failures have a
+separate `MimirRuleCompletenessCheckerFailed` alert.
+
+The expected set is intentionally independent from the loader's
+`mimir-rules.files` list. `tools/check-mimir-rules.sh` verifies it against every
+rule source on disk, so a file omitted from the loader still remains expected
+at runtime. The checker queries all three tenant IDs and does not alert on
+extra live groups, which can be an intentional branch/live-version difference.
+
+The bootstrap boundary is explicit: the checker is delivered by the Ottawa
+monitoring app, not as a Mimir rule or loader container, and it posts directly
+to Alertmanager. Its own presence therefore does not depend on the rule group
+whose completeness it checks.
+
+### km#2809 replay and timing
+
+The committed replay constructs a successful ruler response containing every
+declared group except `bhaiya-workspace-image/bhaiya-workspace-image.rules`.
+The same parser and set comparison used by the checker reports that group as
+missing and would fire `MimirRuleGroupIncomplete`; the test passes. A read-only
+live run found no missing expected groups in any tenant. It did initially log
+`stpetersburg-memory` as an extra because the live ruler had received that
+group before the rule source was present on this branch; the current source
+and expected set now include it.
+
+`MISSING_GROUP_GRACE_SECONDS=300` is **5 minutes**. There is no downstream
+Mimir `for:` because the checker posts directly to Alertmanager: `for=0m`.
+With the 60-second poll interval, detection is 5–6 minutes after the omission;
+Alertmanager's configured 1-minute `group_wait` makes worst-case notification
+delay 7 minutes. That is the real end-to-end number next to the constant, not
+an unstated grace-plus-`for` total like #807's 15m + 10m = 25m.
+
 ## The #808 dependency
 
 Do **not** repair the SSH rules by matching `client_close` or

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -28,10 +28,10 @@ diagram in the [README](../../README.md#architecture).
 
 | Location | Talos machines | Pointer directories | Flux Kustomizations |
 |---|---:|---:|---:|
-| `ottawa` | 4 | 62 | 125 |
+| `ottawa` | 4 | 62 | 126 |
 | `robbinsdale` | 3 | 43 | 87 |
 | `stpetersburg` | 3 | 41 | 84 |
-| **total** | **10** | **146** | **296** |
+| **total** | **10** | **146** | **297** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -102,7 +102,7 @@ diagram in the [README](../../README.md#architecture).
 | Observability | `fluent-bit` | `fluent-bit` |
 | Observability | `gatus` | `gatus` |
 | Observability | `mimir` | `mimir` |
-| Observability | `monitoring` | `blackbox-exporter`, `blackbox-exporter-config`, `blackbox-exporter-ottawa`, `config`, `grafana`, `grafana-dashboards`, `grafana-datasources`, `grafana-instance`, `grafana-mcp`, `kromgo`, `monitoring`, `monitoring-nagato`, `smartctl-exporter`, `smartctl-exporter-config`, `unpoller` |
+| Observability | `monitoring` | `blackbox-exporter`, `blackbox-exporter-config`, `blackbox-exporter-ottawa`, `config`, `grafana`, `grafana-dashboards`, `grafana-datasources`, `grafana-instance`, `grafana-mcp`, `kromgo`, `mimir-rule-completeness`, `monitoring`, `monitoring-nagato`, `smartctl-exporter`, `smartctl-exporter-config`, `unpoller` |
 | Observability | `opencost` | `opencost` |
 | Observability | `victoria-logs` | `victoria-logs` → ns `monitoring` |
 | Certificates and secrets | `cert-manager` | `cert-manager`, `cert-manager-common-issuers` |

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/deployment.yaml
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-rule-completeness
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir-rule-completeness
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir-rule-completeness
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: checker
+          image: python:3.14-alpine@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc
+          imagePullPolicy: IfNotPresent
+          command: [python3, /scripts/rule_completeness.py]
+          env:
+            - name: MIMIR_RULES_URL
+              value: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus/api/v1/rules?type=alert
+            - name: ALERTMANAGER_URL
+              value: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093/api/v2/alerts
+            - name: CHECKER_CLUSTER
+              value: talos-ottawa
+            - name: TENANTS
+              value: talos-ottawa,talos-robbinsdale,talos-stpetersburg
+            - name: POLL_INTERVAL_SECONDS
+              value: "60"
+            # 300s grace + no downstream Mimir `for` (the checker posts
+            # directly to Alertmanager) = 5m after first observation, or 6m
+            # worst-case including the 60s poll interval. Alertmanager's
+            # configured 1m group_wait makes the worst notification delay 7m.
+            - name: MISSING_GROUP_GRACE_SECONDS
+              value: "300"
+            - name: ALERT_TTL_SECONDS
+              value: "180"
+            - name: HTTP_TIMEOUT_SECONDS
+              value: "10"
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: scripts
+          configMap:
+            name: mimir-rule-completeness
+            defaultMode: 0555

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/expected-groups.tsv
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/expected-groups.tsv
@@ -1,0 +1,52 @@
+# Mimir ruler identity: file/namespace<TAB>group name.
+# Keep this independent from the loader's mimir-rules.files list. The
+# check-mimir-rules gate verifies it against every rule source on disk so a
+# file omitted from the loader still remains an expected live group.
+bhaiya-model	bhaiya-model.rules
+bhaiya-provider-provisioning	bhaiya.provider-fence
+bhaiya-provider-provisioning	bhaiya.workspace-provisioning
+bhaiya-reconciler	bhaiya-reconciler.rules
+bhaiya-sandbox-telemetry	bhaiya-sandbox-telemetry.rules
+bhaiya-ssh	bhaiya-ssh.rules
+bhaiya-velero-coverage	bhaiya-velero-coverage.rules
+bhaiya-workspace-endpoints	bhaiya-workspace-endpoints.rules
+bhaiya-workspace-image	bhaiya-workspace-image.rules
+bhaiya-fleet	bhaiya.fleet.availability
+bhaiya-fleet	bhaiya.fleet.ssh
+bhaiya-fleet	bhaiya.fleet.release
+bhaiya-fleet	bhaiya.fleet.resources
+bhaiya-fleet	bhaiya.postgresql
+bhaiya-fleet	bhaiya.opencost
+blackbox	blackbox-exporter.rules
+ceph	ceph.rules
+ceph	bhaiya-sandbox.rules
+cnpg-backup-coverage	cnpg-backup-coverage.rules
+flux	flux-instance.rules
+garage	garage.rules
+job-failures	kubernetes.jobs.rules
+k8gb-dns	k8gb-dns.rules
+k8gb	k8gb.rules
+media	media.rules
+mimir-loader	mimir-rule-loader.rules
+mimir-queryable-window	mimir.queryable-window
+monitoring	container.rules
+monitoring	kata-virtiofs.rules
+monitoring	node.rules
+monitoring	gpu.rules
+monitoring	packet-loss.rules
+monitoring	kubernetes.rules
+monitoring	dockerhub.rules
+monitoring	prometheus.rules
+monitoring	kubelet.rules
+monitoring	watchdog.rules
+node-clock	node-clock.rules
+node-health	node-health.rules
+bhaiya	bhaiya.payments
+smartctl	smartctl-exporter.rules
+stpetersburg-memory	stpetersburg-memory.rules
+velero-integrity	velero-integrity.rules
+velero-node-saturation	velero-node-saturation.rules
+velero-restore-admission	velero.restore-admission.rules
+velero-volume-progress	velero.volume-progress.rules
+velero-backups	velero-backups.rules
+zot	zot.rules

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/kustomization.yaml
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - deployment.yaml
+configMapGenerator:
+  - name: mimir-rule-completeness
+    files:
+      - rule_completeness.py
+      - expected-groups.tsv

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/rule_completeness.py
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/rule_completeness.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Compare the GitOps-declared Mimir rule groups with the live ruler.
+
+This process deliberately runs outside the Mimir rules loader.  It sends its
+own alerts to Alertmanager so an incomplete loader sync cannot also remove the
+rule that would report the incompleteness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_TENANTS = (
+    "talos-ottawa",
+    "talos-robbinsdale",
+    "talos-stpetersburg",
+)
+DEFAULT_EXPECTED_PATH = "/scripts/expected-groups.tsv"
+DEFAULT_MIMIR_RULES_URL = (
+    "http://mimir-gateway.mimir.svc.cluster.local:8080"
+    "/prometheus/api/v1/rules?type=alert"
+)
+DEFAULT_ALERTMANAGER_URL = (
+    "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093"
+    "/api/v2/alerts"
+)
+
+
+class CheckError(RuntimeError):
+    """The live ruler response could not be checked safely."""
+
+
+def now_utc() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def timestamp(value: dt.datetime) -> str:
+    return value.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def load_expected(path: Path) -> set[tuple[str, str]]:
+    expected: set[tuple[str, str]] = set()
+    for line_number, raw_line in enumerate(path.read_text().splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = raw_line.split("\t")
+        if len(fields) != 2 or not all(field.strip() for field in fields):
+            raise CheckError(
+                f"{path}:{line_number}: expected namespace<TAB>group"
+            )
+        identity = (fields[0].strip(), fields[1].strip())
+        if identity in expected:
+            raise CheckError(f"{path}:{line_number}: duplicate group {identity!r}")
+        expected.add(identity)
+    if not expected:
+        raise CheckError(f"{path}: expected at least one rule group")
+    return expected
+
+
+def ruler_groups(payload: dict) -> set[tuple[str, str]]:
+    if payload.get("status") != "success":
+        raise CheckError(f"ruler API returned {payload.get('status')!r}")
+    groups = payload.get("data", {}).get("groups")
+    if not isinstance(groups, list):
+        raise CheckError("ruler API response has no data.groups list")
+
+    actual: set[tuple[str, str]] = set()
+    for group in groups:
+        if not isinstance(group, dict):
+            raise CheckError("ruler API returned a non-object rule group")
+        namespace = group.get("file")
+        name = group.get("name")
+        if not isinstance(namespace, str) or not namespace:
+            raise CheckError("ruler API returned a group without file")
+        if not isinstance(name, str) or not name:
+            raise CheckError("ruler API returned a group without name")
+        actual.add((namespace, name))
+    return actual
+
+
+def compare_groups(
+    expected: set[tuple[str, str]], actual: set[tuple[str, str]]
+) -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
+    """Return (missing, unexpected) without treating a partial set as healthy."""
+
+    return expected - actual, actual - expected
+
+
+def get_ruler_groups(url: str, tenant: str, timeout: float) -> set[tuple[str, str]]:
+    request = Request(
+        url,
+        headers={"Accept": "application/json", "X-Scope-OrgID": tenant},
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.load(response)
+    except (HTTPError, URLError, TimeoutError, OSError, ValueError) as error:
+        raise CheckError(f"ruler query failed: {error}") from error
+    if not isinstance(payload, dict):
+        raise CheckError("ruler API returned a non-object JSON response")
+    return ruler_groups(payload)
+
+
+def alert_payload(
+    alertname: str,
+    tenant: str,
+    summary: str,
+    description: str,
+    starts_at: dt.datetime,
+    ends_at: dt.datetime,
+    cluster: str,
+) -> dict:
+    return {
+        "labels": {
+            "alertname": alertname,
+            "cluster": cluster,
+            "job": "mimir-rule-completeness",
+            "severity": "critical",
+            "tenant": tenant,
+        },
+        "annotations": {
+            "summary": summary,
+            "description": description,
+        },
+        "startsAt": timestamp(starts_at),
+        "endsAt": timestamp(ends_at),
+    }
+
+
+def send_alerts(
+    alerts: list[dict],
+    url: str,
+    timeout: float,
+    dry_run: bool,
+) -> None:
+    if not alerts:
+        return
+    if dry_run:
+        for alert in alerts:
+            print(json.dumps(alert, sort_keys=True))
+        return
+    request = Request(
+        url,
+        data=json.dumps(alerts).encode("utf-8"),
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            response.read()
+    except (HTTPError, URLError, TimeoutError, OSError) as error:
+        raise CheckError(f"Alertmanager notification failed: {error}") from error
+
+
+def fixture_payload(path: Path, tenant: str) -> dict:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise CheckError(f"fixture could not be read: {error}") from error
+    if isinstance(payload, dict) and "status" in payload:
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get(tenant), dict):
+        return payload[tenant]
+    raise CheckError(f"fixture has no ruler response for {tenant}")
+
+
+def replay_fixture(expected_path: Path, fixture_path: Path, tenant: str) -> int:
+    expected = load_expected(expected_path)
+    actual = ruler_groups(fixture_payload(fixture_path, tenant))
+    missing, unexpected = compare_groups(expected, actual)
+    print(f"tenant={tenant} expected_groups={len(expected)} actual_groups={len(actual)}")
+    print("missing=" + ",".join(sorted(f"{namespace}/{name}" for namespace, name in missing)))
+    print(
+        "unexpected="
+        + ",".join(sorted(f"{namespace}/{name}" for namespace, name in unexpected))
+    )
+    if missing:
+        print("DETECTOR WOULD FIRE: declared group set is incomplete")
+        return 1
+    print("DETECTOR WOULD NOT FIRE: declared group set is complete")
+    return 0
+
+
+def run_loop(args: argparse.Namespace, expected: set[tuple[str, str]]) -> int:
+    tenants = tuple(
+        tenant.strip()
+        for tenant in args.tenants.split(",")
+        if tenant.strip()
+    )
+    if not tenants:
+        raise CheckError("TENANTS must contain at least one tenant")
+
+    missing_since: dict[str, dt.datetime] = {}
+    firing_since: dict[str, dt.datetime] = {}
+    last_missing: dict[str, set[tuple[str, str]]] = {}
+    error_since: dict[str, dt.datetime] = {}
+    error_firing_since: dict[str, dt.datetime] = {}
+
+    while True:
+        current = now_utc()
+        alerts: list[dict] = []
+        for tenant in tenants:
+            try:
+                actual = get_ruler_groups(args.mimir_rules_url, tenant, args.timeout)
+            except CheckError as error:
+                print(f"tenant={tenant} check failed: {error}", file=sys.stderr)
+                error_since.setdefault(tenant, current)
+                if (
+                    current - error_since[tenant]
+                ).total_seconds() >= args.grace_seconds:
+                    error_firing_since.setdefault(tenant, error_since[tenant])
+                    alerts.append(
+                        alert_payload(
+                            "MimirRuleCompletenessCheckerFailed",
+                            tenant,
+                            f"Mimir rule completeness check failed for {tenant}",
+                            f"The live ruler group set could not be checked: {error}",
+                            error_firing_since[tenant],
+                            current + dt.timedelta(seconds=args.alert_ttl_seconds),
+                            args.cluster,
+                        )
+                    )
+                if tenant in firing_since and tenant in last_missing:
+                    alerts.append(
+                        alert_payload(
+                            "MimirRuleGroupIncomplete",
+                            tenant,
+                            f"Mimir rule group set remains incomplete for {tenant}",
+                            "The last successful comparison was missing: "
+                            + ", ".join(
+                                f"{namespace}/{name}"
+                                for namespace, name in sorted(last_missing[tenant])
+                            ),
+                            firing_since[tenant],
+                            current + dt.timedelta(seconds=args.alert_ttl_seconds),
+                            args.cluster,
+                        )
+                    )
+                continue
+
+            if tenant in error_firing_since:
+                alerts.append(
+                    alert_payload(
+                        "MimirRuleCompletenessCheckerFailed",
+                        tenant,
+                        f"Mimir rule completeness check recovered for {tenant}",
+                        "The ruler API is responding again.",
+                        error_firing_since.pop(tenant),
+                        current,
+                        args.cluster,
+                    )
+                )
+            error_since.pop(tenant, None)
+
+            missing, unexpected = compare_groups(expected, actual)
+            if unexpected:
+                print(
+                    f"tenant={tenant} unexpected groups: "
+                    + ", ".join(f"{namespace}/{name}" for namespace, name in sorted(unexpected)),
+                    file=sys.stderr,
+                )
+            if missing:
+                missing_since.setdefault(tenant, current)
+                last_missing[tenant] = missing
+                if (
+                    current - missing_since[tenant]
+                ).total_seconds() >= args.grace_seconds:
+                    firing_since.setdefault(tenant, missing_since[tenant])
+                    alerts.append(
+                        alert_payload(
+                            "MimirRuleGroupIncomplete",
+                            tenant,
+                            f"Mimir rule group set incomplete for {tenant}",
+                            "The ruler is missing declared group(s): "
+                            + ", ".join(
+                                f"{namespace}/{name}" for namespace, name in sorted(missing)
+                            ),
+                            firing_since[tenant],
+                            current + dt.timedelta(seconds=args.alert_ttl_seconds),
+                            args.cluster,
+                        )
+                    )
+            elif tenant in firing_since:
+                alerts.append(
+                    alert_payload(
+                        "MimirRuleGroupIncomplete",
+                        tenant,
+                        f"Mimir rule group set recovered for {tenant}",
+                        "The live ruler now contains every declared rule group.",
+                        firing_since.pop(tenant),
+                        current,
+                        args.cluster,
+                    )
+                )
+                missing_since.pop(tenant, None)
+                last_missing.pop(tenant, None)
+            else:
+                missing_since.pop(tenant, None)
+                last_missing.pop(tenant, None)
+
+        try:
+            send_alerts(alerts, args.alertmanager_url, args.timeout, args.dry_run)
+        except CheckError as error:
+            print(str(error), file=sys.stderr)
+
+        if args.once:
+            return 0
+        time.sleep(args.poll_seconds)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--expected",
+        default=os.environ.get("EXPECTED_GROUPS_PATH", DEFAULT_EXPECTED_PATH),
+        type=Path,
+    )
+    parser.add_argument(
+        "--actual-json",
+        type=Path,
+        help="replay one ruler API response instead of querying the live API",
+    )
+    parser.add_argument("--tenant", default="talos-ottawa")
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--mimir-rules-url",
+        default=os.environ.get("MIMIR_RULES_URL", DEFAULT_MIMIR_RULES_URL),
+    )
+    parser.add_argument(
+        "--alertmanager-url",
+        default=os.environ.get("ALERTMANAGER_URL", DEFAULT_ALERTMANAGER_URL),
+    )
+    parser.add_argument(
+        "--tenants",
+        default=os.environ.get("TENANTS", ",".join(DEFAULT_TENANTS)),
+    )
+    parser.add_argument(
+        "--cluster",
+        default=os.environ.get("CHECKER_CLUSTER", "talos-ottawa"),
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=float(os.environ.get("POLL_INTERVAL_SECONDS", "60")),
+    )
+    parser.add_argument(
+        "--grace-seconds",
+        type=float,
+        default=float(os.environ.get("MISSING_GROUP_GRACE_SECONDS", "300")),
+    )
+    parser.add_argument(
+        "--alert-ttl-seconds",
+        type=float,
+        default=float(os.environ.get("ALERT_TTL_SECONDS", "180")),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("HTTP_TIMEOUT_SECONDS", "10")),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        expected = load_expected(args.expected)
+        if args.actual_json:
+            return replay_fixture(args.expected, args.actual_json, args.tenant)
+        return run_loop(args, expected)
+    except (CheckError, OSError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/tests/test_rule_completeness.py
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/tests/test_rule_completeness.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Replay km#2809: a successful-looking ruler missing one declared group."""
+
+from pathlib import Path
+import sys
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from rule_completeness import compare_groups, load_expected, ruler_groups  # noqa: E402
+
+
+EXPECTED = SCRIPT_DIR / "expected-groups.tsv"
+
+
+def main() -> int:
+    expected = load_expected(EXPECTED)
+    omitted = ("bhaiya-workspace-image", "bhaiya-workspace-image.rules")
+
+    # This is the concrete km#2809 state: the live ruler returns every group
+    # except one file that remains declared by GitOps.
+    simulated_ruler = set(expected)
+    simulated_ruler.remove(omitted)
+    ruler_response = {
+        "status": "success",
+        "data": {
+            "groups": [
+                {"file": namespace, "name": name}
+                for namespace, name in sorted(simulated_ruler)
+            ]
+        },
+    }
+    parsed_ruler = ruler_groups(ruler_response)
+
+    missing, unexpected = compare_groups(expected, parsed_ruler)
+    assert missing == {omitted}, (missing, unexpected)
+    assert not unexpected, unexpected
+    print(
+        "✓ km#2809 replay: ruler omitted "
+        f"{omitted[0]}/{omitted[1]}; detector flags it"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kubernetes/apps/ottawa/monitoring/kustomization.yaml
+++ b/kubernetes/apps/ottawa/monitoring/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - ./grafana-mcp.yaml
   - ./kromgo.yaml
   - ./monitoring-nagato.yaml
+  - ./mimir-rule-completeness.yaml
   - ./smartctl-exporter.yaml
   - ./unpoller.yaml

--- a/kubernetes/apps/ottawa/monitoring/mimir-rule-completeness.yaml
+++ b/kubernetes/apps/ottawa/monitoring/mimir-rule-completeness.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mimir-rule-completeness
+  namespace: flux-system
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: mimir-rule-completeness
+  dependsOn:
+    - name: mimir
+    - name: monitoring
+    - name: config
+  path: ./kubernetes/apps/base/monitoring/mimir-rule-completeness
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/tools/check-mimir-rules.sh
+++ b/tools/check-mimir-rules.sh
@@ -32,6 +32,12 @@ MIMIR = ROOT / "kubernetes/apps/base/mimir/mimir-ottawa"
 RULES = MIMIR / "rules"
 KUSTOMIZATION = MIMIR / "kustomization.yaml"
 LOADER = MIMIR / "loader-job.yaml"
+TEST_RUNNER = RULES / "tests" / "run.sh"
+TEST_FIXTURES = RULES / "tests"
+EXPECTED_GROUPS = (
+    ROOT
+    / "kubernetes/apps/base/monitoring/mimir-rule-completeness/expected-groups.tsv"
+)
 TENANTS = {"rules-ottawa", "rules-robbinsdale", "rules-stpetersburg"}
 # media.yaml predates the per-file Mimir namespace convention and contains
 # cluster-independent groups. Keep that existing exception explicit so a newly
@@ -186,7 +192,11 @@ for name in sorted(missing_on_disk):
     fail(f"rules/{name}: listed in mimir-rules ConfigMap but missing from rules/")
 
 namespaces = {}
-for name in sorted(generator_files & on_disk):
+source_group_ids = set()
+# Derive the expected set from every rule source on disk, not only the files
+# currently listed in mimir-rules.files. That independence is what makes an
+# omitted loader entry visible to the completeness checker.
+for name in sorted(on_disk):
     path = RULES / name
     document = read_yaml(path)
     if not isinstance(document, dict):
@@ -203,8 +213,53 @@ for name in sorted(generator_files & on_disk):
         )
     else:
         namespaces[namespace] = str(path)
-    if not isinstance(document.get("groups"), list) or not document["groups"]:
+    groups = document.get("groups")
+    if not isinstance(groups, list) or not groups:
         fail(f"{path}: groups must be a non-empty list")
+        continue
+    effective_namespace = (
+        namespace.strip()
+        if isinstance(namespace, str) and namespace.strip()
+        else path.stem
+    )
+    for group in groups:
+        if not isinstance(group, dict) or not isinstance(group.get("name"), str):
+            fail(f"{path}: every group must have a non-empty name")
+            continue
+        group_id = (effective_namespace, group["name"].strip())
+        if not group_id[1]:
+            fail(f"{path}: every group must have a non-empty name")
+        elif group_id in source_group_ids:
+            fail(f"{path}: duplicate group identity {group_id!r}")
+        else:
+            source_group_ids.add(group_id)
+
+declared_group_ids = set()
+if not EXPECTED_GROUPS.is_file():
+    fail(f"{EXPECTED_GROUPS}: missing independent expected-group set")
+else:
+    for line_number, raw_line in enumerate(EXPECTED_GROUPS.read_text().splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = raw_line.split("\t")
+        if len(fields) != 2 or not all(field.strip() for field in fields):
+            fail(f"{EXPECTED_GROUPS}:{line_number}: expected namespace<TAB>group")
+            continue
+        group_id = (fields[0].strip(), fields[1].strip())
+        if group_id in declared_group_ids:
+            fail(f"{EXPECTED_GROUPS}:{line_number}: duplicate group {group_id!r}")
+        declared_group_ids.add(group_id)
+    for group_id in sorted(source_group_ids - declared_group_ids):
+        fail(
+            f"{EXPECTED_GROUPS}: source group {group_id!r} is absent from the "
+            "independent expected set"
+        )
+    for group_id in sorted(declared_group_ids - source_group_ids):
+        fail(
+            f"{EXPECTED_GROUPS}: expected group {group_id!r} has no source rule "
+            "group"
+        )
 
 loader = read_yaml(LOADER)
 containers = []
@@ -272,6 +327,67 @@ for container in containers:
         fail(f"{LOADER}: {name} does not load /rules/{rule}")
     for rule in sorted(extra):
         fail(f"{LOADER}: {name} loads unlisted /rules/{rule}")
+
+# The normal rule test runner intentionally covers a fixture-backed subset of
+# production files; requiring a fixture for every rule would change that
+# existing policy. Do, however, keep the subset internally complete: every
+# rule named by its loop must have a source file, a case mapping, and a fixture
+# that names the corresponding source. This catches a new rule being wired to
+# the loader but silently omitted from its own test registration.
+tested_rules = set()
+test_files = {}
+if not TEST_RUNNER.is_file():
+    fail(f"{TEST_RUNNER}: missing Mimir rule test runner")
+else:
+    test_runner_text = TEST_RUNNER.read_text()
+    loop = re.search(
+        r"(?m)^\s*for rule in\s+(.+?)\s*;\s*do\s*$", test_runner_text
+    )
+    if loop is None:
+        fail(f"{TEST_RUNNER}: cannot find the fixture test loop")
+    else:
+        tested_rules = set(loop.group(1).split())
+    for match in re.finditer(
+        r"(?m)^\s*([A-Za-z0-9][A-Za-z0-9_-]*)\)\s+"
+        r"test_file=([^\s;]+)\s*;;?\s*$",
+        test_runner_text,
+    ):
+        rule, filename = match.groups()
+        if rule in test_files:
+            fail(f"{TEST_RUNNER}: duplicate fixture mapping for {rule!r}")
+        test_files[rule] = filename
+    if 'promtool check rules "$tmpdir/${rule}.yaml"' not in test_runner_text:
+        fail(f"{TEST_RUNNER}: fixture loop does not check each rule file")
+    if 'promtool test rules "$tmpdir/$test_file"' not in test_runner_text:
+        fail(f"{TEST_RUNNER}: fixture loop does not run each rule fixture")
+
+for rule in sorted(tested_rules):
+    source = RULES / f"{rule}.yaml"
+    if not source.is_file():
+        fail(f"{TEST_RUNNER}: tested rule {rule!r} has no source file {source}")
+    filename = test_files.get(rule)
+    if filename is None:
+        fail(f"{TEST_RUNNER}: tested rule {rule!r} has no case fixture mapping")
+        continue
+    fixture = TEST_FIXTURES / filename
+    if not fixture.is_file():
+        fail(f"{TEST_RUNNER}: fixture for {rule!r} is missing: {fixture}")
+        continue
+    fixture_document = read_yaml(fixture)
+    fixture_rule_files = (
+        fixture_document.get("rule_files", [])
+        if isinstance(fixture_document, dict)
+        else []
+    )
+    expected_reference = f"../{rule}.yaml"
+    if expected_reference not in fixture_rule_files:
+        fail(
+            f"{fixture}: test for {rule!r} must reference "
+            f"{expected_reference!r}"
+        )
+
+for rule in sorted(set(test_files) - tested_rules):
+    fail(f"{TEST_RUNNER}: case fixture mapping for untested rule {rule!r}")
 
 required = {
     "bhaiya-sandbox-telemetry.yaml": "bhaiya-sandbox-telemetry",

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -391,6 +391,11 @@ aliasout="$(PATH="$mstub:$PATH" "$gate_root/tools/check.sh" ot 2>/dev/null)"
 assert "short cluster alias accepted"   grep -q '^✓ render OK: talos-ottawa$' <<<"$aliasout"
 rm -rf "$gate_root"
 
+# ---------------------------------------------------------------- Mimir rule completeness replay
+section "Mimir rule completeness replay"
+exits "km#2809 missing-group condition is detected" 0 \
+  python3 "$ROOT/kubernetes/apps/base/monitoring/mimir-rule-completeness/tests/test_rule_completeness.py"
+
 # A completed gate must reap every watchdog timer descendant. Use an isolated
 # temporary gate root so this test exercises the real run_capped implementation
 # without allowing a sleep stub to affect repository prerequisite checks.


### PR DESCRIPTION
## Summary

- Add an out-of-band `mimir-rule-completeness` Deployment in Ottawa that queries all three tenant ruler APIs and compares the live `(file/namespace, group)` set with the independently maintained GitOps expected set.
- Send `MimirRuleGroupIncomplete` and checker-failure notifications directly to Alertmanager, outside the Mimir loader and its rule files, so a successful-but-incomplete loader sync cannot remove its own detector.
- Record the km#2809 replay in the repository: a successful ruler response omitting `bhaiya-workspace-image/bhaiya-workspace-image.rules` is detected by the same parser and comparison used at runtime.
- Add CI checks for the expected source group set and the fixture-backed `rules/tests/run.sh` registration, alongside the existing ConfigMap and all-three-tenant loader checks.

## Timing and validation

- `MISSING_GROUP_GRACE_SECONDS=300` (5 minutes), 60-second polling, and no downstream Mimir `for:` (`for=0m`) means detection in 5–6 minutes after an omission.
- Alertmanager `group_wait=1m` makes the worst-case notification delay about 7 minutes.
- Passed `tools/check-mimir-rules.sh`, the km#2809 replay, `tools/check.sh ot`, `tools/check-diagram.sh`, `tools/gen-inventory.sh --check`, and `git diff --check`.
- The full helper suite reaches and passes the new replay but retains unrelated existing `check.sh` stub failures and times out in its existing watchdog section; those are recorded in the handoff.

This closes the km#2809 silent-omission gap without placing the completeness check inside the loader path.