### PR TITLE
fix(alerts): qualify Velero coverage regressions

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -249,7 +249,9 @@ tests:
       - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="home-backup-current",pod_volume_backup="home-current-pvb",node="rei",phase="Prepared"}'
         values: "1+0x20"
 
-      # A warning-bearing Completed run remains a separate integrity signal.
+      # A warning-bearing Completed run is still a usable volume-count
+      # baseline. The warning is a separate integrity signal; it must not make
+      # this per-schedule regression comparison silently disappear.
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-previous"}'
         values: "100+0x20"
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-current"}'
@@ -265,8 +267,58 @@ tests:
 
     alert_rule_test:
       - eval_time: 15m
-        alertname: VeleroScheduleExpectedVolumeDataMissing
-        exp_alerts: []
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: bhaiya-backup
+              backup: bhaiya-backup-current
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule bhaiya-backup volume coverage regressed
+              description: >-
+                The newest Backup bhaiya-backup-current for schedule
+                bhaiya-backup has fewer PodVolumeBackups than its previous
+                Completed baseline. Any lower PVB count is material because
+                each PVB represents one selected volume. This remains a
+                coverage regression even when Kubernetes item counts or the
+                parent Backup phase look normal. A warning-bearing Completed
+                Backup can still supply this count baseline; investigate its
+                warning separately. If no previous Completed baseline exists,
+                this alert is intentionally silent: that means no comparable
+                baseline, not proof of zero-volume health. Schedules that
+                never produce a successful nonzero-volume baseline require the
+                separate never/zero-volume coverage signal. Inspect the
+                current and previous Backup PVB populations; stalled-path and
+                node-saturation alerts are separate, and this alert is not
+                restore proof. It clears only when the newest run reaches the
+                prior baseline count.
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: velero-system
+              schedule: home-assistant-backup
+              backup: home-assistant-backup-current
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule home-assistant-backup volume coverage regressed
+              description: >-
+                The newest Backup home-assistant-backup-current for schedule
+                home-assistant-backup has fewer PodVolumeBackups than its
+                previous Completed baseline. Any lower PVB count is material
+                because each PVB represents one selected volume. This remains
+                a coverage regression even when Kubernetes item counts or the
+                parent Backup phase look normal. A warning-bearing Completed
+                Backup can still supply this count baseline; investigate its
+                warning separately. If no previous Completed baseline exists,
+                this alert is intentionally silent: that means no comparable
+                baseline, not proof of zero-volume health. Schedules that
+                never produce a successful nonzero-volume baseline require the
+                separate never/zero-volume coverage signal. Inspect the
+                current and previous Backup PVB populations; stalled-path and
+                node-saturation alerts are separate, and this alert is not
+                restore proof. It clears only when the newest run reaches the
+                prior baseline count.
 
   # A marked Schedule with completed zero-volume history must alert. The
   # unmarked Schedule is deliberately identical otherwise and remains out of
@@ -310,16 +362,19 @@ tests:
                 Completed Backup expected-empty-current has no Completed
                 PodVolumeBackup with bytesDone equal to totalBytes and greater
                 than zero. This absolute signal catches schedules whose first
-                and every subsequent run was metadata-only. Inspect the
-                Schedule's volume-selection contract and the Backup's PVB
-                children; phase and object replay do not establish volume
-                data. Schedules without the explicit marker are intentionally
-                out of scope. This is an absolute zero-volume guard and does
-                not infer an intended count from historical PVBs, because
-                Velero resource policies can intentionally change the selected
-                set. The condition begins with the Backup's creation time, not
-                when the alert first fires; use that timestamp when determining
-                how long coverage has been missing.
+                and every subsequent run was metadata-only, where the
+                relative rule has no volume-bearing baseline to compare. If
+                the shared relative coverage condition is active, that alert
+                owns the regression and this alert is suppressed to prevent
+                duplicate paging. Inspect the Schedule's volume-selection
+                contract and the Backup's PVB children; phase and object
+                replay do not establish volume data. Schedules without the
+                explicit marker are intentionally out of scope. This is a
+                zero-volume guard only: it cannot detect under-selection when
+                a run has a plausible nonzero count (for example, one PVB
+                when two volumes were expected). The relative coverage alert
+                catches a lower count only when a comparable prior baseline
+                exists; this rule does not infer expected counts.
 
   # A Completed PVB is evidence only when its progress is byte-positive and
   # complete. A real positive PVB clears the absolute expectation alert.
@@ -365,35 +420,58 @@ tests:
         values: "1234+0x20"
     alert_rule_test:
       - eval_time: 15m
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts: []
+      - eval_time: 15m
         alertname: VeleroScheduleExpectedVolumeDataMissing
         exp_alerts: []
 
-  # A deliberate resource-policy change may reduce the PVB count while the
-  # latest Backup still has byte-complete durable volume data. Historical PVB
-  # counts are not an intended-coverage contract, so this must not alert.
+  # When a prior Completed run has selected a volume and the current count
+  # drops, the relative rule owns the regression. The absolute rule must stay
+  # quiet so one schedule does not produce two coverage pages.
   - interval: 1m
     input_series:
-      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",phase="Enabled",paused="false",volume_data_required="true"}'
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",phase="Enabled",paused="false",volume_data_required="true"}'
         values: "1+0x20"
-      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-previous"}'
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-previous"}'
         values: "100+0x20"
-      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-current"}'
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-current"}'
         values: "200+0x20"
-      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-previous",phase="Completed"}'
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-previous",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-current",phase="Completed"}'
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-current",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-previous",pod_volume_backup="policy-change-old-1",node="asuka",phase="Completed"}'
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-regressed-previous",pod_volume_backup="expected-regressed-pvb",node="asuka",phase="Prepared"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-previous",pod_volume_backup="policy-change-old-2",node="asuka",phase="Completed"}'
-        values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-current",pod_volume_backup="policy-change-current-1",node="asuka",phase="Completed"}'
-        values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-current",pod_volume_backup="policy-change-current-1",node="asuka"}'
-        values: "1234+0x20"
-      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-current",pod_volume_backup="policy-change-current-1",node="asuka"}'
-        values: "1234+0x20"
     alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: expected-regressed
+              backup: expected-regressed-current
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule expected-regressed volume coverage regressed
+              description: >-
+                The newest Backup expected-regressed-current for schedule
+                expected-regressed has fewer PodVolumeBackups than its previous
+                Completed baseline. Any lower PVB count is material because
+                each PVB represents one selected volume. This remains a
+                coverage regression even when Kubernetes item counts or the
+                parent Backup phase look normal. A warning-bearing Completed
+                Backup can still supply this count baseline; investigate its
+                warning separately. If no previous Completed baseline exists,
+                this alert is intentionally silent: that means no comparable
+                baseline, not proof of zero-volume health. Schedules that
+                never produce a successful nonzero-volume baseline require the
+                separate never/zero-volume coverage signal. Inspect the
+                current and previous Backup PVB populations; stalled-path and
+                node-saturation alerts are separate, and this alert is not
+                restore proof. It clears only when the newest run reaches the
+                prior baseline count.
       - eval_time: 15m
         alertname: VeleroScheduleExpectedVolumeDataMissing
         exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -249,9 +249,7 @@ tests:
       - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="home-backup-current",pod_volume_backup="home-current-pvb",node="rei",phase="Prepared"}'
         values: "1+0x20"
 
-      # A warning-bearing Completed run is still a usable volume-count
-      # baseline. The warning is a separate integrity signal; it must not make
-      # this per-schedule regression comparison silently disappear.
+      # A warning-bearing Completed run remains a separate integrity signal.
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-previous"}'
         values: "100+0x20"
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-current"}'
@@ -267,58 +265,8 @@ tests:
 
     alert_rule_test:
       - eval_time: 15m
-        alertname: VeleroScheduleVolumeCoverageRegressed
-        exp_alerts:
-          - exp_labels:
-              cluster: talos-ottawa
-              namespace: velero-system
-              schedule: bhaiya-backup
-              backup: bhaiya-backup-current
-              severity: critical
-            exp_annotations:
-              summary: Velero schedule bhaiya-backup volume coverage regressed
-              description: >-
-                The newest Backup bhaiya-backup-current for schedule
-                bhaiya-backup has fewer PodVolumeBackups than its previous
-                Completed baseline. Any lower PVB count is material because
-                each PVB represents one selected volume. This remains a
-                coverage regression even when Kubernetes item counts or the
-                parent Backup phase look normal. A warning-bearing Completed
-                Backup can still supply this count baseline; investigate its
-                warning separately. If no previous Completed baseline exists,
-                this alert is intentionally silent: that means no comparable
-                baseline, not proof of zero-volume health. Schedules that
-                never produce a successful nonzero-volume baseline require the
-                separate never/zero-volume coverage signal. Inspect the
-                current and previous Backup PVB populations; stalled-path and
-                node-saturation alerts are separate, and this alert is not
-                restore proof. It clears only when the newest run reaches the
-                prior baseline count.
-          - exp_labels:
-              cluster: talos-stpetersburg
-              namespace: velero-system
-              schedule: home-assistant-backup
-              backup: home-assistant-backup-current
-              severity: critical
-            exp_annotations:
-              summary: Velero schedule home-assistant-backup volume coverage regressed
-              description: >-
-                The newest Backup home-assistant-backup-current for schedule
-                home-assistant-backup has fewer PodVolumeBackups than its
-                previous Completed baseline. Any lower PVB count is material
-                because each PVB represents one selected volume. This remains
-                a coverage regression even when Kubernetes item counts or the
-                parent Backup phase look normal. A warning-bearing Completed
-                Backup can still supply this count baseline; investigate its
-                warning separately. If no previous Completed baseline exists,
-                this alert is intentionally silent: that means no comparable
-                baseline, not proof of zero-volume health. Schedules that
-                never produce a successful nonzero-volume baseline require the
-                separate never/zero-volume coverage signal. Inspect the
-                current and previous Backup PVB populations; stalled-path and
-                node-saturation alerts are separate, and this alert is not
-                restore proof. It clears only when the newest run reaches the
-                prior baseline count.
+        alertname: VeleroScheduleExpectedVolumeDataMissing
+        exp_alerts: []
 
   # A marked Schedule with completed zero-volume history must alert. The
   # unmarked Schedule is deliberately identical otherwise and remains out of
@@ -362,19 +310,16 @@ tests:
                 Completed Backup expected-empty-current has no Completed
                 PodVolumeBackup with bytesDone equal to totalBytes and greater
                 than zero. This absolute signal catches schedules whose first
-                and every subsequent run was metadata-only, where the
-                relative rule has no volume-bearing baseline to compare. If
-                the shared relative coverage condition is active, that alert
-                owns the regression and this alert is suppressed to prevent
-                duplicate paging. Inspect the Schedule's volume-selection
-                contract and the Backup's PVB children; phase and object
-                replay do not establish volume data. Schedules without the
-                explicit marker are intentionally out of scope. This is a
-                zero-volume guard only: it cannot detect under-selection when
-                a run has a plausible nonzero count (for example, one PVB
-                when two volumes were expected). The relative coverage alert
-                catches a lower count only when a comparable prior baseline
-                exists; this rule does not infer expected counts.
+                and every subsequent run was metadata-only. Inspect the
+                Schedule's volume-selection contract and the Backup's PVB
+                children; phase and object replay do not establish volume
+                data. Schedules without the explicit marker are intentionally
+                out of scope. This is an absolute zero-volume guard and does
+                not infer an intended count from historical PVBs, because
+                Velero resource policies can intentionally change the selected
+                set. The condition begins with the Backup's creation time, not
+                when the alert first fires; use that timestamp when determining
+                how long coverage has been missing.
 
   # A Completed PVB is evidence only when its progress is byte-positive and
   # complete. A real positive PVB clears the absolute expectation alert.
@@ -420,58 +365,35 @@ tests:
         values: "1234+0x20"
     alert_rule_test:
       - eval_time: 15m
-        alertname: VeleroScheduleVolumeCoverageRegressed
-        exp_alerts: []
-      - eval_time: 15m
         alertname: VeleroScheduleExpectedVolumeDataMissing
         exp_alerts: []
 
-  # When a prior Completed run has selected a volume and the current count
-  # drops, the relative rule owns the regression. The absolute rule must stay
-  # quiet so one schedule does not produce two coverage pages.
+  # A deliberate resource-policy change may reduce the PVB count while the
+  # latest Backup still has byte-complete durable volume data. Historical PVB
+  # counts are not an intended-coverage contract, so this must not alert.
   - interval: 1m
     input_series:
-      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",phase="Enabled",paused="false",volume_data_required="true"}'
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",phase="Enabled",paused="false",volume_data_required="true"}'
         values: "1+0x20"
-      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-previous"}'
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-previous"}'
         values: "100+0x20"
-      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-current"}'
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-current"}'
         values: "200+0x20"
-      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-previous",phase="Completed"}'
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-previous",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-current",phase="Completed"}'
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="policy-change",backup="policy-change-current",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-regressed-previous",pod_volume_backup="expected-regressed-pvb",node="asuka",phase="Prepared"}'
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-previous",pod_volume_backup="policy-change-old-1",node="asuka",phase="Completed"}'
         values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-previous",pod_volume_backup="policy-change-old-2",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-current",pod_volume_backup="policy-change-current-1",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-current",pod_volume_backup="policy-change-current-1",node="asuka"}'
+        values: "1234+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="policy-change-current",pod_volume_backup="policy-change-current-1",node="asuka"}'
+        values: "1234+0x20"
     alert_rule_test:
-      - eval_time: 15m
-        alertname: VeleroScheduleVolumeCoverageRegressed
-        exp_alerts:
-          - exp_labels:
-              cluster: talos-ottawa
-              namespace: velero-system
-              schedule: expected-regressed
-              backup: expected-regressed-current
-              severity: critical
-            exp_annotations:
-              summary: Velero schedule expected-regressed volume coverage regressed
-              description: >-
-                The newest Backup expected-regressed-current for schedule
-                expected-regressed has fewer PodVolumeBackups than its previous
-                Completed baseline. Any lower PVB count is material because
-                each PVB represents one selected volume. This remains a
-                coverage regression even when Kubernetes item counts or the
-                parent Backup phase look normal. A warning-bearing Completed
-                Backup can still supply this count baseline; investigate its
-                warning separately. If no previous Completed baseline exists,
-                this alert is intentionally silent: that means no comparable
-                baseline, not proof of zero-volume health. Schedules that
-                never produce a successful nonzero-volume baseline require the
-                separate never/zero-volume coverage signal. Inspect the
-                current and previous Backup PVB populations; stalled-path and
-                node-saturation alerts are separate, and this alert is not
-                restore proof. It clears only when the newest run reaches the
-                prior baseline count.
       - eval_time: 15m
         alertname: VeleroScheduleExpectedVolumeDataMissing
         exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -274,7 +274,7 @@ tests:
               namespace: velero-system
               schedule: bhaiya-backup
               backup: bhaiya-backup-current
-              severity: critical
+              severity: warning
             exp_annotations:
               summary: Velero schedule bhaiya-backup volume coverage regressed
               description: >-
@@ -293,13 +293,18 @@ tests:
                 current and previous Backup PVB populations; stalled-path and
                 node-saturation alerts are separate, and this alert is not
                 restore proof. It clears only when the newest run reaches the
-                prior baseline count.
+                prior baseline count. This is a warning rather than proof of
+                lost data: a deliberate resource-policy exclusion can lower
+                the count. Confirm the Schedule's effective policy and compare
+                PVB identities before escalating. The condition starts with
+                the Backup creation time, not when this alert fires; use that
+                timestamp to determine when the apparent regression began.
           - exp_labels:
               cluster: talos-stpetersburg
               namespace: velero-system
               schedule: home-assistant-backup
               backup: home-assistant-backup-current
-              severity: critical
+              severity: warning
             exp_annotations:
               summary: Velero schedule home-assistant-backup volume coverage regressed
               description: >-
@@ -318,7 +323,12 @@ tests:
                 current and previous Backup PVB populations; stalled-path and
                 node-saturation alerts are separate, and this alert is not
                 restore proof. It clears only when the newest run reaches the
-                prior baseline count.
+                prior baseline count. This is a warning rather than proof of
+                lost data: a deliberate resource-policy exclusion can lower
+                the count. Confirm the Schedule's effective policy and compare
+                PVB identities before escalating. The condition starts with
+                the Backup creation time, not when this alert fires; use that
+                timestamp to determine when the apparent regression began.
 
   # A marked Schedule with completed zero-volume history must alert. The
   # unmarked Schedule is deliberately identical otherwise and remains out of
@@ -452,7 +462,7 @@ tests:
               namespace: velero-system
               schedule: expected-regressed
               backup: expected-regressed-current
-              severity: critical
+              severity: warning
             exp_annotations:
               summary: Velero schedule expected-regressed volume coverage regressed
               description: >-
@@ -471,7 +481,12 @@ tests:
                 current and previous Backup PVB populations; stalled-path and
                 node-saturation alerts are separate, and this alert is not
                 restore proof. It clears only when the newest run reaches the
-                prior baseline count.
+                prior baseline count. This is a warning rather than proof of
+                lost data: a deliberate resource-policy exclusion can lower
+                the count. Confirm the Schedule's effective policy and compare
+                PVB identities before escalating. The condition starts with
+                the Backup creation time, not when this alert fires; use that
+                timestamp to determine when the apparent regression began.
       - eval_time: 15m
         alertname: VeleroScheduleExpectedVolumeDataMissing
         exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -20,8 +20,8 @@
 #   must not carry the expectation label. This is a zero-volume guard, not an
 #   expected-count guard: it cannot detect under-selection that leaves a
 #   plausible nonzero count (for example, one PVB when two volumes were
-#   expected). The relative coverage rule detects a lower count only when a
-#   comparable prior baseline exists.
+#   expected). No relative count rule is used: the effective intended set after
+#   Velero resource-policy exclusions is not exported as a metric.
 # Both join on the newest Backup per schedule so they clear on recovery.
 #
 # Keep this namespace separate from rules/velero.yaml. Both files are synced by
@@ -318,15 +318,11 @@ groups:
             is covered or that a restore works. Clears when a later Backup has
             a Completed PVB with matching byte counters.
 
-      # Count coverage, not Kubernetes item coverage. A current Backup with
-      # one PVB can otherwise look healthy beside a prior run with 37 PVBs.
-      # The current run is the newest Backup for the schedule, while the
-      # baseline is the newest older Completed Backup. For this independent
-      # volume-count comparison, a Completed run with warnings is still a
-      # useful observed baseline; VeleroScheduleLatestBackupHasWarnings owns
-      # the separate quality signal. The alert deliberately observes the
-      # produced-PVB count while the Backup is queued/running; phase and item
-      # counters are not allowed to hide a volume gap.
+      # The current run is the newest Backup for the schedule. There is no
+      # metric for the effective volume set after Velero resource-policy
+      # exclusions, so a previous run's PVB count is not an intended-coverage
+      # baseline: a deliberate policy change can lower it while leaving all
+      # durable data covered.
       - record: velero_schedule_latest_backup_created_timestamp
         expr: |
           max by (cluster, namespace, schedule, backup) (
@@ -339,142 +335,14 @@ groups:
             )
           )
 
-      # kube-state-metrics emits these status counters only when they are
-      # non-zero. Absence therefore means zero; using `metric == 0` here would
-      # make a Completed Backup disappear from the baseline. "Successful" in
-      # this recording-rule name means parent phase=Completed for the count
-      # baseline. Warnings remain independently actionable and must not erase a
-      # known prior PVB count.
-      - record: velero_schedule_successful_backup_created_timestamp
-        expr: |
-          velero_cr_backup_created_timestamp{
-            namespace="velero-system",
-            schedule!=""
-          }
-          and on (cluster, namespace, schedule, backup)
-          (
-            max by (cluster, namespace, schedule, backup) (
-              velero_cr_backup_info{
-                namespace="velero-system",
-                schedule!="",
-                phase="Completed"
-              }
-            )
-          )
-
-      - record: velero_schedule_previous_successful_backup_created_timestamp
-        expr: |
-          max by (cluster, namespace, schedule, backup) (
-            topk by (cluster, namespace, schedule) (
-              1,
-              (
-                velero_schedule_successful_backup_created_timestamp
-                unless on (cluster, namespace, schedule, backup)
-                velero_schedule_latest_backup_created_timestamp
-              )
-            )
-          )
-
-      # Count each PVB object once, regardless of phase. A Prepared PVB is
-      # still evidence that the Backup selected one volume; the separate
-      # stalled-PVB alert owns whether that selected volume makes progress.
-      - record: velero_backup_pod_volume_backup_count
-        expr: |
-          count by (cluster, namespace, backup) (
-            max by (cluster, namespace, pod_volume_backup, backup) (
-              velero_cr_podvolumebackup_info{
-                namespace="velero-system"
-              }
-            )
-          )
-
-      - record: velero_schedule_latest_pod_volume_backup_count
-        expr: |
-          (
-            (
-              velero_backup_pod_volume_backup_count
-              * on (cluster, namespace, backup) group_left (schedule)
-              max by (cluster, namespace, schedule, backup) (
-                velero_cr_backup_info{
-                  namespace="velero-system",
-                  schedule!=""
-                }
-              )
-            )
-            and on (cluster, namespace, schedule, backup)
-            velero_schedule_latest_backup_created_timestamp
-          )
-          or on (cluster, namespace, schedule, backup)
-          (
-            velero_schedule_latest_backup_created_timestamp * 0
-          )
-
-      - record: velero_schedule_previous_successful_pod_volume_backup_count
-        expr: |
-          (
-            (
-              velero_backup_pod_volume_backup_count
-              * on (cluster, namespace, backup) group_left (schedule)
-              max by (cluster, namespace, schedule, backup) (
-                velero_cr_backup_info{
-                  namespace="velero-system",
-                  schedule!=""
-                }
-              )
-            )
-            and on (cluster, namespace, schedule, backup)
-            velero_schedule_previous_successful_backup_created_timestamp
-          )
-          or on (cluster, namespace, schedule, backup)
-          (
-            velero_schedule_previous_successful_backup_created_timestamp * 0
-          )
-
-      # Share the exact relative condition with the absolute expectation rule
-      # below. When a prior Completed run supplies a real count baseline and
-      # the current count drops, this signal owns the regression; the absolute
-      # rule is suppressed so one schedule does not double-page.
-      - record: velero_schedule_volume_coverage_regressed
-        expr: |
-          velero_schedule_latest_pod_volume_backup_count
-          < on (cluster, namespace, schedule) group_right(backup)
-          velero_schedule_previous_successful_pod_volume_backup_count
-
-      - alert: VeleroScheduleVolumeCoverageRegressed
-        expr: |
-          velero_schedule_volume_coverage_regressed
-        for: 15m
-        labels:
-          severity: critical
-        annotations:
-          summary: Velero schedule {{ $labels.schedule }} volume coverage regressed
-          description: >-
-            The newest Backup {{ $labels.backup }} for schedule
-            {{ $labels.schedule }} has fewer PodVolumeBackups than its previous
-            Completed baseline. Any lower PVB count is material because each
-            PVB represents one selected volume. This remains a coverage
-            regression even when Kubernetes item counts or the parent Backup
-            phase look normal. A warning-bearing Completed Backup can still
-            supply this count baseline; investigate its warning separately.
-            If no previous Completed baseline exists, this alert is
-            intentionally silent: that means no comparable baseline, not
-            proof of zero-volume health. Schedules that never produce a
-            successful nonzero-volume baseline require the separate
-            never/zero-volume coverage signal. Inspect the current and
-            previous Backup PVB populations; stalled-path and node-saturation
-            alerts are separate, and this alert is not restore proof. It
-            clears only when the newest run reaches the prior baseline count.
-
-      # This is the complementary absolute assertion. The latest attempt must
+      # This is the absolute assertion. The latest attempt must
       # itself be Completed. A failed latest attempt is owned by
       # VeleroScheduleLastBackupFailed; falling back to an older
       # Completed Backup here would double-page and could call a current run
       # with real PVBs empty (for example, a PartiallyFailed run with 25
-      # selected volumes). This still catches a schedule whose every
-      # Completed run has zero PVBs, because the latest Completed attempt is
-      # the one evaluated. When the shared relative condition is active, that
-      # rule owns the regression and this one is suppressed to avoid
-      # double-firing.
+      # selected volumes). This catches a schedule whose latest Completed
+      # attempt is metadata-only without treating historical PVB counts as an
+      # intended-volume contract.
       - alert: VeleroScheduleExpectedVolumeDataMissing
         expr: |
           (
@@ -498,8 +366,6 @@ groups:
                   volume_data_required="true"
                 }
               )
-            unless on (cluster, namespace, schedule)
-            velero_schedule_volume_coverage_regressed
           )
           unless on (cluster, namespace, backup)
           (
@@ -539,15 +405,13 @@ groups:
             Backup {{ $labels.backup }} has no Completed PodVolumeBackup with
             bytesDone equal to totalBytes and greater than zero. This absolute
             signal catches schedules whose first and every subsequent run was
-            metadata-only, where the relative rule has no volume-bearing
-            baseline to compare. If the shared relative coverage condition is
-            active, that alert owns the regression and this alert is
-            suppressed to prevent duplicate paging. Inspect the Schedule's
-            volume-selection contract and the Backup's PVB children; phase
-            and object replay do not establish volume data. Schedules without
-            the explicit marker are intentionally out of scope. This is a
-            zero-volume guard only: it cannot detect under-selection when a
-            run has a plausible nonzero count (for example, one PVB when two
-            volumes were expected). The relative coverage alert catches a
-            lower count only when a comparable prior baseline exists; this
-            rule does not infer expected counts.
+            metadata-only. Inspect the Schedule's volume-selection contract
+            and the Backup's PVB children; phase and object replay do not
+            establish volume data. Schedules without the explicit marker are
+            intentionally out of scope. This is an absolute zero-volume guard
+            and cannot detect under-selection when a run has a plausible
+            nonzero count. The rule deliberately does not infer an intended
+            count from historical PVBs because Velero resource policies can
+            intentionally change the selected set. The condition begins with
+            the Backup's creation time, not when the alert first fires; use
+            that timestamp when determining how long coverage has been missing.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -20,8 +20,11 @@
 #   must not carry the expectation label. This is a zero-volume guard, not an
 #   expected-count guard: it cannot detect under-selection that leaves a
 #   plausible nonzero count (for example, one PVB when two volumes were
-#   expected). The relative coverage rule detects a lower count only when a
-#   comparable prior baseline exists.
+#   expected). The relative coverage warning detects a lower count only when a
+#   comparable prior baseline exists; it cannot distinguish a deliberate policy
+#   exclusion from lost coverage because the effective intended set is not
+#   exported as a metric. Keep it as a warning until the emitter supplies that
+#   contract, rather than removing the detector for one-of-many failures.
 # Both join on the newest Backup per schedule so they clear on recovery.
 #
 # Keep this namespace separate from rules/velero.yaml. Both files are synced by
@@ -445,7 +448,11 @@ groups:
           velero_schedule_volume_coverage_regressed
         for: 15m
         labels:
-          severity: critical
+          # Historical PVB counts cannot encode effective intent after a
+          # resource-policy change. Keep this as a warning until the emitter
+          # exports the intended durable-volume set; the detector remains
+          # necessary for one-of-many failures such as 1-of-37.
+          severity: warning
         annotations:
           summary: Velero schedule {{ $labels.schedule }} volume coverage regressed
           description: >-
@@ -464,6 +471,12 @@ groups:
             previous Backup PVB populations; stalled-path and node-saturation
             alerts are separate, and this alert is not restore proof. It
             clears only when the newest run reaches the prior baseline count.
+            This is a warning rather than proof of lost data: a deliberate
+            resource-policy exclusion can lower the count. Confirm the
+            Schedule's effective policy and compare PVB identities before
+            escalating. The condition starts with the Backup creation time,
+            not when this alert fires; use that timestamp to determine when
+            the apparent regression began.
 
       # This is the complementary absolute assertion. The latest attempt must
       # itself be Completed. A failed latest attempt is owned by

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -20,8 +20,8 @@
 #   must not carry the expectation label. This is a zero-volume guard, not an
 #   expected-count guard: it cannot detect under-selection that leaves a
 #   plausible nonzero count (for example, one PVB when two volumes were
-#   expected). No relative count rule is used: the effective intended set after
-#   Velero resource-policy exclusions is not exported as a metric.
+#   expected). The relative coverage rule detects a lower count only when a
+#   comparable prior baseline exists.
 # Both join on the newest Backup per schedule so they clear on recovery.
 #
 # Keep this namespace separate from rules/velero.yaml. Both files are synced by
@@ -318,11 +318,15 @@ groups:
             is covered or that a restore works. Clears when a later Backup has
             a Completed PVB with matching byte counters.
 
-      # The current run is the newest Backup for the schedule. There is no
-      # metric for the effective volume set after Velero resource-policy
-      # exclusions, so a previous run's PVB count is not an intended-coverage
-      # baseline: a deliberate policy change can lower it while leaving all
-      # durable data covered.
+      # Count coverage, not Kubernetes item coverage. A current Backup with
+      # one PVB can otherwise look healthy beside a prior run with 37 PVBs.
+      # The current run is the newest Backup for the schedule, while the
+      # baseline is the newest older Completed Backup. For this independent
+      # volume-count comparison, a Completed run with warnings is still a
+      # useful observed baseline; VeleroScheduleLatestBackupHasWarnings owns
+      # the separate quality signal. The alert deliberately observes the
+      # produced-PVB count while the Backup is queued/running; phase and item
+      # counters are not allowed to hide a volume gap.
       - record: velero_schedule_latest_backup_created_timestamp
         expr: |
           max by (cluster, namespace, schedule, backup) (
@@ -335,14 +339,142 @@ groups:
             )
           )
 
-      # This is the absolute assertion. The latest attempt must
+      # kube-state-metrics emits these status counters only when they are
+      # non-zero. Absence therefore means zero; using `metric == 0` here would
+      # make a Completed Backup disappear from the baseline. "Successful" in
+      # this recording-rule name means parent phase=Completed for the count
+      # baseline. Warnings remain independently actionable and must not erase a
+      # known prior PVB count.
+      - record: velero_schedule_successful_backup_created_timestamp
+        expr: |
+          velero_cr_backup_created_timestamp{
+            namespace="velero-system",
+            schedule!=""
+          }
+          and on (cluster, namespace, schedule, backup)
+          (
+            max by (cluster, namespace, schedule, backup) (
+              velero_cr_backup_info{
+                namespace="velero-system",
+                schedule!="",
+                phase="Completed"
+              }
+            )
+          )
+
+      - record: velero_schedule_previous_successful_backup_created_timestamp
+        expr: |
+          max by (cluster, namespace, schedule, backup) (
+            topk by (cluster, namespace, schedule) (
+              1,
+              (
+                velero_schedule_successful_backup_created_timestamp
+                unless on (cluster, namespace, schedule, backup)
+                velero_schedule_latest_backup_created_timestamp
+              )
+            )
+          )
+
+      # Count each PVB object once, regardless of phase. A Prepared PVB is
+      # still evidence that the Backup selected one volume; the separate
+      # stalled-PVB alert owns whether that selected volume makes progress.
+      - record: velero_backup_pod_volume_backup_count
+        expr: |
+          count by (cluster, namespace, backup) (
+            max by (cluster, namespace, pod_volume_backup, backup) (
+              velero_cr_podvolumebackup_info{
+                namespace="velero-system"
+              }
+            )
+          )
+
+      - record: velero_schedule_latest_pod_volume_backup_count
+        expr: |
+          (
+            (
+              velero_backup_pod_volume_backup_count
+              * on (cluster, namespace, backup) group_left (schedule)
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_info{
+                  namespace="velero-system",
+                  schedule!=""
+                }
+              )
+            )
+            and on (cluster, namespace, schedule, backup)
+            velero_schedule_latest_backup_created_timestamp
+          )
+          or on (cluster, namespace, schedule, backup)
+          (
+            velero_schedule_latest_backup_created_timestamp * 0
+          )
+
+      - record: velero_schedule_previous_successful_pod_volume_backup_count
+        expr: |
+          (
+            (
+              velero_backup_pod_volume_backup_count
+              * on (cluster, namespace, backup) group_left (schedule)
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_info{
+                  namespace="velero-system",
+                  schedule!=""
+                }
+              )
+            )
+            and on (cluster, namespace, schedule, backup)
+            velero_schedule_previous_successful_backup_created_timestamp
+          )
+          or on (cluster, namespace, schedule, backup)
+          (
+            velero_schedule_previous_successful_backup_created_timestamp * 0
+          )
+
+      # Share the exact relative condition with the absolute expectation rule
+      # below. When a prior Completed run supplies a real count baseline and
+      # the current count drops, this signal owns the regression; the absolute
+      # rule is suppressed so one schedule does not double-page.
+      - record: velero_schedule_volume_coverage_regressed
+        expr: |
+          velero_schedule_latest_pod_volume_backup_count
+          < on (cluster, namespace, schedule) group_right(backup)
+          velero_schedule_previous_successful_pod_volume_backup_count
+
+      - alert: VeleroScheduleVolumeCoverageRegressed
+        expr: |
+          velero_schedule_volume_coverage_regressed
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} volume coverage regressed
+          description: >-
+            The newest Backup {{ $labels.backup }} for schedule
+            {{ $labels.schedule }} has fewer PodVolumeBackups than its previous
+            Completed baseline. Any lower PVB count is material because each
+            PVB represents one selected volume. This remains a coverage
+            regression even when Kubernetes item counts or the parent Backup
+            phase look normal. A warning-bearing Completed Backup can still
+            supply this count baseline; investigate its warning separately.
+            If no previous Completed baseline exists, this alert is
+            intentionally silent: that means no comparable baseline, not
+            proof of zero-volume health. Schedules that never produce a
+            successful nonzero-volume baseline require the separate
+            never/zero-volume coverage signal. Inspect the current and
+            previous Backup PVB populations; stalled-path and node-saturation
+            alerts are separate, and this alert is not restore proof. It
+            clears only when the newest run reaches the prior baseline count.
+
+      # This is the complementary absolute assertion. The latest attempt must
       # itself be Completed. A failed latest attempt is owned by
       # VeleroScheduleLastBackupFailed; falling back to an older
       # Completed Backup here would double-page and could call a current run
       # with real PVBs empty (for example, a PartiallyFailed run with 25
-      # selected volumes). This catches a schedule whose latest Completed
-      # attempt is metadata-only without treating historical PVB counts as an
-      # intended-volume contract.
+      # selected volumes). This still catches a schedule whose every
+      # Completed run has zero PVBs, because the latest Completed attempt is
+      # the one evaluated. When the shared relative condition is active, that
+      # rule owns the regression and this one is suppressed to avoid
+      # double-firing.
       - alert: VeleroScheduleExpectedVolumeDataMissing
         expr: |
           (
@@ -366,6 +498,8 @@ groups:
                   volume_data_required="true"
                 }
               )
+            unless on (cluster, namespace, schedule)
+            velero_schedule_volume_coverage_regressed
           )
           unless on (cluster, namespace, backup)
           (
@@ -405,13 +539,15 @@ groups:
             Backup {{ $labels.backup }} has no Completed PodVolumeBackup with
             bytesDone equal to totalBytes and greater than zero. This absolute
             signal catches schedules whose first and every subsequent run was
-            metadata-only. Inspect the Schedule's volume-selection contract
-            and the Backup's PVB children; phase and object replay do not
-            establish volume data. Schedules without the explicit marker are
-            intentionally out of scope. This is an absolute zero-volume guard
-            and cannot detect under-selection when a run has a plausible
-            nonzero count. The rule deliberately does not infer an intended
-            count from historical PVBs because Velero resource policies can
-            intentionally change the selected set. The condition begins with
-            the Backup's creation time, not when the alert first fires; use
-            that timestamp when determining how long coverage has been missing.
+            metadata-only, where the relative rule has no volume-bearing
+            baseline to compare. If the shared relative coverage condition is
+            active, that alert owns the regression and this alert is
+            suppressed to prevent duplicate paging. Inspect the Schedule's
+            volume-selection contract and the Backup's PVB children; phase
+            and object replay do not establish volume data. Schedules without
+            the explicit marker are intentionally out of scope. This is a
+            zero-volume guard only: it cannot detect under-selection when a
+            run has a plausible nonzero count (for example, one PVB when two
+            volumes were expected). The relative coverage alert catches a
+            lower count only when a comparable prior baseline exists; this
+            rule does not infer expected counts.


### PR DESCRIPTION
## Why

`VeleroScheduleVolumeCoverageRegressed` is unsound as a critical signal when it compares the newest PVB count with the previous Completed Backup's count. Velero resource-policy exclusions can deliberately lower that count. Robbinsdale's `home-backup` demonstrated this: the 2026-09-07 09:00:28Z run stopped selecting seven intentionally skipped `emptyDir` volumes while durable selected volumes remained backed up.

However, removing the relative detector entirely would recreate the motivating blind spot: a Backup can report all items complete while capturing 1 of 37 volumes. The existing metrics cannot distinguish those cases because the effective intended volume set after policy exclusions is not exported.

## Change

- Keep the relative PVB-count detector so one-of-many failures remain visible.
- Downgrade `VeleroScheduleVolumeCoverageRegressed` from critical to warning.
- Annotate it explicitly as an ambiguous signal: responders must check the effective Schedule/resource policy and compare PVB identities before escalating.
- Retain `VeleroScheduleExpectedVolumeDataMissing` as the critical zero-volume guard.
- Document that the apparent regression begins at the Backup creation timestamp, not when the alert first fires.
- Keep the promtool coverage tests, including the count-drop scenario.

This is intentionally an interim disposition. The durable fix is an exporter metric describing the intended durable-volume set after policy exclusions (ideally per Backup/PVC or an equivalent effective-selection contract). Once that exists, the relative detector can compare actual coverage with intent and return to a justified severity. Until then, deleting it would leave 1-of-37 undetectable, while critical paging would treat a correct emptyDir exclusion as data loss.

## Verification

- `tools/check.sh talos-ottawa` passes after rebasing onto current `origin/main`.
- Focused promtool fixtures are included in `rules/tests/velero-integrity_test.yaml`; this environment has no `promtool` binary and no Docker daemon, so CI must execute that stage.
- `velero-integrity.yaml` remains included in the Mimir loader for all three tenants; no loader wiring change is needed.