### PR TITLE
ci: run offline tool self-tests

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -97,3 +97,14 @@ jobs:
         with:
           header: flate-diff-${{ matrix.cluster }}
           path: comment.md
+
+  tool-self-tests:
+    name: offline tool self-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run offline tool self-tests
+        run: tools/tests/run.sh

--- a/tools/tests/helmrelease-schema.sh
+++ b/tools/tests/helmrelease-schema.sh
@@ -175,7 +175,7 @@ make_gate_root() {
   local result="$2"
   mkdir -p "$root/tools" "$root/bin"
   cp "$T/check.sh" "$root/tools/check.sh"
-  for helper in check-versions.sh check-notification-scope.sh \
+  for helper in check-mimir-promql.sh check-versions.sh check-notification-scope.sh \
     check-cliproxy-pi-bridge.sh check-zot-upload-affinity.sh \
     check-mimir-rules.sh check-velero-pvc-coverage.sh; do
     printf '#!/usr/bin/env bash\nexit 0\n' >"$root/tools/$helper"

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -372,7 +372,7 @@ printf '#!/usr/bin/env bash\nexit 0\n' >"$mstub/make"; chmod +x "$mstub/make"
 gate_root="$(mktemp -d)"
 mkdir -p "$gate_root/tools"
 cp "$T/check.sh" "$gate_root/tools/check.sh"
-for helper in check-versions.sh check-notification-scope.sh \
+for helper in check-mimir-promql.sh check-versions.sh check-notification-scope.sh \
   check-cliproxy-pi-bridge.sh check-zot-upload-affinity.sh \
   check-mimir-rules.sh check-velero-pvc-coverage.sh \
   check-helmrelease-schema.sh; do
@@ -406,7 +406,7 @@ exits "km#2809 missing-group condition is detected" 0 \
 watchdog_tmp="$(mktemp -d)"
 mkdir -p "$watchdog_tmp/tools" "$watchdog_tmp/stub"
 cp "$T/check.sh" "$watchdog_tmp/tools/check.sh"
-for helper in check-versions.sh check-notification-scope.sh \
+for helper in check-mimir-promql.sh check-versions.sh check-notification-scope.sh \
   check-cliproxy-pi-bridge.sh check-zot-upload-affinity.sh \
   check-mimir-rules.sh check-velero-pvc-coverage.sh \
   check-helmrelease-schema.sh; do


### PR DESCRIPTION
## Summary

- Add the missing `check-mimir-promql.sh` stub to all three copied-gate fixture lists: the main self-suite gate root, its watchdog gate root, and the HelmRelease contract suite.
- Run `tools/tests/run.sh` as a blocking job in `.github/workflows/flate.yaml`.
- Keep a 10-minute job timeout so a future real hang fails visibly instead of consuming an indefinite runner.

## Why

#2818 added `check-mimir-promql.sh` to `tools/check.sh` without updating the self-test fixtures. That left four main-suite assertions and six HelmRelease-sub-suite assertions red since 2026-09-07. The missing helper also made the watchdog test wait for a render-ready FIFO that could never be written.

## Validation

- Corrected suite: `197 passed, 0 failed`.
- Two full runs completed in 170s and 198s.
- The watchdog exit and timer-reaping assertions pass; the earlier timeout was fixture-induced, not a genuine gate hang.
- `tools/check.sh ot`, `tools/check-diagram.sh`, workflow YAML parsing, `bash -n`, and `git diff --check` pass.

The new job has no `continue-on-error` or warning path, so a regression fails the workflow.