### PR TITLE
feat(alerts): detect MCP provider upstream error ratio

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya.yaml
@@ -153,6 +153,36 @@ groups:
       description: More than five percent of {{ $labels.service }} requests have returned
         5xx for ten minutes with meaningful traffic. Inspect the service logs and route-level
         errors, then compare the current rollout with the last known good image.
+  - alert: BhaiyaMCPProviderUpstreamErrorRatio
+    expr: |
+      (
+        sum by (cluster, provider) (
+          rate(
+            bhaiya_mcp_proxy_requests_total{
+              result="upstream_error"
+            }[5m]
+          )
+        )
+        /
+        sum by (cluster, provider) (
+          rate(bhaiya_mcp_proxy_requests_total[5m])
+        )
+      ) > 0.05
+      and on(cluster, provider)
+      sum by (cluster, provider) (
+        rate(bhaiya_mcp_proxy_requests_total[5m])
+      ) > 0.1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Bhaiya MCP provider {{ $labels.provider }} has a high upstream error ratio
+      description: >-
+        More than five percent of {{ $labels.provider }} MCP proxy requests in
+        {{ $labels.cluster }} have been classified as upstream_error for five
+        minutes with meaningful traffic. Inspect the provider and the MCP
+        proxy body-copy path; a response can have status 2xx and still fail
+        while its streaming body is being copied.
   - alert: BhaiyaServiceP99LatencyRegression
     expr: |
       histogram_quantile(

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_test.yaml
@@ -1,0 +1,47 @@
+rule_files:
+  - ../bhaiya.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Grafana has a sustained upstream-error ratio well above the five-percent
+  # threshold. The alert is pending immediately and fires after its five-minute
+  # hold.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_mcp_proxy_requests_total{cluster="talos-ottawa",provider="grafana",result="success",status_class="2xx"}'
+        values: "0 100 200 300 400 500 600 700 800 900 1000"
+      - series: 'bhaiya_mcp_proxy_requests_total{cluster="talos-ottawa",provider="grafana",result="upstream_error",status_class="2xx"}'
+        values: "0 100 200 300 400 500 600 700 800 900 1000"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: BhaiyaMCPProviderUpstreamErrorRatio
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BhaiyaMCPProviderUpstreamErrorRatio
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              provider: grafana
+              severity: critical
+            exp_annotations:
+              summary: Bhaiya MCP provider grafana has a high upstream error ratio
+              description: >-
+                More than five percent of grafana MCP proxy requests in
+                talos-ottawa have been classified as upstream_error for five
+                minutes with meaningful traffic. Inspect the provider and the
+                MCP proxy body-copy path; a response can have status 2xx and
+                still fail while its streaming body is being copied.
+
+  # A healthy provider can have occasional upstream errors without paging: its
+  # error ratio remains below five percent with meaningful traffic.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_mcp_proxy_requests_total{cluster="talos-ottawa",provider="firecrawl",result="success",status_class="2xx"}'
+        values: "0 100 200 300 400 500 600 700 800 900 1000"
+      - series: 'bhaiya_mcp_proxy_requests_total{cluster="talos-ottawa",provider="firecrawl",result="upstream_error",status_class="4xx"}'
+        values: "0 1 2 3 4 5 6 7 8 9 10"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BhaiyaMCPProviderUpstreamErrorRatio
+        exp_alerts: []


### PR DESCRIPTION
Summary

- Add BhaiyaMCPProviderUpstreamErrorRatio to the existing Mimir Bhaiya rules.
- Alert per cluster and provider on the five-minute ratio of bhaiya_mcp_proxy_requests_total{result=upstream_error} to all proxy requests.
- Keep the 5% threshold above the observed single-digit non-Grafana error baseline and require meaningful traffic.
- Add promtool coverage for a sustained failing Grafana-shaped provider and a healthy provider.
- Never use the lifetime counter total as the alert predicate.

Expected behavior

This alert is deliberately expected to fire after merge. Grafana is genuinely failing at roughly 61% upstream errors at the current incident snapshot, while Firecrawl, GitHub, and Woodpecker are in the single-digit range. That first firing is a true positive, not a broken rule or a reason to silence it. The cos-cephrisk timeout fix should make the five-minute ratio recover and clear the alert, validating both the fix and this rule.

With the existing 30-second ServiceMonitor scrape, approximately one-minute Mimir ruler evaluation, for: 5m, and Alertmanager groupWait of 1m, notification should arrive nominally about 7 minutes after a sustained failure begins, with an honest worst case around 8-9 minutes. Human acknowledgment is separate. The lifetime counters will remain elevated after recovery, so later investigations must use the windowed ratio.

Verification

- tools/check.sh talos-ottawa
- Includes promtool tests: sustained failure fires; healthy-provider baseline stays clear