### PR TITLE
feat(alerts): remind on long-paused Velero schedules

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
@@ -39,6 +39,61 @@ tests:
                 missing data, and it also needs the Velero metric to remain
                 scrapeable.
 
+  # A paused schedule is deliberate, but it must not silently remain without
+  # backups forever. Seven days is longer than a normal maintenance window
+  # while still material for daily member/platform data. The rule uses
+  # lastBackup age because the Schedule CR has no pause-transition timestamp.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="paused-old",phase="Enabled",paused="true"}'
+        values: "1+0x20"
+      - series: 'velero_cr_schedule_last_backup_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="paused-old"}'
+        values: "-604801+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="paused-new",phase="Enabled",paused="true"}'
+        values: "1+0x20"
+      - series: 'velero_cr_schedule_last_backup_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="paused-new"}'
+        values: "300+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="unpaused-old",phase="Enabled",paused="false"}'
+        values: "1+0x20"
+      - series: 'velero_cr_schedule_last_backup_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="unpaused-old"}'
+        values: "-604801+0x20"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: VeleroSchedulePausedTooLong
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: VeleroSchedulePausedTooLong
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: paused-old
+              severity: warning
+            exp_annotations:
+              summary: Velero schedule paused-old has been paused for more than 7 days
+              description: >-
+                Schedule paused-old is intentionally paused and has gone more
+                than seven days without a successful Backup. This is a reminder,
+                not an outage assertion: confirm the maintenance window is
+                still deliberate, then unpause the Schedule when its protected
+                data should resume daily coverage. The seven-day threshold
+                allows ordinary maintenance windows while preventing a paused
+                member or platform schedule from becoming an indefinite silent
+                gap. This alert clears when the Schedule is unpaused or deleted.
+
+  # Historical metrics must not resurrect the reminder after a paused Schedule
+  # is deleted. The unpaused-old case above covers the other clear path.
+  - interval: 1m
+    input_series:
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",schedule="deleted-while-paused"}'
+        values: "-604801+0x20"
+      - series: 'velero_cr_schedule_last_backup_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="deleted-while-paused"}'
+        values: "-604801+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroSchedulePausedTooLong
+        exp_alerts: []
+
   # A deleted or paused Schedule must clear stale metrics from historical
   # Backup objects. Otherwise this alert becomes a permanent orphaned
   # incident after workspace or schedule cleanup.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
@@ -90,6 +90,69 @@ groups:
             it cannot detect a backup that completes while silently missing
             data, and it also needs the Velero metric to remain scrapeable.
 
+      # Pausing is deliberate, so it must not page like an active schedule
+      # outage. It must still leave a reminder when the pause outlasts a
+      # maintenance window: the daily schedules protect member and platform
+      # data, and seven missed daily windows is long enough to distinguish a
+      # normal repair window from an easily forgotten suspension without
+      # waiting a month. Use lastBackup age as the observable lower bound on
+      # pause age because Velero does not expose a pause-transition timestamp.
+      # For a schedule that has never backed up, use its creation age instead.
+      # The Enabled/paused Schedule join is intentionally on the outside, so
+      # deleting or unpausing the Schedule removes the alert even when old
+      # Backup metrics remain.
+      - alert: VeleroSchedulePausedTooLong
+        expr: |
+          max by (cluster, namespace, schedule) (
+            velero_cr_schedule_info{
+              namespace="velero-system",
+              phase="Enabled",
+              paused="true"
+            }
+          )
+          and on (cluster, namespace, schedule) (
+            (
+              time()
+              - max by (cluster, namespace, schedule) (
+                  velero_cr_schedule_last_backup_timestamp{
+                    namespace="velero-system"
+                  }
+                )
+              > 604800
+            )
+            or
+            (
+              (
+                time()
+                - max by (cluster, namespace, schedule) (
+                    velero_cr_schedule_created_timestamp{
+                      namespace="velero-system"
+                    }
+                  )
+              ) > 604800
+              unless on (cluster, namespace, schedule)
+              max by (cluster, namespace, schedule) (
+                velero_cr_schedule_last_backup_timestamp{
+                  namespace="velero-system"
+                }
+              )
+            )
+          )
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Velero schedule {{ $labels.schedule }} has been paused for more than 7 days
+          description: >-
+            Schedule {{ $labels.schedule }} is intentionally paused and has
+            gone more than seven days without a successful Backup. This is a
+            reminder, not an outage assertion: confirm the maintenance window
+            is still deliberate, then unpause the Schedule when its protected
+            data should resume daily coverage. The seven-day threshold allows
+            ordinary maintenance windows while preventing a paused member or
+            platform schedule from becoming an indefinite silent gap. This
+            alert clears when the Schedule is unpaused or deleted.
+
       # VeleroBackupStale requires a last_successful_timestamp series and a
       # currently enabled, unpaused Schedule. A historical Backup metric must
       # not keep an alert alive after its Schedule is deleted or paused. A Schedule


### PR DESCRIPTION
## Problem

km#2876 correctly prevents deleted or paused schedules from keeping `VeleroBackupStale` alive. That also makes a deliberately paused schedule silent forever: backups stop and no freshness alert remains.

## Change

Add `VeleroSchedulePausedTooLong`, a warning after seven days without a successful Backup while the Schedule is still `Enabled` and `paused=true`. Seven days is longer than a normal maintenance window but appropriate for daily member/platform data; waiting a month would leave too much data coverage unexamined. For schedules with no Backup yet, schedule age is used.

The annotation explicitly frames this as a reminder that backups are intentionally suspended, not as an outage. The rule is state-gated by the live Schedule, so it clears when the Schedule is unpaused or deleted and cannot reintroduce an orphaned historical alert.

## Verification

- Promtool tests: paused over seven days fires; paused under seven days does not; unpaused does not; deleted Schedule with historical metrics does not.
- `tools/check.sh talos-ottawa`: green.
- Live check: `bhaiya-staging-kingraj-member-shell` is currently paused, but its last Backup is only about 15 hours old and is not overdue.