### PR TITLE
feat(alerts): monitor Kopiur backup health

### DIFF
--- a/kubernetes/apps/base/kopiur/kopiur/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./namespace.yaml
   - ./helmrepository.yaml
   - ./helmrelease.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/base/kopiur/kopiur/servicemonitor.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur/servicemonitor.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kopiur-controller
+  labels:
+    app.kubernetes.io/name: kopiur
+    app.kubernetes.io/part-of: kopiur
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: kopiur
+      app.kubernetes.io/name: kopiur
+  namespaceSelector:
+    matchNames:
+      - kopiur-system
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -33,6 +33,7 @@ configMapGenerator:
       - rules/blackbox.yaml
       - rules/ceph.yaml
       - rules/cnpg-backup-coverage.yaml
+      - rules/kopiur.yaml
       - rules/flux.yaml
       - rules/garage.yaml
       - rules/k8gb.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -43,6 +43,7 @@ spec:
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/cnpg-backup-coverage.yaml
+            - /rules/kopiur.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
@@ -88,6 +89,7 @@ spec:
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/cnpg-backup-coverage.yaml
+            - /rules/kopiur.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml
@@ -129,6 +131,7 @@ spec:
             - /rules/blackbox.yaml
             - /rules/ceph.yaml
             - /rules/cnpg-backup-coverage.yaml
+            - /rules/kopiur.yaml
             - /rules/flux.yaml
             - /rules/garage.yaml
             - /rules/k8gb.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
@@ -1,0 +1,169 @@
+# Kopiur is the capture-plane replacement candidate for the St Petersburg
+# Home Assistant volume. The controller exports these metrics, but the
+# Prometheus agents are the only scrapers and Mimir is the only evaluator;
+# PrometheusRule objects would be inert here.
+#
+# The expected-source/repository records are an explicit inventory from the
+# Git-managed SnapshotPolicy and Repository. They deliberately do not infer
+# intent from the number of Snapshot objects or from a previous run: a backup
+# can contain a plausible item count while omitting a required volume.
+# Add a new protected source here only when its policy and repository are
+# intentionally added to Git.
+#
+# Keep this namespace unique across every file passed to mimirtool. A repeated
+# namespace aborts the complete rule sync for every tenant.
+namespace: kopiur-backups
+groups:
+  - name: kopiur-backups.inventory
+    rules:
+      - record: kopiur_expected_source_info
+        expr: vector(1)
+        labels:
+          cluster: talos-stpetersburg
+          namespace: home-assistant
+          policy: homeassistant-config
+          pvc: homeassistant-config
+          repository: kopiur-stpetersburg
+
+      - record: kopiur_expected_repository_info
+        expr: vector(1)
+        labels:
+          cluster: talos-stpetersburg
+          kind: Repository
+          namespace: home-assistant
+          name: kopiur-stpetersburg
+
+  - name: kopiur-backups.rules
+    rules:
+      - alert: KopiurSnapshotFailed
+        expr: |
+          (
+            kopiur_expected_source_info
+            and on (cluster, namespace, policy)
+            (
+              kopiur_snapshotpolicy_last_backup_success{
+                namespace="home-assistant",
+                policy="homeassistant-config"
+              } == 0
+            )
+          )
+          and on (cluster)
+          (kopiur_leader_is_leader == 1)
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: Kopiur policy {{ $labels.policy }} reports a failed snapshot
+          description: >-
+            Kopiur's latest terminal snapshot for {{ $labels.namespace }}/{{
+            $labels.policy }} is failed. This is a per-policy current-result
+            signal; an old Failed Snapshot object alone does not keep the alert
+            firing after a later success. Inspect the current Snapshot,
+            SnapshotPolicy, mover Job, and repository logs.
+
+      - alert: KopiurSnapshotStale
+        expr: |
+          (
+            kopiur_expected_source_info
+            and on (cluster, namespace, policy)
+            (
+              kopiur_snapshotpolicy_last_backup_success{
+                namespace="home-assistant",
+                policy="homeassistant-config"
+              } == 1
+            )
+            and on (cluster, namespace, policy)
+            (
+              kopiur_policy_last_backup_success_timestamp_seconds{
+                namespace="home-assistant",
+                policy="homeassistant-config"
+              } > 0
+              and
+              time()
+                - kopiur_policy_last_backup_success_timestamp_seconds{
+                    namespace="home-assistant",
+                    policy="homeassistant-config"
+                  }
+                > 129600
+            )
+          )
+          and on (cluster)
+          (kopiur_leader_is_leader == 1)
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Kopiur policy {{ $labels.policy }} has a stale snapshot
+          description: >-
+            No successful Kopiur snapshot for {{ $labels.namespace }}/{{
+            $labels.policy }} has completed within 36 hours (the daily schedule,
+            jitter, and operational margin). The timestamp must be positive, so
+            a controller restart/reset cannot turn a zero gauge into an
+            immediate stale alert. Inspect the SnapshotSchedule, current
+            Snapshot, mover Job, and repository reachability.
+
+      - alert: KopiurRepositoryUnreachable
+        expr: |
+          (
+            kopiur_expected_repository_info
+            unless on (cluster, kind, namespace, name)
+            (
+              max by (cluster, kind, namespace, name) (
+                kopiur_resource_phase{
+                  kind="Repository",
+                  namespace="home-assistant",
+                  name="kopiur-stpetersburg",
+                  phase="Ready"
+                } == 1
+              )
+              and on (cluster, kind, namespace, name)
+              max by (cluster, kind, namespace, name) (
+                kopiur_repository_consecutive_backend_failures{
+                  kind="Repository",
+                  namespace="home-assistant",
+                  name="kopiur-stpetersburg"
+                } == 0
+              )
+            )
+          )
+          and on (cluster)
+          (kopiur_leader_is_leader == 1)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Kopiur repository {{ $labels.name }} is unreachable
+          description: >-
+            The expected Kopiur repository {{ $labels.namespace }}/{{
+            $labels.name }} is not simultaneously Ready and reporting zero
+            consecutive backend failures. This excludes maintenance
+            configuration from the health decision: maintenance is intentionally
+            disabled for the St Petersburg Garage backend. Inspect Repository
+            status, Garage, credentials, and controller events.
+
+      - alert: KopiurCoverageMissing
+        expr: |
+          (
+            kopiur_expected_source_info
+            unless on (cluster, namespace, policy)
+            max by (cluster, namespace, policy) (
+              kopiur_snapshotpolicy_last_backup_success{
+                namespace="home-assistant",
+                policy="homeassistant-config"
+              }
+            )
+          )
+          and on (cluster)
+          (kopiur_leader_is_leader == 1)
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Kopiur expected source {{ $labels.pvc }} has no terminal backup
+          description: >-
+            The Git-declared Kopiur source {{ $labels.namespace }}/{{
+            $labels.pvc }} has no per-policy terminal Snapshot result. This is
+            an explicit expected-source check, not an item-count comparison, so
+            a policy that silently omits a required volume cannot look healthy
+            merely because another volume produced data. Inspect the
+            SnapshotPolicy source list, Snapshot objects, and mover Jobs.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
@@ -1,0 +1,213 @@
+rule_files:
+  - ../kopiur.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # All four alerts stay quiet for a current successful backup, a healthy
+  # repository, and an intentionally configured maintenance gauge. The
+  # maintenance gauge is informational; it is not itself an incident.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "1+0x20"
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "900+0x20"
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg",phase="Ready"}'
+        values: "1+0x20"
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+        values: "0+0x20"
+      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KopiurSnapshotFailed
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KopiurSnapshotStale
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KopiurRepositoryUnreachable
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KopiurCoverageMissing
+        exp_alerts: []
+
+  # A failed Snapshot object is immutable history. A later successful policy
+  # result must clear the failure alert even while both Snapshot phases remain
+  # visible in the exporter.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "1+0x20"
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Snapshot",namespace="home-assistant",name="homeassistant-config-old",phase="Failed",policy="homeassistant-config"}'
+        values: "1+0x20"
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Snapshot",namespace="home-assistant",name="homeassistant-config-new",phase="Succeeded",policy="homeassistant-config"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KopiurSnapshotFailed
+        exp_alerts: []
+
+  # An excluded policy is not part of the Git-declared expected-source
+  # inventory. Its failed result must not create either a policy-failure or a
+  # coverage alert for the protected source.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="excluded-policy"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KopiurSnapshotFailed
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KopiurCoverageMissing
+        exp_alerts: []
+
+  # A current failed terminal result is actionable even though a historical
+  # failed Snapshot alone is not.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: KopiurSnapshotFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: home-assistant
+              policy: homeassistant-config
+              pvc: homeassistant-config
+              repository: kopiur-stpetersburg
+              severity: critical
+            exp_annotations:
+              summary: Kopiur policy homeassistant-config reports a failed snapshot
+              description: >-
+                Kopiur's latest terminal snapshot for home-assistant/homeassistant-config
+                is failed. This is a per-policy current-result signal; an old Failed
+                Snapshot object alone does not keep the alert firing after a later
+                success. Inspect the current Snapshot, SnapshotPolicy, mover Job, and
+                repository logs.
+
+  # The last-success timestamp is a real Unix timestamp, so this remains
+  # meaningful across controller restarts. A positive but 37-hour-old value
+  # fires after the ten-minute hold.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x2250"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "1+0x2250"
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "1+0x2250"
+    alert_rule_test:
+      - eval_time: 37h
+        alertname: KopiurSnapshotStale
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: home-assistant
+              policy: homeassistant-config
+              pvc: homeassistant-config
+              repository: kopiur-stpetersburg
+              severity: critical
+            exp_annotations:
+              summary: Kopiur policy homeassistant-config has a stale snapshot
+              description: >-
+                No successful Kopiur snapshot for home-assistant/homeassistant-config
+                has completed within 36 hours (the daily schedule, jitter, and
+                operational margin). The timestamp must be positive, so a controller
+                restart/reset cannot turn a zero gauge into an immediate stale alert.
+                Inspect the SnapshotSchedule, current Snapshot, mover Job, and
+                repository reachability.
+
+  # A reset-to-zero timestamp is not evidence of staleness. This protects the
+  # alert from paging on every controller restart while the gauge is rebuilt.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x2250"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "1+0x2250"
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+        values: "0+0x2250"
+    alert_rule_test:
+      - eval_time: 37h
+        alertname: KopiurSnapshotStale
+        exp_alerts: []
+
+  # Backend failure on the expected Repository is distinct from a configured
+  # maintenance gauge and must raise even while the CR still has phase=Ready.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg",phase="Ready"}'
+        values: "1+0x20"
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+        values: "2+0x20"
+      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: KopiurRepositoryUnreachable
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: KopiurRepositoryUnreachable
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              kind: Repository
+              namespace: home-assistant
+              name: kopiur-stpetersburg
+              severity: critical
+            exp_annotations:
+              summary: Kopiur repository kopiur-stpetersburg is unreachable
+              description: >-
+                The expected Kopiur repository home-assistant/kopiur-stpetersburg is
+                not simultaneously Ready and reporting zero consecutive backend
+                failures. This excludes maintenance configuration from the health
+                decision: maintenance is intentionally disabled for the St Petersburg
+                Garage backend. Inspect Repository status, Garage, credentials, and
+                controller events.
+
+  # No terminal result at all is the coverage failure. A policy's item count
+  # is deliberately not used, so a partial backup cannot satisfy this check.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: KopiurCoverageMissing
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: KopiurCoverageMissing
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: home-assistant
+              policy: homeassistant-config
+              pvc: homeassistant-config
+              repository: kopiur-stpetersburg
+              severity: critical
+            exp_annotations:
+              summary: Kopiur expected source homeassistant-config has no terminal backup
+              description: >-
+                The Git-declared Kopiur source home-assistant/homeassistant-config has
+                no per-policy terminal Snapshot result. This is an explicit
+                expected-source check, not an item-count comparison, so a policy that
+                silently omits a required volume cannot look healthy merely because
+                another volume produced data. Inspect the SnapshotPolicy source list,
+                Snapshot objects, and mover Jobs.

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/expected-groups.tsv
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/expected-groups.tsv
@@ -41,6 +41,8 @@ monitoring	kubelet.rules
 monitoring	watchdog.rules
 node-clock	node-clock.rules
 node-health	node-health.rules
+kopiur-backups	kopiur-backups.inventory
+kopiur-backups	kopiur-backups.rules
 bhaiya	bhaiya.payments
 smartctl	smartctl-exporter.rules
 stpetersburg-memory	stpetersburg-memory.rules


### PR DESCRIPTION
## Summary

Kopiur already exposes backup metrics, but St Petersburg was not scraping them. The live `kopiur-system/kopiur-controller-metrics` Service has the named `metrics` port on `8081`, one ready endpoint (`10.5.2.245:8081`), and `/metrics` returned 211 lines including the policy result/timestamp, repository backend health, resource phases, and leader gauge. St Petersburg had no live Kopiur ServiceMonitor, and the read-only Mimir query in tenant `talos-stpetersburg` returned a successful query with an empty result.

This PR:

- adds the Kopiur ServiceMonitor (the Prometheus agents accept ServiceMonitors and add the cluster external label);
- adds four Mimir-ruler alerts for Kopiur backup health;
- registers the rule in the rules ConfigMap, all three tenant loader containers, and the independent completeness inventory; and
- adds a dedicated promtool fixture with healthy, excluded, historical, restart-reset, and positive cases.

## Alert design

- `KopiurSnapshotFailed` uses the current per-policy terminal result, so an immutable historical Failed Snapshot does not keep paging after a later success.
- `KopiurSnapshotStale` uses the per-policy Unix success timestamp and requires it to be positive, so a controller restart/reset to zero cannot page immediately. The threshold is 36 hours with a ten-minute hold.
- `KopiurRepositoryUnreachable` checks the explicitly expected Repository is Ready and has zero consecutive backend failures. It does not alert on the maintenance-configuration gauge itself.
- `KopiurCoverageMissing` compares the Git-declared expected source inventory with the per-policy terminal-result series; it does not infer coverage from item counts.

The rule is in the Mimir ruler, not a PrometheusRule CR, and is loaded for all three tenants. The expected inventory is St Petersburg-specific, so other tenants do not manufacture alerts.

## Verification

- Prometheus 3.14.0: rule parse passed and the dedicated `kopiur_test.yaml` fixture passed all four alerts and negative cases.
- `tools/check-mimir-promql.sh` passed.
- `tools/check-mimir-rules.sh` passed: 33 rule files, 3 tenant loaders, 32 unique namespaces.
- `tools/check.sh sp` passed: `render OK: talos-stpetersburg`.

The shared `rules/tests/run.sh` harness was intentionally not edited because it is owned by the adjacent agent; the fixture is supplied for that owner to register. The fixture was run directly with the pinned promtool.

Mimir series arrival cannot be verified until this PR is merged and Flux reconciles the ServiceMonitor. At that point the St Petersburg tenant query must return `kopiur_*` series rather than the currently observed empty result, and the content-hashed Mimir loader Job must be checked for successful completion in all three tenants. No live objects were changed by this PR.
