### PR TITLE
fix(alerts): correct Velero stale schedule detection

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
@@ -5,19 +5,30 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
-  # Staleness is one alert per schedule. The latest-backup recording rule adds
-  # the backup identity only as a grouping label; it must not create one stale
-  # alert for every historical Backup.
+  # Staleness is one alert per active schedule. A fresh success must not produce
+  # a zero-valued alert series, while active schedules that missed one or more
+  # daily runs must alert even when historical Backup objects have per-attempt
+  # identities.
   - interval: 1m
     input_series:
-      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",schedule="media-config-backup"}'
-        values: "-200000+0x20"
-      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",phase="Enabled",paused="false"}'
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="fresh-daily-backup"}'
+        values: "-7200+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="fresh-daily-backup",phase="Enabled",paused="false"}'
         values: "1+0x20"
-      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-backup-20260907060000"}'
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="stale-26h-backup"}'
+        values: "-95040+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="stale-26h-backup",phase="Enabled",paused="false"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="stale-26h-backup",backup="stale-26h-backup-20260907060000"}'
         values: "100+0x20"
-      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-backup-20260906060000"}'
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="stale-26h-backup",backup="stale-26h-backup-20260906060000"}'
         values: "50+0x20"
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="stale-49h-backup"}'
+        values: "-179640+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="stale-49h-backup",phase="Enabled",paused="false"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="stale-49h-backup",backup="stale-49h-backup-20260907060000"}'
+        values: "100+0x20"
     alert_rule_test:
       - eval_time: 15m
         alertname: VeleroBackupStale
@@ -25,16 +36,28 @@ tests:
           - exp_labels:
               cluster: talos-ottawa
               namespace: velero-system
-              schedule: media-config-backup
-              backup: media-config-backup-20260907060000
+              schedule: stale-26h-backup
               severity: critical
             exp_annotations:
-              summary: Velero schedule media-config-backup has no recent successful backup
+              summary: Velero schedule stale-26h-backup has no recent successful backup
               description: >-
-                Schedule media-config-backup has not reported a successful
-                backup for more than 36 hours (the daily schedule's expected
-                period plus margin). Check the Schedule, BackupStorageLocation,
-                Velero server, and node-agent pods. This is a freshness/reporting
+                Schedule stale-26h-backup has not reported a successful
+                backup for more than 24 hours (one missed daily schedule). Check
+                the Schedule, BackupStorageLocation, Velero server, and node-agent pods. This is a freshness/reporting
+                guard; it cannot detect a backup that completes while silently
+                missing data, and it also needs the Velero metric to remain
+                scrapeable.
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: stale-49h-backup
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule stale-49h-backup has no recent successful backup
+              description: >-
+                Schedule stale-49h-backup has not reported a successful
+                backup for more than 24 hours (one missed daily schedule). Check
+                the Schedule, BackupStorageLocation, Velero server, and node-agent pods. This is a freshness/reporting
                 guard; it cannot detect a backup that completes while silently
                 missing data, and it also needs the Velero metric to remain
                 scrapeable.
@@ -48,7 +71,42 @@ tests:
         values: "-200000+0x20"
       - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="deleted-schedule",backup="deleted-schedule-20260907020000"}'
         values: "100+0x20"
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="paused-schedule"}'
+        values: "-200000+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="paused-schedule",phase="Enabled",paused="true"}'
+        values: "1+0x20"
     alert_rule_test:
       - eval_time: 15m
         alertname: VeleroBackupStale
         exp_alerts: []
+
+  # Promtool fixes time() to the test evaluation time. Pin the same successful
+  # timestamp on both sides of the 24-hour threshold so a wall-clock change
+  # cannot turn this rule into a flaky test or silently invert its verdict.
+  - interval: 5m
+    input_series:
+      - series: 'velero_backup_last_successful_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="boundary-backup"}'
+        values: "0+0x360"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="boundary-backup",phase="Enabled",paused="false"}'
+        values: "1+0x360"
+    alert_rule_test:
+      - eval_time: 23h
+        alertname: VeleroBackupStale
+        exp_alerts: []
+      - eval_time: 25h
+        alertname: VeleroBackupStale
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: boundary-backup
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule boundary-backup has no recent successful backup
+              description: >-
+                Schedule boundary-backup has not reported a successful
+                backup for more than 24 hours (one missed daily schedule). Check
+                the Schedule, BackupStorageLocation, Velero server, and node-agent pods. This is a freshness/reporting
+                guard; it cannot detect a backup that completes while silently
+                missing data, and it also needs the Velero metric to remain
+                scrapeable.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
@@ -58,25 +58,25 @@ groups:
             (
               time()
               - max by (cluster, schedule) (
-                  velero_backup_last_successful_timestamp{schedule!=""}
+                  velero_backup_last_successful_timestamp{
+                    namespace="velero-system",
+                    schedule!=""
+                  }
                 )
-            ) > bool 129600
+            ) > 86400
           )
-          * on (cluster, schedule) group_left (namespace, backup)
+          * on (cluster, schedule) group_left (namespace)
           (
-            velero_schedule_latest_backup_created_timestamp > bool 0
+            (
+              max by (cluster, namespace, schedule) (
+                velero_cr_schedule_info{
+                  namespace="velero-system",
+                  phase="Enabled",
+                  paused!="true"
+                }
+              )
+            ) > 0
           )
-          and on (cluster, namespace, schedule)
-          (
-            max by (cluster, namespace, schedule) (
-              velero_cr_schedule_info{
-                namespace="velero-system",
-                phase="Enabled",
-                paused!="true"
-              }
-            )
-          )
-          > 0
         for: 15m
         labels:
           severity: critical
@@ -84,17 +84,21 @@ groups:
           summary: Velero schedule {{ $labels.schedule }} has no recent successful backup
           description: >-
             Schedule {{ $labels.schedule }} has not reported a successful
-            backup for more than 36 hours (the daily schedule's expected period
-            plus margin). Check the Schedule, BackupStorageLocation, Velero
+            backup for more than 24 hours (one missed daily schedule). Check
+            the Schedule, BackupStorageLocation, Velero
             server, and node-agent pods. This is a freshness/reporting guard;
             it cannot detect a backup that completes while silently missing
             data, and it also needs the Velero metric to remain scrapeable.
 
       # VeleroBackupStale requires a last_successful_timestamp series and a
       # currently enabled, unpaused Schedule. A historical Backup metric must
-      # not keep an alert alive after its Schedule is deleted or paused. A Schedule
-      # that is Enabled but has never produced a Backup (forgejo-backup after
-      # #2732 had status.lastBackup unset) creates no such series and stays
+      # not keep an alert alive after its Schedule is deleted or paused. The
+      # comparison deliberately omits bool: alerting rules fire on series
+      # presence, so a bool comparison would retain a zero-valued fresh series.
+      # Do not join the per-Backup latest-created recording rule here: stale
+      # freshness is per Schedule and must not carry an immutable backup label.
+      # A Schedule that is Enabled but has never produced a Backup (forgejo-backup
+      # after #2732 had status.lastBackup unset) creates no such series and stays
       # invisible. Page from the Schedule CR once it is older than 36h without
       # lastBackup. Clears when lastBackup is set; does not latch on history.
       - alert: VeleroScheduleNeverBackedUp


### PR DESCRIPTION
## Summary

VeleroBackupStale was inverted because bool comparisons retained zero-valued fresh series, and its latest-backup join carried an immutable per-attempt backup label. The alert now evaluates velero_backup_last_successful_timestamp once per schedule, emits only true stale series, and carries no backup-instance label.

The daily threshold is 24h so an active schedule missing one daily run is stale. The enabled and unpaused Schedule gate remains: the intentionally paused bhaiya-staging-kingraj-member-shell and the deleted bhaiya-tailscale-engineering history do not create permanent orphan alerts. VeleroBackupStale never uses velero_backup_last_status, which is not authoritative for persisted Backup outcomes.

## Verification

- Pinned Prometheus 3.14.0 focused Velero fixture: PASS.
- Fixture proves active 26.6h and 49.9h stale schedules alert, a 2h success does not, historical Backup labels do not leak into the alert, and paused/deleted schedules stay quiet.
- Fixed eval-time boundary fixture: 23h is quiet and 25h alerts, pinning time() behavior.
- Full rules/tests/run.sh under the shared heavy-build lock: exit 0.
- tools/check-mimir-promql.sh, tools/check-mimir-rules.sh, and tools/check.sh ot: PASS.

This is separate from #2894 and is not a merge request.