### PR TITLE
revert: roll back multus-cni v4.3.1

### DIFF
--- a/kubernetes/apps/base/kube-system/cilium-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/app/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - generic-device-plugin.yaml
-  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.1/deployments/multus-daemonset-thick.yml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.0/deployments/multus-daemonset-thick.yml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/daemonset-install.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml

--- a/kubernetes/apps/base/kube-system/cilium-ottawa/app/patch-multus.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/app/patch-multus.yaml
@@ -14,7 +14,7 @@ spec:
             path: /var/run/netns/
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
           command:
             - "cp"
             - "-f"

--- a/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - generic-device-plugin.yaml
-  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.1/deployments/multus-daemonset-thick.yml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.0/deployments/multus-daemonset-thick.yml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/daemonset-install.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -42,7 +42,7 @@ patches:
                   path: /var/run/netns/
             initContainers:
               - name: install-multus-binary
-                image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
+                image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
                 command:
                   - "cp"
                   - "-f"

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - generic-device-plugin.yaml
-  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.1/deployments/multus-daemonset-thick.yml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.0/deployments/multus-daemonset-thick.yml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/daemonset-install.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
@@ -13,7 +13,7 @@ spec:
             path: /var/run/netns/
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
           command:
             - "cp"
             - "-f"


### PR DESCRIPTION
## Live incident

New pod sandboxes are failing in Ottawa with:

```
plugin type="multus-shim" name="multus-cni-network" failed (add):
CmdAdd (shim): timed out waiting for the condition
```

This affects Bhaiya and bhaiya-ssh replacements on `rei` and `kaji`; both Deployments are at DESIRED=2, READY=1. The event stream also shows the same failure for descheduler, Hubble Relay, CoreDNS, and Kata pods, so this is cluster-wide latent CNI degradation.

## Confirmed cause

This is a shim/daemon version skew introduced by #2891 (`cfda286`):

- v4.3.0 `WaitUntilAPIReady` polls `/healthz`.
- v4.3.1 changes it to poll `/readyz` before CNI `ADD`.
- v4.3.1 adds the daemon's `/readyz` handler, but the live daemon container remains `ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick`, image digest `beeca1d104e0d0b882dbd8d93f8b8d9060bfe403245283651b8c1fb8179b8f38` on `rei` and `kaji`.
- The host-installed shim is v4.3.1, digest `a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25`.
- The live Multus daemon logs repeatedly show `POST /readyz` returning `http not found`. The DaemonSet is 4/4 only because it has no readiness or liveness probe; the process is running while the CNI protocol is broken.

The socket/config theory is refuted: all four nodes have the same v4.3.1 `multus-shim` hash, `00-multus.conf` points to `multus-shim`, `/run/multus/multus.sock` exists, and the daemon config uses the matching host socket directory `/host/run/multus/`. Regenerating those files would not add the missing daemon endpoint.

## Change

Restore the exact v4.3.0 deployment references and pinned thick shim digest changed by #2891 in all three cluster overlays. This makes the host shim match the currently deployed daemon behavior and is the known-good fallback.

`tools/check.sh` passed for all three clusters:

```
✓ render OK: talos-ottawa talos-robbinsdale talos-stpetersburg
```

## Operational boundary

This PR is intentionally unmerged. Do not merge until Raj confirms; no live Kubernetes object was applied, patched, deleted, or restarted during diagnosis.

A future targeted upgrade can retain v4.3.1 only by pinning the daemon and shim to the same validated release image and adding an end-to-end sandbox test. A config regeneration alone is not a fix.

## Governance

This is the second incident-backed failure from automerged safety-relevant infrastructure after the recommendation to exclude CNI, storage/CSI, backup, and operator families from automerge. The problem is not that every routine digest bump is unsafe; it is that this CNI bump changed a live protocol contract without a matching daemon rollout or sandbox-level validation.