### PR TITLE
fix(multus): align daemon and shim and add health probes

### DIFF
--- a/kubernetes/apps/base/kube-system/cilium-ottawa/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/app/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - generic-device-plugin.yaml
-  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.0/deployments/multus-daemonset-thick.yml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.1/deployments/multus-daemonset-thick.yml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/daemonset-install.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml

--- a/kubernetes/apps/base/kube-system/cilium-ottawa/app/patch-multus.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-ottawa/app/patch-multus.yaml
@@ -5,6 +5,11 @@ metadata:
   name: kube-multus-ds
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  minReadySeconds: 10
   template:
     spec:
 
@@ -14,7 +19,7 @@ spec:
             path: /var/run/netns/
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
           command:
             - "cp"
             - "-f"
@@ -34,6 +39,52 @@ spec:
         - name: kube-multus
           # Keep the daemon and host-installed shim on the same immutable release.
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
+          # Probe the Unix API used by multus-shim; DS Ready must reflect daemon health.
+          startupProbe:
+            exec:
+              command:
+                - /usr/bin/perl
+                - -MIO::Socket::UNIX
+                - -MSocket
+                - -e
+                - |
+                  my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                  print $s "GET /readyz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                  my $line = <$s>;
+                  exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/perl
+                - -MIO::Socket::UNIX
+                - -MSocket
+                - -e
+                - |
+                  my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                  print $s "GET /readyz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                  my $line = <$s>;
+                  exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/perl
+                - -MIO::Socket::UNIX
+                - -MSocket
+                - -e
+                - |
+                  my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                  print $s "GET /healthz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                  my $line = <$s>;
+                  exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
           resources:
             requests:
               cpu: "200m"

--- a/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-robbinsdale/app/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - generic-device-plugin.yaml
-  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.0/deployments/multus-daemonset-thick.yml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.1/deployments/multus-daemonset-thick.yml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/daemonset-install.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -34,6 +34,11 @@ patches:
         name: kube-multus-ds
         namespace: kube-system
       spec:
+        updateStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+        minReadySeconds: 10
         template:
           spec:
             volumes:
@@ -42,7 +47,7 @@ patches:
                   path: /var/run/netns/
             initContainers:
               - name: install-multus-binary
-                image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
+                image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
                 command:
                   - "cp"
                   - "-f"
@@ -62,6 +67,52 @@ patches:
               - name: kube-multus
                 # Keep the daemon and host-installed shim on the same immutable release.
                 image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
+                # Probe the Unix API used by multus-shim; DS Ready must reflect daemon health.
+                startupProbe:
+                  exec:
+                    command:
+                      - /usr/bin/perl
+                      - -MIO::Socket::UNIX
+                      - -MSocket
+                      - -e
+                      - |
+                        my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                        print $s "GET /readyz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                        my $line = <$s>;
+                        exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+                  periodSeconds: 2
+                  timeoutSeconds: 2
+                  failureThreshold: 60
+                readinessProbe:
+                  exec:
+                    command:
+                      - /usr/bin/perl
+                      - -MIO::Socket::UNIX
+                      - -MSocket
+                      - -e
+                      - |
+                        my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                        print $s "GET /readyz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                        my $line = <$s>;
+                        exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+                  periodSeconds: 5
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+                livenessProbe:
+                  exec:
+                    command:
+                      - /usr/bin/perl
+                      - -MIO::Socket::UNIX
+                      - -MSocket
+                      - -e
+                      - |
+                        my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                        print $s "GET /healthz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                        my $line = <$s>;
+                        exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+                  periodSeconds: 10
+                  timeoutSeconds: 2
+                  failureThreshold: 3
                 resources:
                   requests:
                     cpu: "200m"

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - generic-device-plugin.yaml
-  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.0/deployments/multus-daemonset-thick.yml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.3.1/deployments/multus-daemonset-thick.yml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/daemonset-install.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
   # - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/refs/heads/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml

--- a/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
+++ b/kubernetes/apps/base/kube-system/cilium-stpetersburg/app/patch-multus.yaml
@@ -5,6 +5,11 @@ metadata:
   name: kube-multus-ds
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  minReadySeconds: 10
   template:
     spec:
       volumes:
@@ -13,7 +18,7 @@ spec:
             path: /var/run/netns/
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
           command:
             - "cp"
             - "-f"
@@ -33,6 +38,52 @@ spec:
         - name: kube-multus
           # Keep the daemon and host-installed shim on the same immutable release.
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25
+          # Probe the Unix API used by multus-shim; DS Ready must reflect daemon health.
+          startupProbe:
+            exec:
+              command:
+                - /usr/bin/perl
+                - -MIO::Socket::UNIX
+                - -MSocket
+                - -e
+                - |
+                  my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                  print $s "GET /readyz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                  my $line = <$s>;
+                  exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/perl
+                - -MIO::Socket::UNIX
+                - -MSocket
+                - -e
+                - |
+                  my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                  print $s "GET /readyz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                  my $line = <$s>;
+                  exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/perl
+                - -MIO::Socket::UNIX
+                - -MSocket
+                - -e
+                - |
+                  my $s = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => "/host/run/multus/multus.sock") or exit 1;
+                  print $s "GET /healthz HTTP/1.0\r\nHost: localhost\r\n\r\n" or exit 1;
+                  my $line = <$s>;
+                  exit(($line // "") =~ m{^HTTP/\d(?:\.\d)? 200\b} ? 0 : 1);
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
           resources:
             # orin-0 usage ~28Mi; 200Mi request was pure schedulable waste on the
             # sole control-plane node that also pins Home Assistant.


### PR DESCRIPTION
## Incident and root cause

At 06:0x UTC, new pod sandboxes failed with:

`plugin type="multus-shim" ... CmdAdd (shim): timed out waiting for the condition`

The failure was a protocol/version mismatch, not timing. The v4.3.1 shim waits on `POST /readyz`; the daemon that was running on the node exposed only `/healthz`, and its logs showed `POST /readyz -> http not found`. The DaemonSet still reported 4/4 because it had no readiness or liveness probes.

The partial rollback left the same class of mismatch in Git and live state:

- daemon container: v4.3.1-thick @ `sha256:a357a793...`
- init container's host-installed shim: v4.3.0-thick @ `sha256:2b967144...`

## Change

Normalize Ottawa, Robbinsdale, and St. Petersburg to the verified aligned v4.3.1 pair:

- raw Multus deployment URL: `v4.3.1`
- init container and host-installed `multus-shim`: `v4.3.1-thick@sha256:a357a79359b80ddd5f4699117946cacf3b54f5baecf7944535594863e875fc25`
- long-running `multus-daemon`: the same immutable image

The pair matches the shape established by `f4d73d5`. The image roles are intentionally kept adjacent and identical so a future Renovate update cannot move only one side unnoticed.

Add probes over the daemon's Unix socket:

- startup/readiness: `GET /readyz`
- liveness: `GET /healthz`

The probe command was executed read-only in the live v4.3.1 daemon and returned HTTP 200 for both endpoints. The DaemonSet rollout is explicit `RollingUpdate`, `maxUnavailable: 1`, with `minReadySeconds: 10`.

## Rollout risk and ordering

This changes the DaemonSet pod template and therefore requires one Multus pod churn per node. It is lower risk while sandbox creation is currently healthy: each replacement pod copies the v4.3.1 shim before starting the v4.3.1 daemon, eliminating the bad interval. It is not risk-free: a node has no Multus daemon during its replacement window, so new sandboxes scheduled there can briefly fail.

Merge only during a staffed healthy window and observe all three DaemonSets and sandbox creation. Because the shared base is consumed by all three cluster Flux children, one main-branch merge may start all three rolling updates in parallel; strict cluster-by-cluster ordering would require staging location-specific commits or holding the other Flux children. No live action is taken by this PR.

## Validation

- Read-only live pod inspection confirmed init/main roles and the Unix socket path.
- Read-only live probe returned 200 for both `/readyz` and `/healthz`.
- YAML parsing, diff check, and all-three-cluster image/probe invariants pass.
- `tools/check.sh` was attempted but stalled in the repository's known Flate/mimir-promql timeout path without manifest diagnostics.

Do not merge without Raj's approval; this affects the CNI on every node.