### PR TITLE
fix(mimir): alert on current loader job failure

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/mimir-loader.yaml
@@ -2,6 +2,12 @@
 # therefore the aggregate signal for rule delivery to Ottawa, Robbinsdale, and
 # St. Petersburg. Keep this namespace unique across every file passed to
 # mimirtool: one repeated namespace aborts the entire sync for every tenant.
+#
+# kube_job_status_failed is a retry counter, not a terminal outcome. A Job can
+# have failed attempts and still complete successfully. The failure alert below
+# therefore requires a non-empty terminal reason and joins it to the newest
+# content-hashed Job; MimirRuleLoaderStale remains the dead-man's switch for a
+# loader that has not produced a recent successful completion.
 namespace: mimir-loader
 groups:
   - name: mimir-rule-loader.rules
@@ -11,19 +17,28 @@ groups:
           max by (cluster, namespace, job_name) (
             kube_job_status_failed{
               namespace="mimir",
-              job_name=~"mimir-rules-.*"
+              job_name=~"mimir-rules-.*",
+              reason=~".+"
             }
           ) > 0
+          and on (cluster, namespace, job_name)
+          topk by (cluster, namespace) (
+            1,
+            kube_job_created{
+              namespace="mimir",
+              job_name=~"mimir-rules-.*"
+            }
+          )
         for: 5m
         labels:
           severity: critical
         annotations:
           summary: Mimir rule loader Job is failing
           description: >-
-            The content-hashed Mimir rules loader Job has failed. Its three tenant sync
-            containers deliver every native rule group to the Ottawa,
-            Robbinsdale, and St. Petersburg Mimir rulers; inspect the Job and
-            its logs before relying on a newly changed alert.
+            The newest content-hashed Mimir rules loader Job has reached a terminal
+            failure. Its three tenant sync containers deliver every native rule
+            group to the Ottawa, Robbinsdale, and St. Petersburg Mimir rulers;
+            inspect the Job and its logs before relying on a newly changed alert.
 
       - alert: MimirRuleLoaderStale
         expr: |

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/mimir-loader_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/mimir-loader_test.yaml
@@ -1,24 +1,91 @@
 rule_files:
   - ../mimir-loader.yaml
 
-evaluation_interval: 1h
+evaluation_interval: 1m
 
 tests:
-  - interval: 1h
+  # kube_job_status_failed is an attempt counter. A Job that failed three
+  # times and then succeeded has reason="" and must not page.
+  - interval: 1m
+    input_series:
+      - series: 'kube_job_created{cluster="talos-ottawa",job_name="mimir-rules-retried-success",namespace="mimir"}'
+        values: "100+0x30"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",job_name="mimir-rules-retried-success",namespace="mimir",reason=""}'
+        values: "0 1 2 3 3+0x30"
+      - series: 'kube_job_status_succeeded{cluster="talos-ottawa",job_name="mimir-rules-retried-success",namespace="mimir"}'
+        values: "0+0x4 1+0x30"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: MimirRuleLoaderFailing
+        exp_alerts: []
+
+  # A terminal failure has a non-empty kube-state-metrics reason and should
+  # alert after the normal five-minute hold.
+  - interval: 1m
+    input_series:
+      - series: 'kube_job_created{cluster="talos-ottawa",job_name="mimir-rules-terminal-failed",namespace="mimir"}'
+        values: "100+0x30"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",job_name="mimir-rules-terminal-failed",namespace="mimir",reason=""}'
+        values: "0 1 2 3 3+0x30"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",job_name="mimir-rules-terminal-failed",namespace="mimir",reason="BackoffLimitExceeded"}'
+        values: "0+0x5 1+0x30"
+      - series: 'kube_job_status_succeeded{cluster="talos-ottawa",job_name="mimir-rules-terminal-failed",namespace="mimir"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: MimirRuleLoaderFailing
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: mimir
+              job_name: mimir-rules-terminal-failed
+              severity: critical
+            exp_annotations:
+              summary: Mimir rule loader Job is failing
+              description: >-
+                The newest content-hashed Mimir rules loader Job has reached a terminal
+                failure. Its three tenant sync containers deliver every native rule
+                group to the Ottawa, Robbinsdale, and St. Petersburg Mimir rulers;
+                inspect the Job and its logs before relying on a newly changed alert.
+
+  # A retained terminally failed Job is history once a newer clean Job exists.
+  - interval: 1m
+    input_series:
+      - series: 'kube_job_created{cluster="talos-ottawa",job_name="mimir-rules-old-failed",namespace="mimir"}'
+        values: "100+0x30"
+      - series: 'kube_job_status_failed{cluster="talos-ottawa",job_name="mimir-rules-old-failed",namespace="mimir",reason="BackoffLimitExceeded"}'
+        values: "1+0x30"
+      - series: 'kube_job_status_succeeded{cluster="talos-ottawa",job_name="mimir-rules-old-failed",namespace="mimir"}'
+        values: "0+0x30"
+      - series: 'kube_job_created{cluster="talos-ottawa",job_name="mimir-rules-new-success",namespace="mimir"}'
+        values: "3600+0x30"
+      - series: 'kube_job_status_succeeded{cluster="talos-ottawa",job_name="mimir-rules-new-success",namespace="mimir"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: MimirRuleLoaderFailing
+        exp_alerts: []
+
+  - interval: 1m
     input_series:
       - series: 'kube_job_status_completion_time{cluster="talos-ottawa",job_name="mimir-rules-old",namespace="mimir"}'
-        values: "0+0x25"
+        values: "0+0x1560"
       - series: 'kube_job_status_completion_time{cluster="talos-ottawa",job_name="mimir-rules-current",namespace="mimir"}'
-        values: "86400+0x25"
+        values: "86400+0x1560"
+      - series: 'kube_job_status_succeeded{cluster="talos-ottawa",job_name="mimir-rules-current",namespace="mimir"}'
+        values: "1+0x1560"
     alert_rule_test:
+      - eval_time: 26h
+        alertname: MimirRuleLoaderFailing
+        exp_alerts: []
       - eval_time: 26h
         alertname: MimirRuleLoaderStale
         exp_alerts: []
 
-  - interval: 1h
+  - interval: 1m
     input_series:
       - series: 'kube_job_status_completion_time{cluster="talos-ottawa",job_name="mimir-rules-old",namespace="mimir"}'
-        values: "0+0x25"
+        values: "0+0x1560"
     alert_rule_test:
       - eval_time: 26h
         alertname: MimirRuleLoaderStale
@@ -34,10 +101,10 @@ tests:
                 the last 24 hours. This also covers the loader Job not being
                 created; inspect Flux, the Job, and the three tenant sync logs.
 
-  - interval: 1h
+  - interval: 1m
     input_series:
       - series: 'kube_node_info{cluster="talos-ottawa",node="node-1"}'
-        values: "1+0x26"
+        values: "1+0x1560"
     alert_rule_test:
       - eval_time: 26h
         alertname: MimirRuleLoaderStale


### PR DESCRIPTION
MimirRuleLoaderFailing previously treated kube_job_status_failed as a terminal signal, so retry failures remained firing after a Job succeeded. This now requires a non-empty terminal failure reason and matches only the newest content-hashed loader Job by kube_job_created. MimirRuleLoaderStale remains the 24-hour no-success dead-man switch. Added fixture coverage for retried-then-succeeded, terminal failure, superseded failure, no recent load, and clean success. Registration in the ConfigMap generator and all three tenant containers was verified.