### PR TITLE
fix(mimir): migrate Bhaiya reconciler liveness alert

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
@@ -10,6 +10,12 @@
 # the cluster aggregation because only the leader runs the loop; a dead
 # non-leader is a separate deployment concern.
 #
+# This file is synced into every Mimir tenant even though Bhaiya is currently
+# deployed only in Ottawa. Gate the liveness expression on the desired Bhaiya
+# Deployment so intentional absence in another tenant is not an incident. The
+# kube-state-metrics signal remains independent of the Bhaiya scrape, allowing
+# the absence arm to detect a dead, evicted, or uns scraped Bhaiya process.
+#
 # Keep this namespace unique across every file passed to mimirtool. A repeated
 # namespace aborts the complete sync for every Mimir tenant.
 namespace: bhaiya-reconciler
@@ -135,11 +141,20 @@ groups:
             ) == 0
           )
           or
-          absent_over_time(
-            bhaiya_reconcile_heartbeat_total{
-              job="bhaiya",
-              container="bhaiya"
-            }[10m]
+          (
+            absent_over_time(
+              bhaiya_reconcile_heartbeat_total{
+                job="bhaiya",
+                container="bhaiya"
+              }[10m]
+            )
+            and on()
+            (
+              kube_deployment_spec_replicas{
+                namespace="bhaiya",
+                deployment="bhaiya"
+              } > 0
+            )
           )
         for: 5m
         labels:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/bhaiya-reconciler.yaml
@@ -1,14 +1,14 @@
 # The reconciler emits cycle-level results: success, blocked, or error. Keep the
-# cycle alerts for compatibility while the bounded workspace gauge provides the
-# actionable page. The gauge identifies the workspace whose reconcile operation
-# returned ErrPendingReview; related stale provider objects can belong to other
-# workspaces and must not be attributed to this label.
+# cycle alerts for compatibility while the bounded workspace gauges provide the
+# actionable pages. The workspace handler gauge identifies the workspace and
+# handler whose latest invocation failed; related provider objects can belong to
+# other workspaces and must not be attributed to this label.
 #
-# last_success_timestamp is updated only after a complete successful pass. Take
-# the newest value across replicas: the non-leader's value is harmless, and the
-# maximum remains the last real success during a leader transfer. Do not gate
-# this alert on bhaiya_reconcile_leader; no leader is itself a no-success
-# condition and must not suppress the signal.
+# Reconciler liveness is a heartbeat counter, not the process-local
+# last_success_timestamp gauge. The heartbeat is emitted by the leader when a
+# pass starts, including passes that later fail. The liveness rule below keeps
+# the cluster aggregation because only the leader runs the loop; a dead
+# non-leader is a separate deployment concern.
 #
 # Keep this namespace unique across every file passed to mimirtool. A repeated
 # namespace aborts the complete sync for every Mimir tenant.
@@ -102,22 +102,55 @@ groups:
             reconciler logs and the affected provider or workspace operation;
             this is distinct from a review-only blocked cycle.
 
-      - alert: BhaiyaReconcileLastSuccessStale
+      - alert: BhaiyaReconcileWorkspaceHandlerFailure
         expr: |
-          time() - max by (cluster) (
-            bhaiya_reconcile_last_success_timestamp_seconds{
+          max by (cluster, workspace, handler) (
+            bhaiya_reconcile_handler_failure{
               job="bhaiya",
               container="bhaiya"
             }
-          ) > 10 * 60
+          ) > 0
         for: 5m
         labels:
           severity: critical
         annotations:
-          summary: Bhaiya reconciliation has stopped completing successful cycles
+          summary: Bhaiya reconciliation handler {{ $labels.handler }} is failing for {{ $labels.workspace }}
           description: >-
-            No successful reconciliation cycle has completed for more than ten
-            minutes. Check `kubectl logs -n bhaiya deploy/bhaiya | grep
-            'reconcile workspace resources'` for the aggregated error, then
-            inspect the cycle result and affected workspace before relying on
-            desired-state convergence.
+            The latest observed {{ $labels.handler }} handler invocation for
+            workspace {{ $labels.workspace }} failed for at least five minutes.
+            This is an item-level failure and does not by itself mean that the
+            reconciler loop is dead; inspect the workspace state, provider-fence
+            decision, and Bhaiya logs.
+
+      - alert: BhaiyaReconcileLastSuccessStale
+        expr: |
+          (
+            sum by (cluster) (
+              increase(
+                bhaiya_reconcile_heartbeat_total{
+                  job="bhaiya",
+                  container="bhaiya"
+                }[10m]
+              )
+            ) == 0
+          )
+          or
+          absent_over_time(
+            bhaiya_reconcile_heartbeat_total{
+              job="bhaiya",
+              container="bhaiya"
+            }[10m]
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Bhaiya reconciliation heartbeat is stale
+          description: >-
+            No Bhaiya reconciliation heartbeat was observed for ten minutes.
+            A zero increase means the scraped process is alive but its loop has
+            stopped; an absent series means the emitting process or scrape is
+            gone. The five-minute alert hold follows the ten-minute emitter
+            grace window, so a brief deploy restart does not page. Check
+            `kubectl logs -n bhaiya deploy/bhaiya | grep 'reconcile workspace
+            resources'` and inspect the per-workspace handler failure alert.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_leader_transition_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_leader_transition_test.yaml
@@ -1,0 +1,60 @@
+rule_files:
+  - ../bhaiya-reconciler.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Only the leader advances the counter. The standby's permanently zero
+  # counter must not create a per-series false positive after the heartbeat
+  # increases are aggregated by cluster.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="leader-1"}'
+        values: "1+1x30"
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="standby-1"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+
+  # The old leader stops exporting at the handoff and the new leader starts
+  # emitting immediately. The old handler-failure series goes stale while the
+  # new leader publishes a current zero, so neither liveness nor attribution
+  # should remain active after the move.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="old-leader"}'
+        values: "1+1x9 _x20"
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="new-leader"}'
+        values: "_x10 1+1x20"
+      - series: 'bhaiya_reconcile_handler_failure{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="old-leader",workspace="raj-trades",handler="ready"}'
+        values: "1+0x9 _x20"
+      - series: 'bhaiya_reconcile_handler_failure{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="new-leader",workspace="raj-trades",handler="ready"}'
+        values: "_x10 0+0x20"
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: BhaiyaReconcileWorkspaceHandlerFailure
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              handler: ready
+              severity: critical
+              workspace: raj-trades
+            exp_annotations:
+              summary: Bhaiya reconciliation handler ready is failing for raj-trades
+              description: >-
+                The latest observed ready handler invocation for workspace
+                raj-trades failed for at least five minutes. This is an
+                item-level failure and does not by itself mean that the
+                reconciler loop is dead; inspect the workspace state,
+                provider-fence decision, and Bhaiya logs.
+      - eval_time: 10m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: BhaiyaReconcileWorkspaceHandlerFailure
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_leader_transition_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_leader_transition_test.yaml
@@ -58,3 +58,13 @@ tests:
       - eval_time: 15m
         alertname: BhaiyaReconcileWorkspaceHandlerFailure
         exp_alerts: []
+
+  # The rule is loaded into every tenant, but Bhaiya is intentionally absent
+  # from tenants where its Deployment is not declared. The absence arm must
+  # stay quiet in those tenants rather than treating configuration as a dead
+  # reconciler.
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_observed_labels_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_observed_labels_test.yaml
@@ -1,0 +1,50 @@
+rule_files:
+  - ../bhaiya-reconciler.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # These labels are copied from a live Mimir-Ottawa control-plane series.
+  # Keep the complete scrape label set here: if a future scrape change moves
+  # job/container to exported_* (or the rule selects the wrong names), the
+  # stalled-loop and item-failure assertions below must stop matching.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",container="bhaiya",endpoint="grpc-web",instance="10.3.3.89:8080",job="bhaiya",namespace="bhaiya",pod="bhaiya-7748f46cc-vk88f",prometheus="monitoring/kube-prometheus-stack",prometheus_replica="prom-agent-kube-prometheus-stack-0",service="bhaiya"}'
+        values: "1+0x20"
+      - series: 'bhaiya_reconcile_handler_failure{cluster="talos-ottawa",container="bhaiya",endpoint="grpc-web",handler="ready",instance="10.3.3.89:8080",job="bhaiya",namespace="bhaiya",pod="bhaiya-7748f46cc-vk88f",prometheus="monitoring/kube-prometheus-stack",prometheus_replica="prom-agent-kube-prometheus-stack-0",service="bhaiya",workspace="raj-trades"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              severity: critical
+            exp_annotations:
+              summary: Bhaiya reconciliation heartbeat is stale
+              description: >-
+                No Bhaiya reconciliation heartbeat was observed for ten minutes.
+                A zero increase means the scraped process is alive but its loop
+                has stopped; an absent series means the emitting process or
+                scrape is gone. The five-minute alert hold follows the
+                ten-minute emitter grace window, so a brief deploy restart does
+                not page. Check `kubectl logs -n bhaiya deploy/bhaiya | grep
+                'reconcile workspace resources'` and inspect the per-workspace
+                handler failure alert.
+      - eval_time: 6m
+        alertname: BhaiyaReconcileWorkspaceHandlerFailure
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              handler: ready
+              severity: critical
+              workspace: raj-trades
+            exp_annotations:
+              summary: Bhaiya reconciliation handler ready is failing for raj-trades
+              description: >-
+                The latest observed ready handler invocation for workspace
+                raj-trades failed for at least five minutes. This is an
+                item-level failure and does not by itself mean that the
+                reconciler loop is dead; inspect the workspace state,
+                provider-fence decision, and Bhaiya logs.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_test.yaml
@@ -34,8 +34,13 @@ tests:
                 handler failure alert.
 
   # No heartbeat series at all must not read as healthy. This exercises the
-  # explicit absent_over_time arm rather than the zero-increase arm.
+  # explicit absent_over_time arm rather than the zero-increase arm. The
+  # desired Deployment proves Bhaiya is expected in this tenant; without it,
+  # intentional absence in a tenant where Bhaiya is not deployed is healthy.
   - interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{cluster="talos-ottawa",namespace="bhaiya",deployment="bhaiya"}'
+        values: "2+0x20"
     alert_rule_test:
       - eval_time: 14m
         alertname: BhaiyaReconcileLastSuccessStale

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_test.yaml
@@ -1,0 +1,114 @@
+rule_files:
+  - ../bhaiya-reconciler.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # A scraped process whose counter stops is alive but its reconcile loop is
+  # dead. The zero-increase arm must remain pending for five minutes and then
+  # fire.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="leader-1"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+      - eval_time: 6m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              severity: critical
+            exp_annotations:
+              summary: Bhaiya reconciliation heartbeat is stale
+              description: >-
+                No Bhaiya reconciliation heartbeat was observed for ten minutes.
+                A zero increase means the scraped process is alive but its loop
+                has stopped; an absent series means the emitting process or
+                scrape is gone. The five-minute alert hold follows the
+                ten-minute emitter grace window, so a brief deploy restart does
+                not page. Check `kubectl logs -n bhaiya deploy/bhaiya | grep
+                'reconcile workspace resources'` and inspect the per-workspace
+                handler failure alert.
+
+  # No heartbeat series at all must not read as healthy. This exercises the
+  # explicit absent_over_time arm rather than the zero-increase arm.
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts:
+          - exp_labels:
+              container: bhaiya
+              job: bhaiya
+              severity: critical
+            exp_annotations:
+              summary: Bhaiya reconciliation heartbeat is stale
+              description: >-
+                No Bhaiya reconciliation heartbeat was observed for ten minutes.
+                A zero increase means the scraped process is alive but its loop
+                has stopped; an absent series means the emitting process or
+                scrape is gone. The five-minute alert hold follows the
+                ten-minute emitter grace window, so a brief deploy restart does
+                not page. Check `kubectl logs -n bhaiya deploy/bhaiya | grep
+                'reconcile workspace resources'` and inspect the per-workspace
+                handler failure alert.
+
+  # A short scrape/process gap during a deploy is inside the ten-minute
+  # emitter grace window. The replacement process resumes with a reset counter
+  # and continues emitting, so neither liveness arm should fire.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="leader-1"}'
+        values: "1+1x4 _x2 1+1x30"
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+
+  # A continuously running loop is healthy even when one workspace handler is
+  # persistently failing. The fleet liveness signal stays clear while the
+  # workspace/handler alert names the failing item.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="leader-1"}'
+        values: "1+1x30"
+      - series: 'bhaiya_reconcile_handler_failure{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="leader-1",workspace="raj-trades",handler="ready"}'
+        values: "1+0x30"
+      - series: 'bhaiya_reconcile_handler_failure{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="leader-1",workspace="healthy",handler="ready"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BhaiyaReconcileWorkspaceHandlerFailure
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              handler: ready
+              severity: critical
+              workspace: raj-trades
+            exp_annotations:
+              summary: Bhaiya reconciliation handler ready is failing for raj-trades
+              description: >-
+                The latest observed ready handler invocation for workspace
+                raj-trades failed for at least five minutes. This is an
+                item-level failure and does not by itself mean that the
+                reconciler loop is dead; inspect the workspace state,
+                provider-fence decision, and Bhaiya logs.
+
+  # A continuously incrementing heartbeat is healthy and must not alert.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="leader-1"}'
+        values: "1+1x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []


### PR DESCRIPTION
## Summary

- Migrate `BhaiyaReconcileLastSuccessStale` from the process-local last-success timestamp to the reset-safe heartbeat counter.
- Aggregate heartbeat activity by `cluster` before testing for zero, because only the elected leader increments it.
- OR the zero-increase arm with an explicit `absent_over_time()` arm so a dead, evicted, crashlooping, or uns scraped emitter is visible.
- Gate only the absence arm on the expected `bhaiya` Deployment. This rule is synchronized into all three Mimir tenants, but Bhaiya is currently deployed only in Ottawa; intentional absence in the other tenants must not page.
- Add `BhaiyaReconcileWorkspaceHandlerFailure`, grouped by `cluster`, `workspace`, and `handler`, so a single workspace failure remains attributable.
- Add leader/standby and leadership-transition fixtures, including stale old-leader handler series and an intentionally undeployed tenant.

## Live emitter

The precondition is satisfied. Live `bhaiya_build_info` reports control-plane version `770b23dbd859a62d8c555064dcd0a0c6ec6af5a4`, and both `bhaiya_reconcile_heartbeat_total` and `bhaiya_reconcile_handler_failure` are present in the Ottawa Mimir tenant.

The exact `job="bhaiya", container="bhaiya"` selector excludes the permanently zero MCP, payments, and SSH series. A tenant sweep found no matching control-plane series in Robbinsdale or St. Petersburg, where Bhaiya is not deployed; no scrape relabeling maps their distinct container labels to `container="bhaiya"`. The shared metric registration remains a Bhaiya follow-up: the reconciler heartbeat and handler-failure families should ideally be registered only by the reconciler-bearing control-plane binary, not every Bhaiya binary. This PR scopes the alert safely without changing the application emitter.

## Exact PromQL

Liveness, with `for: 5m`:

~~~promql
(
  sum by (cluster) (
    increase(bhaiya_reconcile_heartbeat_total{
      job="bhaiya", container="bhaiya"
    }[10m])
  ) == 0
)
or
(
  absent_over_time(
    bhaiya_reconcile_heartbeat_total{
      job="bhaiya", container="bhaiya"
    }[10m]
  )
  and on()
  (
    kube_deployment_spec_replicas{
      namespace="bhaiya", deployment="bhaiya"
    } > 0
  )
)
~~~

The 10-minute range is the emitter/scrape grace window; the five-minute hold follows it. A normal short deploy restart therefore does not alert, while a missing emitter alerts after approximately 15 minutes. The deployment guard prevents a rule loaded in a tenant without Bhaiya from treating intentional configuration as a dead reconciler.

The attribution alert, with `for: 5m`, is:

~~~promql
max by (cluster, workspace, handler) (
  bhaiya_reconcile_handler_failure{
    job="bhaiya", container="bhaiya"
  }
) > 0
~~~

Pod identity is deliberately removed. During leadership transfer the old positive series becomes stale and the new leader publishes the current zero; the grouped alert clears once the old series leaves the five-minute lookback. A new leader publishing a positive current state remains attributable to the same workspace and handler.

Only the leader is expected to increment the heartbeat. A healthy leader plus a permanently zero standby does not alert. A dead standby alone does not alert; a dead leader alerts if no leader takes over, and a successful takeover keeps the aggregate increasing.

## Verification

- Prometheus 3.14.0 rule parse: `Mimir PromQL valid: 33 rule files (Prometheus 3.14.0)`.
- Full fixture runner: `Mimir rule fixtures: 16 fixtures, 15 rule files`.
- Loader registration: `Mimir rule load-path: 33 files, 3 tenant loaders, 32 unique namespaces`.
- Focused reconciler fixtures both pass, covering loop stopped, total absence, normal restart, healthy operation, leader/standby, leadership transfer, stale handler-series cleanup, and intentional tenant absence.

The PR remains open and is not merged.