### PR TITLE
fix(velero): decouple media config backup from Kometa

### DIFF
--- a/kubernetes/apps/base/velero/MIGRATION.md
+++ b/kubernetes/apps/base/velero/MIGRATION.md
@@ -104,8 +104,8 @@
 
 | Namespace | Cluster | StorageStacks | Current Schedule | Velero Schedule |
 |---|---|---|---|---|
-| media | ottawa | 20 | 0 4 * * * | 0 6 * * * ✓ |
-| media | robbinsdale | ~20 | 0 4 * * * | 0 6 * * * ✓ |
+| media | ottawa | 20 | 0 4 * * * | 0 7 * * * ✓ |
+| media | robbinsdale | ~20 | 0 4 * * * | 0 7 * * * ✓ |
 | hermes | ottawa | 1 | 0 4 * * * | 0 7 * * * ✓ |
 | agents | ottawa | 5 | 0 4 * * * | 0 7 * * * ✓ (in hermes schedule) |
 | immich | ottawa | 1 | 0 3 * * * | 0 8 * * * ✓ |

--- a/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
@@ -16,7 +16,10 @@ metadata:
   labels:
     keiretsu.top/volume-data-required: "true"
 spec:
-  schedule: "0 6 * * *"
+  # Run after the 06:00 Kometa jobs have completed and before the next
+  # application-maintenance window.  The filesystem backup needs stable pod
+  # mounts for the duration of the run.
+  schedule: "0 7 * * *"
   template:
     ttl: 168h
     includedNamespaces:

--- a/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
@@ -16,7 +16,10 @@ metadata:
   labels:
     keiretsu.top/volume-data-required: "true"
 spec:
-  schedule: "0 6 * * *"
+  # Run after the 06:00 Kometa jobs have completed and before the next
+  # application-maintenance window.  The filesystem backup needs stable pod
+  # mounts for the duration of the run.
+  schedule: "0 7 * * *"
   template:
     ttl: 168h
     includedNamespaces:


### PR DESCRIPTION
## Summary

Move the Ottawa and Robbinsdale `media-config-backup` Velero schedules from `0 6 * * *` to `0 7 * * *`, after the 06:00 Kometa CronJobs. Update the migration table to match.

This is a deliberate partial mitigation. It removes the deterministic Kometa overlap and moves the backup out of the observed 06:09–06:29 disruption window, but it does **not** bound or repair a backup that wedges for more than one hour. It must not be treated as closing the broader lifecycle issue in #2729.

## Evidence and scope

The schedule covers 29 unique PVC/PVB targets in Ottawa and 24 in Robbinsdale. Observed run windows were:

- Ottawa Sep 8: 06:00:02–06:13:58 (13m56s)
- Ottawa Sep 9: 06:00:03–06:38:37 (38m34s), 25 completed and 4 failed of 29 targets
- Robbinsdale Sep 8: 06:00:29–06:15:36 (15m07s), 23 completed and 1 failed of 24 targets
- Robbinsdale Sep 9: `media-config-backup-20260909060030` remained `InProgress` at 09:14 UTC; its 24 PVBs were already terminal by 06:26:13 (21 `Completed`, 2 `Failed`, 1 `Canceled`)

Kometa completed at 06:05:01 in Robbinsdale on Sep 9, while its failed PVB was created at 06:05:12 after the mount had been torn down. On Sep 8, the Job completed at 06:06:56 and the PVB was created at 06:13:31.

The qBittorrent and qBittorrent-pvt failures were separate delayed-PVB processing against replaced pod identities. No media VPA/HPA rollout was found; the immediate trigger appears to be broader node/cluster maintenance or restart activity and needs separate lifecycle investigation.

## Why the 2h42m run was stuck

This was not a 10x slow data transfer or an unbounded retry. The Velero server log processed all 707 resource items by 06:26:18 and then stopped at `Waiting for completion of PVB`. The canceled PVB `media-config-backup-20260909060030-k7r7q` had a Kopia `StatObject: BLOB not found` during its upload at 06:02:47 and entered `Canceled` at 06:03:13.

The deployed Velero is v1.18.2. Its v1.18.2 `pkg/podvolume/backupper.go:182-185` final-state handler checks the incoming `pvb.Status.Phase == Canceled` instead of the indexed previous object's canceled phase. For the first transition to `Canceled`, that makes `statusChangedToFinal` false, so it never calls `WaitGroup.Done()`. The backup controller consequently waits even though every PVB is terminal. This is an upstream-version defect exposed by the real Kopia failure, not a reason to call the schedule healthy.

## Timeout and follow-up boundary

A bound exists but is four hours: the live Velero pod runs `--fs-backup-timeout=4h`, and the live Backup has `spec.itemOperationTimeout: 4h0m0s`. The 168-hour `ttl` is retention, not an execution timeout. The stuck Backup therefore has a circuit breaker around 10:00:30 UTC, far beyond the one-hour schedule offset.

The durable follow-up should combine an upstream Velero fix/upgrade for canceled-PVB accounting with a per-schedule pod-volume operation timeout of about one hour initially (45 minutes is the lower bound suggested by the observed 38m34s run, but leaves little headroom). If that still produces long variable runs, split the 24–29 targets into stable application groups and run them in separate schedules; that also limits failure blast radius. Neither follow-up is included here because it needs validation of the timeout semantics and target grouping.

## Safety

- No live resources were changed.
- Kometa application schedules remain at 06:00.
- No monitoring rules or Kopiur/Velero restore changes are included.
- The deeper node-agent preparation, delayed-PVB handling, and CSI-snapshot-versus-filesystem-backup decisions remain tracked in #2729.

## Validation

`git diff --check` passes. The repository's scoped render gates reached the baseline render but timed out with unrelated pre-existing HelmRepository `no status reported` failures (Ottawa: 233 failed; Robbinsdale: 177 failed); no schedule-manifest diagnostic was reported. The repository `--quick` gate also stopped on the pre-existing `agent-sandbox/agent-sandbox` directory lacking a kustomization file.
