### PR TITLE
fix(velero): bound media filesystem backup operations

### DIFF
--- a/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/media-config-backup.yaml
@@ -13,6 +13,11 @@ kind: Schedule
 metadata:
   name: media-config-backup
   namespace: velero-system
+  annotations:
+    # Velero copies Schedule annotations onto each generated Backup. Healthy
+    # runs take 14-39 minutes; bound a wedged filesystem operation before it
+    # overlaps the next maintenance window.
+    velero.io/pod-volume-timeout: "1h"
   labels:
     keiretsu.top/volume-data-required: "true"
 spec:

--- a/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
+++ b/kubernetes/apps/robbinsdale/velero/schedules/media-config-backup.yaml
@@ -13,6 +13,11 @@ kind: Schedule
 metadata:
   name: media-config-backup
   namespace: velero-system
+  annotations:
+    # Velero copies Schedule annotations onto each generated Backup. Healthy
+    # runs take 14-39 minutes; bound a wedged filesystem operation before it
+    # overlaps the next maintenance window.
+    velero.io/pod-volume-timeout: "1h"
   labels:
     keiretsu.top/volume-data-required: "true"
 spec:


### PR DESCRIPTION
Adds velero.io/pod-volume-timeout: "1h" to the media-config-backup Schedule metadata in Ottawa and Robbinsdale.

Why:
- Healthy observed media runs were 13m56s, 15m07s, and 38m34s for 24-29 targets.
- A one-hour pod-volume-operation bound leaves 21m26s over the longest healthy run while stopping a wedge from consuming the four-hour global window.
- Schedule metadata annotations are copied to generated Backups by Velero, so this is intentionally on Schedule.metadata, not the label-only spec.template.metadata field.
- This complements the already-merged #2910 07:00 schedule decoupling; it does not claim to eliminate lifecycle failures.

Upstream diagnosis:
Velero v1.18.2 pkg/podvolume/backupper.go:182-185 checks the incoming canceled PVB instead of the indexed existing PVB. On the first Canceled transition that suppresses WaitGroup.Done, leaving the Backup waiting even after all PVBs are terminal. v1.18.3-rc.1 and v1.18.3-rc.2 contain the corrected existing-object check; no stable v1.18.3 tag exists yet as of 2026-09-09. This PR does not roll out an RC. A stable upgrade should be a normal Velero image-tag update with the usual canary and validation.

The canceled-PVB accounting bug explains the Robbinsdale controller wedge, but the observed terminal PVB errors remain distinct: Kometa mount teardown after its CronJob, qBittorrent stale client-pod identities after replacement, Maintainerr preparation timeout, and Tracearr Kopia BLOB-not-found. The long wedge amplifies lifecycle risk but does not turn those four error classes into one cause.

Validation:
- KMAN_CHECK_TIMEOUT=300 tools/check.sh
- ✓ render OK: talos-ottawa talos-robbinsdale talos-stpetersburg

This is a mitigation PR only. No live resources were changed, and it must not be merged or released as part of this change.