### PR TITLE
ci: enforce aligned multus references

### DIFF
--- a/docs/agent-knowledge/flux-helmrelease-missing-rollback-target.md
+++ b/docs/agent-knowledge/flux-helmrelease-missing-rollback-target.md
@@ -1,0 +1,66 @@
+# Flux HelmRelease: recover a stalled missing rollback target
+
+Date: 2026-09-09 UTC
+
+## Symptom
+
+`FluxHelmReleaseNotReady` can remain critical for a HelmRelease whose workload
+is already healthy. The Ottawa `flux-system/flux-operator` release is the
+reference case:
+
+- `Deployment/flux-operator` is Ready on the desired image;
+- the Flux Kustomizations are Ready; but
+- the HelmRelease is `Stalled=True` with reason `MissingRollbackTarget` and
+  `upgradeFailures=2`.
+
+This is a delivery-controller failure, not proof that the Deployment is down.
+While it remains stalled, a later flux-operator upgrade can be withheld, so
+the alert still needs an owner.
+
+## Why a plain reconcile is not enough
+
+Helm-controller's remediation path treats `MissingRollbackTarget` as a failed
+upgrade with no usable rollback target. A plain reconcile preserves the failure
+state and re-enters that rollback remediation; it does not clear the recorded
+failure budget. The exact controller behavior was confirmed from the
+controller source before documenting this procedure.
+
+Do not repeatedly retry a plain reconcile and call that recovery. Do not delete
+the HelmRelease or edit its status.
+
+## Approved one-off recovery
+
+After the owner confirms that the Deployment is healthy and the release should
+be retried, run the following live action once:
+
+```sh
+flux reconcile helmrelease flux-operator -n flux-system --reset
+```
+
+`--reset` is a state-changing operation. It resets the failed remediation state
+so Helm-controller can evaluate the current desired revision again; it is not a
+manifest change and is not a substitute for fixing a bad chart or values file.
+Do not run it unattended during another control-plane or CNI incident.
+
+## Verification and escalation
+
+Before the reset, record the HelmRelease conditions, failure counts, desired
+chart revision, and Deployment image. After the reset, verify read-only that:
+
+1. the HelmRelease returns to `Ready=True` and `Stalled=False`;
+2. `upgradeFailures` no longer increases (and normally returns to zero after
+   successful reconciliation);
+3. the Deployment remains Available and its image is unchanged from the
+   intended revision; and
+4. `FluxHelmReleaseNotReady` clears and no dependent Flux Kustomization or
+   HelmRelease becomes unhealthy.
+
+If the reset fails again, stop retrying. Inspect the HelmRelease events and
+controller logs, identify the failed resource or missing history, and treat it
+as a new release failure. A healthy Deployment does not make an arbitrary
+force-reset safe.
+
+This runbook is deliberately separate from the immutable-Secret rotation
+procedure in issue `#2908`: both are Flux state hazards, but the Secret fix is
+name-based rotation, while this HelmRelease case is an owner-approved,
+one-off remediation reset.

--- a/tools/check-versions.sh
+++ b/tools/check-versions.sh
@@ -368,6 +368,10 @@ for cluster in CLUSTERS:
     base = pathlib.Path(f"kubernetes/apps/base/kube-system/cilium-{cluster}/app")
     kustomization = base / "kustomization.yaml"
 
+    # Multus is a three-part artifact: the raw manifest supplies the daemon,
+    # while the patch installs the shim and runs that daemon. A partial revert
+    # can leave either image on a different release even when Renovate grouped
+    # the references correctly, so compare all three independently.
     def multus_manifest(path=kustomization):
         resource = next(
             item for item in yaml.safe_load(path.read_text())["resources"]
@@ -375,19 +379,21 @@ for cluster in CLUSTERS:
         )
         return canonical(re.search(r"/multus-cni/(v\d+\.\d+\.\d+)/", resource).group(1))
 
-    def multus_runtime(cluster=cluster, base=base, path=kustomization):
+    def multus_runtime(container_name, cluster=cluster, base=base, path=kustomization):
         if cluster == "robbinsdale":
             patch = yaml.safe_load(path.read_text())["patches"][0]["patch"]
             doc = yaml.safe_load(patch)
         else:
             doc = yaml.safe_load((base / "patch-multus.yaml").read_text())
-        containers = doc["spec"]["template"]["spec"]["initContainers"]
-        image = next(c["image"] for c in containers if c["name"] == "install-multus-binary")
+        pod_spec = doc["spec"]["template"]["spec"]
+        containers = pod_spec.get("initContainers", []) + pod_spec.get("containers", [])
+        image = next(c["image"] for c in containers if c["name"] == container_name)
         return canonical(image.split(":", 1)[1].split("@", 1)[0])
 
     require_equal(f"Multus {cluster}", [
         ("manifest", multus_manifest),
-        ("runtime", multus_runtime),
+        ("shim", lambda: multus_runtime("install-multus-binary")),
+        ("daemon", lambda: multus_runtime("kube-multus")),
     ])
 
 envoy_base = pathlib.Path(

--- a/tools/tests/multus-version-invariant.sh
+++ b/tools/tests/multus-version-invariant.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Exercise the real version-sync checker against isolated aligned and split
+# repository fixtures. This deliberately does not change the checkout under
+# test, and it does not require a live cluster.
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture_root="$(mktemp -d)"
+trap 'rm -rf -- "$fixture_root"' EXIT INT TERM
+
+repo="$fixture_root/repo"
+mkdir -p "$repo"
+git -C "$ROOT" archive -o "$fixture_root/repo.tar" HEAD
+tar -xf "$fixture_root/repo.tar" -C "$repo"
+
+# Make the fixture's two image references agree with each cluster's raw
+# manifest URL. The immutable digests are irrelevant to this version-only
+# invariant, so the fixture preserves them while changing only the tags.
+python3 - "$repo" <<'PY'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+for cluster in ("ottawa", "robbinsdale", "stpetersburg"):
+    base = root / f"kubernetes/apps/base/kube-system/cilium-{cluster}/app"
+    kustomization = base / "kustomization.yaml"
+    text = kustomization.read_text()
+    version = re.search(r"/multus-cni/(v\d+\.\d+\.\d+)/", text).group(1)
+    patch = kustomization if cluster == "robbinsdale" else base / "patch-multus.yaml"
+    content = patch.read_text()
+    content, count = re.subn(
+        r"(multus-cni:)v\d+\.\d+\.\d+-thick",
+        rf"\g<1>{version}-thick",
+        content,
+    )
+    if count != 2:
+        raise SystemExit(f"{patch}: expected two Multus image tags, changed {count}")
+    patch.write_text(content)
+PY
+
+run_check() {
+    local output_file="$1"
+    set +e
+    (cd "$repo" && env -u CI tools/check-versions.sh) >"$output_file" 2>&1
+    local status=$?
+    set -e
+    return "$status"
+}
+
+aligned_output="$fixture_root/aligned.out"
+if ! run_check "$aligned_output"; then
+    echo "aligned Multus fixture unexpectedly failed:" >&2
+    cat "$aligned_output" >&2
+    exit 1
+fi
+
+# Split only Ottawa's daemon image after the aligned run. The production check
+# must reject this exact partial-revert shape and identify the daemon artifact.
+python3 - "$repo/kubernetes/apps/base/kube-system/cilium-ottawa/app/patch-multus.yaml" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+prefix, daemon = text.split("- name: kube-multus", 1)
+daemon, count = re.subn(
+    r"(?m)^(\s+image:\s+ghcr\.io/k8snetworkplumbingwg/multus-cni:)v\d+\.\d+\.\d+-thick",
+    r"\g<1>v0.0.0-thick",
+    daemon,
+    count=1,
+)
+if count != 1:
+    raise SystemExit(f"{path}: could not split the daemon image")
+path.write_text(prefix + "- name: kube-multus" + daemon)
+PY
+
+mismatch_output="$fixture_root/mismatch.out"
+if run_check "$mismatch_output"; then
+    echo "mismatched Multus fixture unexpectedly passed" >&2
+    cat "$mismatch_output" >&2
+    exit 1
+fi
+grep -q "Multus ottawa: coupled artifacts differ" "$mismatch_output"
+grep -q "daemon: 0.0.0" "$mismatch_output"
+
+printf '%s\n' "✓ Multus invariant fixtures: aligned passes; Ottawa daemon split fails"

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -391,6 +391,12 @@ aliasout="$(PATH="$mstub:$PATH" "$gate_root/tools/check.sh" ot 2>/dev/null)"
 assert "short cluster alias accepted"   grep -q '^✓ render OK: talos-ottawa$' <<<"$aliasout"
 rm -rf "$gate_root"
 
+# ---------------------------------------------------------------- Multus version invariant
+section "Multus version invariant"
+multus_out="$("$T/tests/multus-version-invariant.sh" 2>&1)"; multus_ec=$?
+assert "aligned fixture passes and split fixture fails" test "$multus_ec" = 0
+assert "fixture test reports both directions" grep -q 'aligned passes; Ottawa daemon split fails' <<<"$multus_out"
+
 # ---------------------------------------------------------------- Mimir rule completeness replay
 section "Mimir rule completeness replay"
 exits "km#2809 missing-group condition is detected" 0 \


### PR DESCRIPTION
## What this adds

- Extends `tools/check-versions.sh` so each cluster compares all three Multus references: the raw `multus-daemonset-thick.yml` URL, the `install-multus-binary` host shim image, and the `kube-multus` daemon image.
- Adds `tools/tests/multus-version-invariant.sh`, which archives an isolated repository fixture, proves an aligned pair passes, then splits only Ottawa daemon version and proves the real checker fails.
- Adds the short `MissingRollbackTarget` recovery runbook at `docs/agent-knowledge/flux-helmrelease-missing-rollback-target.md`. It documents `flux reconcile helmrelease flux-operator -n flux-system --reset` but does not run it.

## Required workflow wiring

This PR intentionally touches no workflow file so it can be pushed with the current GitHub token. After merge, add this exact step to `jobs.validate.steps` in `.github/workflows/validate.yaml`, after checkout and PyYAML installation:

```yaml
- name: Check coupled version invariants
  run: tools/check-versions.sh
```

The repository ruleset requires the `validate` check; `version-sync / check` is supplementary and is not the required gate. The workflow follow-up requires a token with the `workflow` scope.

## Deliberately red until Multus alignment

Current `main` is still the real mismatched state. Running the checker exits 1 for all three clusters:

```text
manifest: 4.3.0
shim: 4.3.0
daemon: 4.3.1
```

That is expected. Merge #2899 or #2905 first; once one aligns the references, this invariant should pass. The fixture test proves both directions independently. #2899 and #2905 overlap on version alignment; if #2899 lands first, #2905 reduces to its probe changes.

## Verification

- Current main mismatch: exit 1 for Ottawa, Robbinsdale, and St. Petersburg.
- Aligned fixture: exit 0.
- Split Ottawa daemon fixture: exit 1 with `daemon: 0.0.0` identified.
- `tools/tests/run.sh`: 199 passed, 0 failed.

Do not merge this PR until the Multus alignment lands and the required workflow step is added.