### PR TITLE
test(mimir): aggregate all fixture failures

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
-RULE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+if [ -n "${MIMIR_RULE_DIR:-}" ]; then
+  RULE_DIR="$MIMIR_RULE_DIR"
+else
+  RULE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fi
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/mimir-rules.XXXXXX")
 trap 'rm -rf -- "$tmpdir"' EXIT
 
@@ -10,6 +14,23 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 # only that Mimir wrapper in the temporary test copy.
 tested_rules=0
 tested_fixtures=0
+failure_names=()
+failure_logs=()
+
+record_failure() {
+  local fixture_name="$1"
+  local failure_log="$2"
+  failure_names+=("$fixture_name")
+  failure_logs+=("$failure_log")
+}
+
+record_message_failure() {
+  local fixture_name="$1"
+  local message="$2"
+  local failure_log="$tmpdir/failure-${#failure_logs[@]}.log"
+  printf '%s\n' "$message" >"$failure_log"
+  record_failure "$fixture_name" "$failure_log"
+}
 
 # Discover the rule files from each fixture's rule_files list. This keeps the
 # runner structural: adding a *_test.yaml is enough to make it run, including
@@ -19,6 +40,7 @@ tested_fixtures=0
 while IFS= read -r test_file; do
   [ -n "$test_file" ] || continue
   fixture_name=${test_file##*/}
+  tested_fixtures=$((tested_fixtures + 1))
   rule_refs=()
   while IFS= read -r rule_ref; do
     [ -n "$rule_ref" ] && rule_refs+=("$rule_ref")
@@ -27,38 +49,89 @@ while IFS= read -r test_file; do
   )
 
   if [ "${#rule_refs[@]}" -eq 0 ]; then
-    echo "error: $test_file has no rule_files entry" >&2
-    exit 1
+    record_message_failure "$fixture_name" "error: $test_file has no rule_files entry"
+    continue
   fi
 
   rewritten_fixture="$tmpdir/$fixture_name"
-  cp "$test_file" "$rewritten_fixture"
+  if ! cp "$test_file" "$rewritten_fixture" 2>"$tmpdir/copy-$tested_fixtures.log"; then
+    record_failure "$fixture_name" "$tmpdir/copy-$tested_fixtures.log"
+    continue
+  fi
+  fixture_failed=0
   for rule_ref in "${rule_refs[@]}"; do
     rule_file=${rule_ref#../}
     case "$rule_file" in
       */*)
-        echo "error: $test_file has an unsafe rule_files path: $rule_ref" >&2
-        exit 1
+        record_message_failure "$fixture_name" \
+          "error: $test_file has an unsafe rule_files path: $rule_ref"
+        fixture_failed=1
+        break
         ;;
     esac
     source_rule="$RULE_DIR/$rule_file"
     temp_rule="$tmpdir/$rule_file"
     if [ ! -f "$source_rule" ]; then
-      echo "error: $test_file references missing rule file: $rule_ref" >&2
-      exit 1
+      record_message_failure "$fixture_name" \
+        "error: $test_file references missing rule file: $rule_ref"
+      fixture_failed=1
+      break
     fi
     if [ ! -f "$temp_rule" ]; then
-      sed -E '/^namespace:[[:space:]]+[^[:space:]]+[[:space:]]*$/d' \
-        "$source_rule" >"$temp_rule"
-      promtool check rules "$temp_rule"
+      if ! sed -E '/^namespace:[[:space:]]+[^[:space:]]+[[:space:]]*$/d' \
+        "$source_rule" >"$temp_rule" 2>"$tmpdir/sed-$tested_fixtures.log"; then
+        record_failure "$fixture_name" "$tmpdir/sed-$tested_fixtures.log"
+        fixture_failed=1
+        break
+      fi
+      rule_check_log="$tmpdir/check-$tested_fixtures-$tested_rules.log"
+      if promtool check rules "$temp_rule" >"$rule_check_log" 2>&1; then
+        cat "$rule_check_log"
+      else
+        rule_status=$?
+        printf '\n[ promtool check rules exited %d ]\n' "$rule_status" >>"$rule_check_log"
+        rm -f -- "$temp_rule"
+        record_failure "$fixture_name" "$rule_check_log"
+        fixture_failed=1
+        break
+      fi
       tested_rules=$((tested_rules + 1))
     fi
-    sed "s#${rule_ref}#${temp_rule}#g" "$rewritten_fixture" >"$rewritten_fixture.next"
-    mv "$rewritten_fixture.next" "$rewritten_fixture"
+    if ! sed "s#${rule_ref}#${temp_rule}#g" "$rewritten_fixture" \
+      >"$rewritten_fixture.next" 2>"$tmpdir/rewrite-$tested_fixtures.log"; then
+      record_failure "$fixture_name" "$tmpdir/rewrite-$tested_fixtures.log"
+      fixture_failed=1
+      break
+    fi
+    if ! mv "$rewritten_fixture.next" "$rewritten_fixture"; then
+      record_message_failure "$fixture_name" "error: could not rewrite $test_file"
+      fixture_failed=1
+      break
+    fi
   done
 
-  promtool test rules "$rewritten_fixture"
-  tested_fixtures=$((tested_fixtures + 1))
+  if [ "$fixture_failed" -ne 0 ]; then
+    continue
+  fi
+
+  fixture_log="$tmpdir/test-$tested_fixtures.log"
+  if promtool test rules "$rewritten_fixture" >"$fixture_log" 2>&1; then
+    cat "$fixture_log"
+  else
+    fixture_status=$?
+    printf '\n[ promtool test rules exited %d ]\n' "$fixture_status" >>"$fixture_log"
+    record_failure "$fixture_name" "$fixture_log"
+  fi
 done < <(find "$RULE_DIR/tests" -maxdepth 1 -type f -name '*_test.yaml' -print | sort)
+
+if [ "${#failure_names[@]}" -ne 0 ]; then
+  printf '\nMimir rule fixture failures: %d of %d fixtures\n' \
+    "${#failure_names[@]}" "$tested_fixtures" >&2
+  for index in "${!failure_names[@]}"; do
+    printf '\n--- %s ---\n' "${failure_names[$index]}" >&2
+    cat "${failure_logs[$index]}" >&2
+  done
+  exit 1
+fi
 
 echo "✓ Mimir rule fixtures: $tested_fixtures fixtures, $tested_rules rule files"

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -868,6 +868,99 @@ else
 fi
 rm -f "$schema_contract_out"
 
+# ---------------------------------------------------------------- Mimir rule fixture runner
+# The production runner must execute every discovered fixture after a failure.
+# Keep this proof offline: a stub promtool makes two deliberately broken
+# fixtures fail independently, so the assertion is about runner aggregation,
+# not Prometheus availability.
+section "Mimir rule fixture runner"
+runner_fixture_root="$(mktemp -d)"
+runner_promtool_root="$(mktemp -d)"
+mkdir -p "$runner_fixture_root/tests"
+cat >"$runner_fixture_root/rule-a.yaml" <<'EOF'
+groups:
+  - name: deliberate-a
+    rules:
+      - alert: DeliberateA
+        expr: vector(0)
+EOF
+cat >"$runner_fixture_root/rule-b.yaml" <<'EOF'
+groups:
+  - name: deliberate-b
+    rules:
+      - alert: DeliberateB
+        expr: vector(0)
+EOF
+cat >"$runner_fixture_root/tests/a_broken_test.yaml" <<'EOF'
+rule_files:
+  - ../rule-a.yaml
+evaluation_interval: 1m
+tests:
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: DeliberateA
+        exp_alerts:
+          - exp_labels: {}
+EOF
+cat >"$runner_fixture_root/tests/b_broken_test.yaml" <<'EOF'
+rule_files:
+  - ../rule-b.yaml
+evaluation_interval: 1m
+tests:
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: DeliberateB
+        exp_alerts:
+          - exp_labels: {}
+EOF
+
+cat >"$runner_promtool_root/promtool" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "check rules")
+    printf 'Checking %s\n  SUCCESS: deliberate rule parsed\n\n' "$3"
+    exit 0
+    ;;
+  "test rules")
+    case "${3##*/}" in
+      a_broken_test.yaml)
+        echo 'FAILED: deliberate fixture A'
+        exit 1
+        ;;
+      b_broken_test.yaml)
+        echo 'FAILED: deliberate fixture B'
+        exit 1
+        ;;
+    esac
+    ;;
+esac
+echo "unexpected promtool invocation: $*" >&2
+exit 2
+EOF
+chmod +x "$runner_promtool_root/promtool"
+
+runner_output="$(
+  PATH="$runner_promtool_root:$PATH" \
+    MIMIR_RULE_DIR="$runner_fixture_root" \
+    "$ROOT/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh" 2>&1
+)"
+runner_exit=$?
+printf '%s\n' "$runner_output" | grep -E '^(Mimir rule fixture failures:|--- |FAILED: deliberate fixture)'
+assert "runner returns nonzero when fixtures fail" test "$runner_exit" != 0
+assert "runner reports first broken fixture" \
+  grep -q -- '^--- a_broken_test.yaml ---$' <<<"$runner_output"
+assert "runner reports second broken fixture" \
+  grep -q -- '^--- b_broken_test.yaml ---$' <<<"$runner_output"
+assert "runner reports both failures together" \
+  test "$(grep -c '^--- .*_broken_test.yaml ---$' <<<"$runner_output")" = 2
+assert "runner retains first promtool error" \
+  grep -q 'FAILED: deliberate fixture A' <<<"$runner_output"
+assert "runner retains second promtool error" \
+  grep -q 'FAILED: deliberate fixture B' <<<"$runner_output"
+rm -rf "$runner_fixture_root" "$runner_promtool_root"
+
 # ---------------------------------------------------------------- summary
 printf '\n== %d passed, %d failed ==\n' "$pass" "$fail"
 [ "$fail" = 0 ]


### PR DESCRIPTION
## Summary

- run every structurally discovered Mimir fixture even after a failure
- collect and report all fixture failures together, then exit non-zero
- add an offline proof with two deliberately broken fixtures

## Proof

The focused proof reports both failures in one run:

```text
Mimir rule fixture failures: 2 of 2 fixtures
--- a_broken_test.yaml ---
FAILED: deliberate fixture A
--- b_broken_test.yaml ---
FAILED: deliberate fixture B
```

Production verification passes: `✓ Mimir rule fixtures: 14 fixtures, 14 rule files`.

## Exact workflow handoff for Raj

This PR intentionally contains no workflow file because the current OAuth token lacks the `workflow` scope. After `gh auth refresh -h github.com -s workflow`, paste these exact additions into `.github/workflows/flate.yaml`.

At line 3, immediately below `on:` and before `pull_request:`, add:

```yaml
  push:
    branches: [main]
    paths:
      - "clusters/**"
      - "kubernetes/**"
      - "tools/**"
      - "Makefile"
      - ".github/workflows/flate.yaml"
```

At line 19, immediately below `jobs:` and before `test:`, add:

```yaml
  mimir-rule-tests:
    name: Mimir rule fixtures
    runs-on: ubuntu-latest
    timeout-minutes: 15
    permissions:
      contents: read
    steps:
      - uses: actions/checkout@v7

      - name: Install pinned promtool
        env:
          PROMETHEUS_VERSION: 3.14.0
          PROMETHEUS_SHA256: f665c6da19eb7ba399c915d30c7d9793c9b417bf8a749b504bc470678631478d
        run: |
          set -euo pipefail
          asset="prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
          url="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/${asset}"
          curl --fail --silent --show-error --location --retry 3 "$url" -o "$RUNNER_TEMP/$asset"
          printf '%s  %s\n' "$PROMETHEUS_SHA256" "$RUNNER_TEMP/$asset" | sha256sum --check --status
          tar -xzf "$RUNNER_TEMP/$asset" -C "$RUNNER_TEMP"
          install -m 0755 "$RUNNER_TEMP/prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool" "$RUNNER_TEMP/promtool"
          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"

      - name: Run all Mimir rule fixtures
        run: kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh
```

The current ruleset requires only `validate`; `Mimir rule fixtures` is not required. Track that governance gap in #2914. Merge #2909 before, or together with, making this check required; do not merge this PR or #2906 here.