### PR TITLE
fix(mimir): clear stale PVB failure alerts

### DIFF
--- a/docs/agent-knowledge/signal-triage-decision-procedure.md
+++ b/docs/agent-knowledge/signal-triage-decision-procedure.md
@@ -148,6 +148,27 @@ to fire, restore healthy input, and confirm that the alert becomes inactive.
 If it cannot, either the predicate or the intended semantics are wrong. Do not
 silence a permanently red alert and do not add another alert beside it.
 
+### 3.1 Does the identity describe an attempt or current state?
+
+Some exporters expose one immutable series per operation attempt rather than
+one series per current target. A PodVolumeBackup, for example, carries the
+Backup and pod identities of the attempt that created it. A query that selects
+every `phase="Failed"` child therefore records an old failure forever when a
+later run succeeds; selecting by pod name can still fail when a replacement
+pod has a new name or UID.
+
+When the exporter does not expose a durable PVC or target identity, reduce the
+parent attempts to the newest current attempt first, then join child failures
+to that parent. Keep any manual/orphan fallback bounded and explicit. Do not
+pretend that a child-attempt label is current protection state, and do not
+silently discard the limitation: a new exporter contract is needed for
+per-volume state when the parent boundary is not sufficient.
+
+The fixtures for this shape must include an older failed child followed by a
+successful newer attempt with a replacement identity, a failure in the latest
+attempt, and a first-ever failed attempt. The recovery case is the essential
+test: a successful current attempt must make the old failure inactive.
+
 ## 4. Is zero a reset rather than stale?
 
 A timestamp gauge can have a third state that an ordinary numeric comparison

--- a/docs/proposals/velero-intended-volume-coverage.md
+++ b/docs/proposals/velero-intended-volume-coverage.md
@@ -42,9 +42,11 @@ configuration:
   policy reference would not create the missing fact.
 
 The existing `velero_cr_podvolumebackup_info` metric is sufficient for the
-actual side of the comparison. Its newest-PVB join is already used by
-`VeleroPodVolumeBackupFailed` and is the correct non-latching pattern; this
-proposal does not replace or duplicate that exporter.
+actual side of the comparison. `VeleroPodVolumeBackupFailed` constrains
+scheduled failures to the newest Backup per schedule (with a bounded fallback
+for unparented/manual records), which is the current-state boundary available
+without a PVC identity in the metric. This proposal does not replace or
+duplicate that exporter.
 
 Therefore this is not a KSM-only or Mimir-side change. Reimplementing
 Velero's policy evaluator in Bhaiya would duplicate upstream semantics and

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -133,19 +133,23 @@ tests:
         alertname: VeleroPodVolumeBackupBytesMismatch
         exp_alerts: []
 
-  # A failed one-shot record must stop alerting when a newer attempt for the
-  # same workload target succeeds, even when the replacement pod has a new
-  # UID. The target key is pod name plus volume; the age bound prevents old
-  # abandoned targets from paging forever.
+  # A failed one-shot record from a scheduled Backup must stop alerting when a
+  # newer Backup succeeds, even when the replacement pod has a new name and
+  # UID. The schedule-level Backup identity is the current-state boundary;
+  # the age bound prevents old abandoned records from paging forever.
   - interval: 1m
     input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="home-backup",backup="teaspoon-old-backup"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="home-backup",backup="teaspoon-new-backup"}'
+        values: "200+0x20"
       - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="old-pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji"}'
         values: "100+0x20"
       - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="old-pod-uid",volume="home",pod_volume_backup="teaspoon-old-pvb",backup="teaspoon-old-backup",node="kaji",phase="Failed"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="new-pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji"}'
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon-replacement",pod_uid="new-pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji"}'
         values: "200+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon",pod_uid="new-pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji",phase="Completed"}'
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="teaspoon-replacement",pod_uid="new-pod-uid",volume="home",pod_volume_backup="teaspoon-new-pvb",backup="teaspoon-new-backup",node="kaji",phase="Completed"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 15m
@@ -179,13 +183,97 @@ tests:
             exp_annotations:
               summary: Velero PodVolumeBackup Failed for broken/home
               description: >-
-                The newest PodVolumeBackup for target home/broken (UID pod-uid,
-                volume home) is Failed. It was created within the last 24 hours
-                and has remained in that state for at least five minutes. A
-                later successful PVB for the same target clears this signal;
-                older Failed records are intentionally ignored. Inspect
-                the PVB status message, node-agent logs, and storage path before
-                treating the target as restorable.
+                The selected PodVolumeBackup for target home/broken (UID
+                pod-uid, volume home) is Failed. It was created within the last
+                24 hours and has remained in that state for at least five
+                minutes. For a scheduled Backup, failures from older attempts
+                are intentionally ignored, including when a replacement pod has
+                a new name or UID; unparented/manual records are retained only
+                within this 24-hour bound. Inspect the PVB status message,
+                node-agent logs, and storage path before treating the target as
+                restorable.
+
+  # A Failed PVB belonging to the newest scheduled Backup remains actionable.
+  # This is the positive counterpart to the recovery fixture above.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="media-config-backup",backup="media-config-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="media",pod_name="maintainerr",pod_uid="pod-uid",volume="config",pod_volume_backup="maintainerr-current-pvb",backup="media-config-current",node="asuka"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="media",pod_name="maintainerr",pod_uid="pod-uid",volume="config",pod_volume_backup="maintainerr-current-pvb",backup="media-config-current",node="asuka",phase="Failed"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroPodVolumeBackupFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              pod_namespace: media
+              pod_name: maintainerr
+              pod_uid: pod-uid
+              volume: config
+              pod_volume_backup: maintainerr-current-pvb
+              backup: media-config-current
+              node: asuka
+              phase: Failed
+              schedule: media-config-backup
+              severity: warning
+            exp_annotations:
+              summary: Velero PodVolumeBackup Failed for maintainerr/config
+              description: >-
+                The selected PodVolumeBackup for target media/maintainerr (UID
+                pod-uid, volume config) is Failed. It was created within the
+                last 24 hours and has remained in that state for at least five
+                minutes. For a scheduled Backup, failures from older attempts
+                are intentionally ignored, including when a replacement pod has
+                a new name or UID; unparented/manual records are retained only
+                within this 24-hour bound. Inspect the PVB status message,
+                node-agent logs, and storage path before treating the target as
+                restorable.
+
+  # A first-ever failed PVB has no prior successful attempt to mask it and
+  # must still alert when it belongs to the newest scheduled Backup.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="new-service-backup",backup="new-service-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",pod_namespace="new-service",pod_name="worker",pod_uid="first-pod-uid",volume="data",pod_volume_backup="new-service-first-pvb",backup="new-service-current",node="kaji"}'
+        values: "200+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="new-service",pod_name="worker",pod_uid="first-pod-uid",volume="data",pod_volume_backup="new-service-first-pvb",backup="new-service-current",node="kaji",phase="Failed"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroPodVolumeBackupFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              pod_namespace: new-service
+              pod_name: worker
+              pod_uid: first-pod-uid
+              volume: data
+              pod_volume_backup: new-service-first-pvb
+              backup: new-service-current
+              node: kaji
+              phase: Failed
+              schedule: new-service-backup
+              severity: warning
+            exp_annotations:
+              summary: Velero PodVolumeBackup Failed for worker/data
+              description: >-
+                The selected PodVolumeBackup for target new-service/worker (UID
+                first-pod-uid, volume data) is Failed. It was created within the
+                last 24 hours and has remained in that state for at least five
+                minutes. For a scheduled Backup, failures from older attempts
+                are intentionally ignored, including when a replacement pod has
+                a new name or UID; unparented/manual records are retained only
+                within this 24-hour bound. Inspect the PVB status message,
+                node-agent logs, and storage path before treating the target as
+                restorable.
 
   # Cancellation is an operator action or a deliberate controller stop, not a
   # failed backup. It must not page as VeleroPodVolumeBackupFailed.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -33,32 +33,56 @@ namespace: velero-integrity
 groups:
   - name: velero-integrity.rules
     rules:
-      # Failed PVB CRs are one-shot records and can outlive both their
-      # parent Backup and a later successful attempt. Select only the newest
-      # PVB for each workload target, so a later success clears a transient
-      # failure. Bound the selected record by its own creation time because
-      # parent Backups are routinely cleaned up while PVBs persist; without
-      # this bound an abandoned target would page forever.
-      # Use pod name plus volume as the target identity. Pod UIDs change on
-      # routine workspace replacement; a PVC label would be more durable but
-      # is not present on the PVB CR or in the exported metric contract.
-      # Schedule-level paging for the newest Backup remains in
-      # VeleroScheduleLastBackupFailed below.
+      # Failed PVB CRs are immutable per-attempt records. For a scheduled
+      # Backup, only keep failures belonging to the newest Backup for that
+      # schedule, so a later successful run clears failures from an older pod
+      # identity as well as from the same pod name. A PVB has no PVC identity
+      # in the exported metric contract, so this newest-Backup boundary is the
+      # durable current-state boundary available here. Keep orphan/manual PVBs
+      # visible as a bounded fallback when no scheduled parent is exported.
+      # Bound every selected record by its own creation time because parent
+      # Backups are routinely cleaned up while PVBs persist; without this bound
+      # an abandoned target would page forever.
       - alert: VeleroPodVolumeBackupFailed
         expr: |
-          max by (
-            cluster, namespace, pod_namespace, pod_name, pod_uid, volume,
-            pod_volume_backup, backup, node, phase
-          ) (
+          (
             (
-              topk by (
-                cluster, namespace, pod_namespace, pod_name, volume
-              ) (
-                1,
+              (
                 velero_cr_podvolumebackup_created_timestamp{
                   namespace="velero-system"
                 }
-              )
+                * on (
+                  cluster, namespace, pod_namespace, pod_name, pod_uid, volume,
+                  pod_volume_backup, backup, node
+                ) group_left (phase)
+                max by (
+                  cluster, namespace, pod_namespace, pod_name, pod_uid, volume,
+                  pod_volume_backup, backup, node, phase
+                ) (
+                  velero_cr_podvolumebackup_info{
+                    namespace="velero-system",
+                    phase="Failed"
+                  }
+                )
+              ) > time() - 24 * 3600
+            )
+            * on (cluster, namespace, backup) group_left (schedule)
+            (
+              topk by (cluster, namespace, schedule) (
+                1,
+                velero_cr_backup_created_timestamp{
+                  namespace="velero-system",
+                  schedule!=""
+                }
+              ) > bool 0
+            )
+          )
+          or
+          (
+            (
+              velero_cr_podvolumebackup_created_timestamp{
+                namespace="velero-system"
+              }
               * on (
                 cluster, namespace, pod_namespace, pod_name, pod_uid, volume,
                 pod_volume_backup, backup, node
@@ -74,20 +98,29 @@ groups:
               )
             ) > time() - 24 * 3600
           )
+          unless on (cluster, namespace, backup)
+          max by (cluster, namespace, backup) (
+            velero_cr_backup_created_timestamp{
+              namespace="velero-system",
+              schedule!=""
+            }
+          )
         for: 5m
         labels:
           severity: warning
         annotations:
           summary: Velero PodVolumeBackup {{ $labels.phase }} for {{ $labels.pod_name }}/{{ $labels.volume }}
           description: >-
-            The newest PodVolumeBackup for target {{ $labels.pod_namespace }}/{{ $labels.pod_name }}
-            (UID {{ $labels.pod_uid }}, volume {{ $labels.volume }}) is
+            The selected PodVolumeBackup for target
+            {{ $labels.pod_namespace }}/{{ $labels.pod_name }} (UID
+            {{ $labels.pod_uid }}, volume {{ $labels.volume }}) is
             {{ $labels.phase }}. It was created within the last 24 hours and
-            has remained in that state for at least five minutes. A later
-            successful PVB for the same target clears this signal; older
-            Failed records are intentionally ignored. Inspect the
-            PVB status message, node-agent logs, and storage path before
-            treating the target as restorable.
+            has remained in that state for at least five minutes. For a
+            scheduled Backup, failures from older attempts are intentionally
+            ignored, including when a replacement pod has a new name or UID;
+            unparented/manual records are retained only within this 24-hour
+            bound. Inspect the PVB status message, node-agent logs, and storage
+            path before treating the target as restorable.
 
       - alert: VeleroPodVolumeBackupBytesMismatch
         expr: |


### PR DESCRIPTION
## Summary

VeleroPodVolumeBackupFailed was using immutable per-attempt PVB identities as current state. A later successful scheduled Backup could leave the older Failed PVB firing, especially after a pod replacement changed the pod name or UID.

This changes scheduled PVB failures to join only the newest Backup per schedule. Unparented or manual PVBs retain a bounded 24-hour fallback. The metric has no PVC identity, so the schedule-level newest-Backup boundary is the durable current-state boundary available here.

## Regression coverage

- An older failed PVB followed by a successful newer Backup does not alert, including a replacement pod name and UID.
- A Failed PVB in the newest scheduled Backup alerts.
- A first-ever Failed PVB alerts.
- The existing parentless/manual failure, cancellation, and age-bound cases remain covered.

The manifests signal-triage guide now documents immutable attempt identities versus current state, and the Velero coverage proposal reflects the new boundary.

## Verification

- `kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh`: 14 fixtures, 14 rule files
- `tools/check-mimir-rules.sh`: passed
- `tools/check.sh`: all three cluster renders passed

No live resources were changed. #2911 is separate and remains untouched.