### PR TITLE
ci: add aggregate generated-data freshness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ check there before reaching for `kubectl -n`.
 tools/gen-inventory.sh     # regenerate the inventory after adding an app
 tools/render-diagram.sh    # re-render the SVGs after editing a .dot
 tools/check-diagram.sh     # what CI runs
+tools/check-generated.sh   # regenerate/diff checked-in generated artifacts
 ```
 
 `tools/check-diagram.sh` is a merge gate rather than a linter. It runs six
@@ -615,6 +616,7 @@ tools/check.sh
 make diff
 tools/check-versions.sh
 tools/check-diagram.sh
+tools/check-generated.sh
 tools/render-diagram.sh
 tools/gen-inventory.sh
 tools/orphans.sh

--- a/tools/check-generated.sh
+++ b/tools/check-generated.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# tools/check-generated.sh — verify every checked-in generated artifact that
+# has a deterministic repository-local freshness check.
+#
+# This is intentionally an aggregate gate: every check runs even when an
+# earlier artifact is stale, so one bad generated file cannot hide another.
+# The workflow that calls this script must install Aqua first.
+set -u -o pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_TMP="$(mktemp -d)"
+trap 'rm -rf -- "$CHECK_TMP"' EXIT HUP INT TERM
+
+failures=0
+
+run_check() {
+  local label="$1"; shift
+  local output="$CHECK_TMP/output"
+
+  if "$@" >"$output" 2>&1; then
+    printf '✓ generated: %s\n' "$label"
+  else
+    printf '✗ generated: %s\n' "$label"
+    sed -n '1,80p' "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+check_aqua_checksums() {
+  local aqua_command="${AQUA_BIN:-aqua}"
+  local checksum_file="$ROOT/aqua-checksums.json"
+  local before="$CHECK_TMP/aqua-checksums.json"
+  local output="$CHECK_TMP/aqua.log"
+  local aqua_rc=0
+
+  if [[ "$aqua_command" == */* ]]; then
+    [ -x "$aqua_command" ] || {
+      echo "aqua executable not found: $aqua_command"
+      return 1
+    }
+  elif ! command -v "$aqua_command" >/dev/null 2>&1; then
+    echo "aqua executable not found; install the CI-pinned Aqua release first"
+    return 1
+  fi
+
+  [ -s "$checksum_file" ] || {
+    echo "missing generated file: aqua-checksums.json"
+    return 1
+  }
+  cp "$checksum_file" "$before"
+
+  (cd "$ROOT" && "$aqua_command" update-checksum --prune) >"$output" 2>&1 || aqua_rc=$?
+  if [ "$aqua_rc" -ne 0 ]; then
+    echo "aqua update-checksum failed (exit $aqua_rc):"
+    sed -n '1,80p' "$output"
+    cp "$before" "$checksum_file"
+    return 1
+  fi
+
+  if [ ! -f "$checksum_file" ]; then
+    echo "aqua update-checksum removed aqua-checksums.json"
+    cp "$before" "$checksum_file"
+    return 1
+  fi
+  if [ "$(git hash-object "$before")" != "$(git hash-object "$checksum_file")" ]; then
+    echo "aqua-checksums.json is stale; regeneration would change it:"
+    git --no-pager diff --no-index -- "$before" "$checksum_file" || true
+    cp "$before" "$checksum_file"
+    return 1
+  fi
+
+  cp "$before" "$checksum_file"
+  return 0
+}
+
+check_schema_provenance() {
+  python3 - \
+    "$ROOT/tools/schemas/helm-controller-v1.6.4/provenance.json" \
+    "$ROOT/tools/schemas/helm-controller-v1.6.4/helmrelease-helm-v2-strict.json" \
+    "$ROOT/clusters/common/bootstrap/flux/kustomization.yaml" <<'PY'
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+provenance, schema, bootstrap = map(pathlib.Path, sys.argv[1:])
+lock = json.loads(provenance.read_text())
+if hashlib.sha256(schema.read_bytes()).hexdigest() != lock["generatedSchemaSha256"]:
+    raise SystemExit("schema artifact hash does not match provenance")
+match = re.search(r"flux2/manifests/install\?ref=v([0-9.]+)", bootstrap.read_text())
+if not match:
+    raise SystemExit("cannot find the Flux bootstrap version")
+if match.group(1) != lock["fluxVersion"]:
+    raise SystemExit(
+        f"Flux bootstrap is v{match.group(1)}, schema provenance is v{lock['fluxVersion']}"
+    )
+PY
+}
+
+# gen-inventory.sh --check regenerates into a temporary file and compares it;
+# check-diagram.sh verifies each SVG's source hash and invokes the inventory
+# check as part of its coverage gate.
+run_check "inventory" "$ROOT/tools/gen-inventory.sh" --check
+run_check "diagrams and documentation coverage" "$ROOT/tools/check-diagram.sh"
+run_check "Aqua checksums" check_aqua_checksums
+run_check "HelmRelease schema provenance" check_schema_provenance
+
+if [ "$failures" -ne 0 ]; then
+  printf '%d generated-data check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf '✓ generated data is current\n'

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -639,6 +639,37 @@ if [ -f "$inv" ]; then
   exits  "--check passes again once restored" 0 "$T/gen-inventory.sh" --check
 fi
 
+# ---------------------------------------------------------------- check-generated.sh
+section "check-generated.sh"
+gstub="$(mktemp -d)"
+cat >"$gstub/aqua" <<'EOF'
+#!/usr/bin/env bash
+if [ "${AQUA_FIXTURE:-}" = stale ]; then
+  printf '\n' >> aqua-checksums.json
+fi
+EOF
+chmod +x "$gstub/aqua"
+
+gchecks_hash="$(git hash-object "$ROOT/aqua-checksums.json")"
+exits "clean generated artifacts pass" 0 \
+  env PATH="$gstub:$PATH" "$T/check-generated.sh"
+invbak3="$(mktemp)"; cp "$inv" "$invbak3"
+printf '# stale generated inventory\n' >"$inv"
+bothout="$(AQUA_FIXTURE=stale PATH="$gstub:$PATH" "$T/check-generated.sh" 2>&1)"; both_ec=$?
+assert "two stale generators -> nonzero" test "$both_ec" = 1
+assert "two stale generators -> reports inventory" grep -q '✗ generated: inventory' <<<"$bothout"
+assert "two stale generators -> reports Aqua" grep -q 'aqua-checksums.json is stale' <<<"$bothout"
+assert "two stale generators -> reaches later checks" \
+  grep -q '✓ generated: HelmRelease schema provenance' <<<"$bothout"
+cp "$invbak3" "$inv"; rm -f "$invbak3"
+gout="$(AQUA_FIXTURE=stale PATH="$gstub:$PATH" "$T/check-generated.sh" 2>&1)"; gec=$?
+assert "stale generator -> nonzero" test "$gec" = 1
+assert "stale generator -> names Aqua artifact" grep -q 'aqua-checksums.json is stale' <<<"$gout"
+assert "stale generator -> reports a diff" grep -q '^[-+]' <<<"$gout"
+assert "stale generator -> restores the worktree" \
+  test "$(git hash-object "$ROOT/aqua-checksums.json")" = "$gchecks_hash"
+rm -rf "$gstub"
+
 # ---------------------------------------------------------------- check-diagram.sh
 section "check-diagram.sh"
 dtmp="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- Add `tools/check-generated.sh`, a cheap aggregate freshness gate for the checked-in generated artifacts.
- Run every generator/check even after a failure, and report all stale artifacts together.
- Add offline coverage for clean data, two simultaneous stale artifacts, diff reporting, and worktree restoration.
- Document the helper. This PR intentionally contains no `.github/workflows` change.

## Current sweep

The sweep is clean on current `origin/main` (`4cd5811`):

- main Aqua verify run [#34338291370](https://github.com/keiretsu-labs/kubernetes-manifests/actions/runs/34338291370) is green after #2918.
- `docs/reference/inventory.md` passes `tools/gen-inventory.sh --check`.
- all diagram SVG source stamps and documentation coverage pass `tools/check-diagram.sh`.
- HelmRelease schema provenance and the full `tools/check.sh` gate pass.

No stale generated artifact was found besides the already-fixed Aqua checksum file.

## Required ordering

This must land advisory-then-required, in two steps:

1. Land this non-workflow helper after the current clean sweep.
2. After Raj restores workflow scope, add the workflow below and observe a successful PR and main-push run.
3. Only then add the `generated data` job context to the required ruleset.

Making generated checks required before the sweep/workflow run is green will turn main red until every stale artifact is regenerated. Do not combine enabling the required rule with the known-broken-fixture ordering: #2909 must land before the Mimir fixture check becomes required, and #2918 is already merged.

## Exact workflow snippet for Raj

Create `.github/workflows/generated-data.yaml` with exactly:

```yaml
name: generated-data

on:
  pull_request:
    branches: [main]
  push:
    branches: [main]
  workflow_dispatch:

permissions:
  contents: read

jobs:
  generated-data:
    name: generated data
    runs-on: ubuntu-latest
    timeout-minutes: 5
    steps:
      - uses: actions/checkout@v7

      - name: Install Aqua
        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
        with:
          aqua_version: v2.62.3
          enable_aqua_install: false

      - name: Check generated data
        run: tools/check-generated.sh
```

Raj must first run `gh auth refresh -h github.com -s workflow`; this PR does not attempt to push the workflow file with the current token scopes.

## Verification

- `tools/check-generated.sh` passes with the CI-pinned Aqua binary.
- The focused self-test proves inventory and Aqua failures are both reported in one run, and that Aqua regeneration cannot dirty the caller's worktree.
