### PR TITLE
docs: codify false-health signal checks

### DIFF
--- a/docs/agent-knowledge/signal-triage-decision-procedure.md
+++ b/docs/agent-knowledge/signal-triage-decision-procedure.md
@@ -26,6 +26,157 @@ coverage from a metric name, a rule file in Git, or a log line alone.
 | The metric name exists but the relevant series count is zero. | Instrumentation, collection, or label-contract failure. | Repair or enable the producer/scrape path first. A rule against an empty series is inert. |
 | A timestamp-like gauge was healthy for a long range, then became exactly `0` after a pod restart. | Reset or initialization state misread as ancient staleness. | Treat `0` as unknown, gate on pod age/readiness, or expose validity separately. Fix the rule or emitter; do not add a duplicate alert. |
 
+## Rule-authoring contract
+
+There was no equivalent tracked contract in this repository. The Bhaiya
+health-rule contract was written in the application repository, but the rules
+that consume those signals live here. This is the manifests-side port of its
+portable authoring requirements, not Bhaiya-specific metric names.
+
+Before merging a rule, record:
+
+- the user-visible capability, its healthy state, and its intentional or
+  unknown states;
+- a live series-count and label check for every input family. A successful
+  empty query is not evidence that a rule can ever fire;
+- the logical current-state identity. Prefer the newest attempt, active
+  schedule, or current object over an immutable historical name or UID;
+- the recovery path. A later success, deletion, pause, restart, or terminal
+  controller state must have an explicit meaning, not be lost by a join;
+- the threshold and `for:` from a healthy baseline and the expected effective
+  detection delay; and
+- tests for the sustained failure, a healthy/noisy target, recovery, and any
+  intentional or unknown state. After loading, query the live ruler as well as
+  the loader Job.
+
+Do not add an `absent()` rule merely because an object disappeared unless an
+independent expected-object inventory can distinguish deletion from exporter
+loss. Do not use `Ready`, `Completed`, `MemoryPressure=False`, or a successful
+controller process as a proxy for the capability the user needs without
+checking currency and the downstream operation.
+
+## Case law: five false-health signals
+
+These are short precedents from the 2026-09-09 incident. Each has a different
+detection question and therefore a different remedy; “add another alert” is
+the right first move for none of these five.
+
+### 1. Process readiness was not CNI capability
+
+**Detection question:** Does `Ready` represent the operation users depend on,
+or only that a process exists?
+
+`kube-multus-ds` reported 4/4 with no readiness or liveness probe. The relevant
+coupled images are visible at
+`kubernetes/apps/base/kube-system/cilium-ottawa/app/patch-multus.yaml:15-36`,
+with the same shape in the Robbinsdale patch at `.../kustomization.yaml:43-64`
+and St. Petersburg at `.../patch-multus.yaml:14-35`. Sandbox `ADD` was timing
+out while the DaemonSet still looked healthy. The shim and daemon also have to
+be treated as one artifact: a host-installed shim polling an endpoint the
+daemon does not expose is a capability failure, not a pod-readiness failure.
+
+The fix is a capability probe against the daemon API, plus moving the raw
+manifest, installed shim, and daemon together. The existing invariant in
+`tools/check-versions.sh:367-391` catches raw-manifest/shim drift; the follow-up
+must include the daemon too. This is why #2899/#2905 aligned the pair and added
+probes, with rollout held for a staffed window.
+
+### 2. Reconciled did not mean current
+
+**Detection question:** Does `Ready=True` mean current, or merely successfully
+reconciled at an older revision?
+
+The Kustomizations were Ready while the Bhaiya Deployment still served an old
+bookkeeping SHA. The exporter already exposes the needed currency field as
+`revision: status.lastAppliedRevision` at
+`kubernetes/apps/base/monitoring/monitoring-common/app/kube-state-metrics-config.yaml:77-94`,
+while the existing alert at
+`kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml:21-38` only asks about
+`ready`. The alert was not wrong; its scope was readiness, not freshness.
+
+The fix is a separate delivery-currency check: compare the Kustomization's
+`lastAppliedRevision` and the workload's image/SHA with the intended Git
+revision. Keep `FluxKustomizationNotReady` for reconciliation failure and do
+not relabel a stale-but-Ready object as a current one.
+
+### 3. A join dropped the stale schedule
+
+**Detection question:** Would this signal change if schedule metadata were
+paused, deleted, or temporarily absent—and is that change intentional?
+
+`VeleroBackupStale` originally fired on fresh schedules while missing schedules
+that were 26h or 49h stale: a join around per-attempt metadata allowed the
+right-hand series to erase the schedule-level freshness signal. The corrected
+rule computes freshness per schedule and gates it with the active schedule at
+`kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml:55-80`. Its tests keep
+the 26h/49h cases firing at
+`kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml:8-63`
+and ensure deleted or paused schedules do not resurrect historical alerts at
+`:120-136`.
+
+The fix is to choose the identity before joining: aggregate the latest
+successful timestamp by schedule, then apply an explicit active-schedule gate.
+If missing metadata is intended to clear the alert, say so; otherwise it is a
+join/collection failure that needs a separate observation signal.
+
+### 4. An immutable attempt was mistaken for current state
+
+**Detection question:** Can a later successful attempt change the series this
+alert evaluates, or is the predicate pinned to a historical object name, UID,
+or Job?
+
+The original `VeleroPodVolumeBackupFailed` and `MimirRuleLoaderFailing` shapes
+selected immutable per-attempt records. A later success therefore could not
+clear an old failed PVB or content-hashed loader Job. The source precedents are
+`kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml:36-75`
+and `.../rules/mimir-loader.yaml:9-17`; the latter's raw
+`kube_job_status_failed > 0` is especially easy to leave latched by retained
+Jobs.
+
+The PVB fix (prepared in `5962f4f`) selects the newest scheduled Backup and
+bounds orphan records by age; its recovery fixture is
+`kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml:136-153`.
+The loader fix (prepared in `13745da`) requires a terminal failure reason and
+joins it to the newest content-hashed Job, while the stale-success rule remains
+the dead-man's switch. Test failed-then-success explicitly. A failure counter
+is evidence of history, not automatically evidence of current failure.
+
+### 5. A terminal delivery state was paged as an active outage
+
+**Detection question:** Can this alert clear when the controller has genuinely
+given up, and does its severity distinguish current user impact from blocked
+future delivery?
+
+`FluxHelmReleaseNotReady` is defined as a critical 15-minute `ready=False`
+condition at
+`kubernetes/apps/base/mimir/mimir-ottawa/rules/flux.yaml:60-77`. The reference
+`flux-system/flux-operator` workload was healthy, but the HelmRelease was
+`Stalled=True`, `MissingRollbackTarget`, with two upgrade failures. The runbook
+records the evidence and owner-approved recovery at
+`docs/agent-knowledge/flux-helmrelease-missing-rollback-target.md:7-18,20-43`:
+the controller had given up and was not retrying, while future operator
+upgrades remained blocked.
+
+The immediate remedy is a deliberate one-off remediation reset, not repeated
+reconcile attempts. The design remedy is to distinguish an active failed
+workload from terminal upgrade debt in severity, routing, and ownership. A
+critical that stays red while no outage is active trains operators to ignore
+critical alerts; do not paper over that with a duplicate detector.
+
+### Adjacent capacity case: a healthy condition hid starvation
+
+**Detection question:** Does the condition measure actual safety, or only one
+narrow eviction signal?
+
+On St. Petersburg `orin-0`, `MemoryPressure=False` coexisted with less than
+1 GiB available for a day and very little request headroom. The replacement
+signal computes allocatable minus Running pod requests at
+`kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml:53-94`;
+the Spark rule explicitly warns that an OOM can occur while MemoryPressure stays
+false at `.../rules/stpetersburg-memory.yaml:39-60`. The fix was to alert on
+schedulable headroom and inspect working set/eviction order, not to infer node
+capacity from the condition alone.
+
 The empty-series row is an important guardrail around the control case. A
 successful empty query proves only that the query syntax is accepted; it does
 not prove that a rule can ever evaluate true.


### PR DESCRIPTION
## Summary

- extend `docs/agent-knowledge/signal-triage-decision-procedure.md` with the manifests-side rule-authoring contract;
- record five distinct false-health/alert-design defects from 2026-09-09 with detection questions, file:line evidence, and remedies;
- include the adjacent `MemoryPressure=False` request-starvation case.

## Contract disposition

No equivalent rule-authoring contract was tracked in `kubernetes-manifests`. The generic, reusable parts of the Bhaiya contract were ported here: verify live series and labels, define current/unknown/intentional states, choose a current logical identity, specify recovery and `for:`, and test failure, healthy, and recovery paths.

## Validation

- `tools/check.sh` passed: `✓ render OK: talos-ottawa talos-robbinsdale talos-stpetersburg`.
- `git diff --check` passed.
- Documentation-only: no workflow, rule, or manifest files changed.

Please do not merge this PR automatically; it is a reference update for review.