### PR TITLE
fix(mimir): repair Kopiur snapshot alert label joins

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
@@ -9,6 +9,9 @@
 # can contain a plausible item count while omitting a required volume.
 # Add a new protected source here only when its policy and repository are
 # intentionally added to Git.
+# Kopiur controller metrics are scraped from kopiur-system and identify the
+# protected namespace with exported_namespace. Snapshot alert joins normalize
+# that live label into the inventory's namespace label before matching.
 #
 # Keep this namespace unique across every file passed to mimirtool. A repeated
 # namespace aborts the complete rule sync for every tenant.
@@ -41,10 +44,13 @@ groups:
             kopiur_expected_source_info
             and on (cluster, namespace, policy)
             (
-              kopiur_snapshotpolicy_last_backup_success{
-                namespace="home-assistant",
-                policy="homeassistant-config"
-              } == 0
+              label_replace(
+                kopiur_snapshotpolicy_last_backup_success{
+                  exported_namespace="home-assistant",
+                  policy="homeassistant-config"
+                },
+                "namespace", "$1", "exported_namespace", "(.+)"
+              ) == 0
             )
           )
           and on (cluster)
@@ -67,23 +73,32 @@ groups:
             kopiur_expected_source_info
             and on (cluster, namespace, policy)
             (
-              kopiur_snapshotpolicy_last_backup_success{
-                namespace="home-assistant",
-                policy="homeassistant-config"
-              } == 1
+              label_replace(
+                kopiur_snapshotpolicy_last_backup_success{
+                  exported_namespace="home-assistant",
+                  policy="homeassistant-config"
+                },
+                "namespace", "$1", "exported_namespace", "(.+)"
+              ) == 1
             )
             and on (cluster, namespace, policy)
             (
-              kopiur_policy_last_backup_success_timestamp_seconds{
-                namespace="home-assistant",
-                policy="homeassistant-config"
-              } > 0
+              label_replace(
+                kopiur_policy_last_backup_success_timestamp_seconds{
+                  exported_namespace="home-assistant",
+                  policy="homeassistant-config"
+                },
+                "namespace", "$1", "exported_namespace", "(.+)"
+              ) > 0
               and
               time()
-                - kopiur_policy_last_backup_success_timestamp_seconds{
-                    namespace="home-assistant",
-                    policy="homeassistant-config"
-                  }
+                - label_replace(
+                    kopiur_policy_last_backup_success_timestamp_seconds{
+                      exported_namespace="home-assistant",
+                      policy="homeassistant-config"
+                    },
+                    "namespace", "$1", "exported_namespace", "(.+)"
+                  )
                 > 129600
             )
           )

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
@@ -35,6 +35,84 @@ tests:
         alertname: KopiurCoverageMissing
         exp_alerts: []
 
+  # The controller's live scrape labels use its own namespace and expose the
+  # protected namespace separately. These cases intentionally use that
+  # observed contract so a selector that reverts to namespace=home-assistant
+  # cannot pass tests while matching no production series.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: KopiurSnapshotFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: home-assistant
+              policy: homeassistant-config
+              pvc: homeassistant-config
+              repository: kopiur-stpetersburg
+              severity: critical
+            exp_annotations:
+              summary: Kopiur policy homeassistant-config reports a failed snapshot
+              description: >-
+                Kopiur's latest terminal snapshot for home-assistant/homeassistant-config
+                is failed. This is a per-policy current-result signal; an old Failed
+                Snapshot object alone does not keep the alert firing after a later
+                success. Inspect the current Snapshot, SnapshotPolicy, mover Job, and
+                repository logs.
+
+  # A recent successful result from the same live label contract must keep
+  # both snapshot alerts quiet.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "1+0x20"
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "900+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KopiurSnapshotFailed
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KopiurSnapshotStale
+        exp_alerts: []
+
+  # A stale successful result from the observed label contract must fire.
+  - interval: 1m
+    input_series:
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x2250"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "1+0x2250"
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "900+0x2250"
+    alert_rule_test:
+      - eval_time: 37h
+        alertname: KopiurSnapshotStale
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: home-assistant
+              policy: homeassistant-config
+              pvc: homeassistant-config
+              repository: kopiur-stpetersburg
+              severity: critical
+            exp_annotations:
+              summary: Kopiur policy homeassistant-config has a stale snapshot
+              description: >-
+                No successful Kopiur snapshot for home-assistant/homeassistant-config
+                has completed within 36 hours (the daily schedule, jitter, and
+                operational margin). The timestamp must be positive, so a controller
+                restart/reset cannot turn a zero gauge into an immediate stale alert.
+                Inspect the SnapshotSchedule, current Snapshot, mover Job, and
+                repository reachability.
+
   # A failed Snapshot object is immutable history. A later successful policy
   # result must clear the failure alert even while both Snapshot phases remain
   # visible in the exporter.
@@ -42,7 +120,7 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x20"
-      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "1+0x20"
       - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Snapshot",namespace="home-assistant",name="homeassistant-config-old",phase="Failed",policy="homeassistant-config"}'
         values: "1+0x20"
@@ -78,7 +156,7 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x20"
-      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "0+0x20"
     alert_rule_test:
       - eval_time: 1m
@@ -107,9 +185,9 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x2250"
-      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "1+0x2250"
-      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "1+0x2250"
     alert_rule_test:
       - eval_time: 37h
@@ -138,9 +216,9 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x2250"
-      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "1+0x2250"
-      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "0+0x2250"
     alert_rule_test:
       - eval_time: 37h
@@ -192,7 +270,7 @@ tests:
       - eval_time: 9m
         alertname: KopiurCoverageMissing
         exp_alerts: []
-      - eval_time: 10m
+      - eval_time: 11m
         alertname: KopiurCoverageMissing
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
## What changed

The live Kopiur controller metrics identify the protected namespace as `exported_namespace="home-assistant"` while their scrape namespace is `namespace="kopiur-system"`. `KopiurSnapshotFailed` and `KopiurSnapshotStale` selected `namespace="home-assistant"` on the raw metrics, so neither alert could match a live series.

This change:

- selects the observed `exported_namespace` label and normalizes it into the inventory `namespace` before the existing policy joins;
- adds observed-label fixture cases for current failure, recent success, and stale success;
- updates the existing snapshot cases to use the observed controller label contract;
- moves the coverage positive assertion to 11m, matching Prometheus `for: 10m` evaluation semantics.

## Verification

- `tools/check-mimir-promql.sh`: 33 rule files valid
- `rules/tests/run.sh`: 14 fixtures / 14 rule files passed
- `tools/check-mimir-rules.sh`: 33 files, 3 tenant loaders, 32 namespaces
- `tools/check.sh ot`: render OK
- Deliberately replacing the selectors with the old `namespace="home-assistant"` form makes the observed-label failed and stale tests fail (promtool exit 1).

No live resources were changed.

## Scope note

The live `homeassistant-config` SnapshotPolicy reports Ready with a successful snapshot and `kopiur_snapshotpolicy_last_backup_success=1`; the current `KopiurCoverageMissing` firing is therefore not evidence of an uncovered PVC. Its expected-inventory labels look correct, but the raw controller namespace/exported_namespace contract also warrants a separate follow-up for that rule (and repository health), and is intentionally not folded into this two-alert fix.