### PR TITLE
fix(mimir): repair Kopiur repository alert label join

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
@@ -10,8 +10,8 @@
 # Add a new protected source here only when its policy and repository are
 # intentionally added to Git.
 # Kopiur controller metrics are scraped from kopiur-system and identify the
-# protected namespace with exported_namespace. Snapshot alert joins normalize
-# that live label into the inventory's namespace label before matching.
+# protected namespace with exported_namespace. Snapshot and repository alert
+# joins normalize that live label into the inventory's namespace before matching.
 #
 # Keep this namespace unique across every file passed to mimirtool. A repeated
 # namespace aborts the complete rule sync for every tenant.
@@ -124,20 +124,28 @@ groups:
             unless on (cluster, kind, namespace, name)
             (
               max by (cluster, kind, namespace, name) (
-                kopiur_resource_phase{
-                  kind="Repository",
-                  namespace="home-assistant",
-                  name="kopiur-stpetersburg",
-                  phase="Ready"
-                } == 1
+                label_replace(
+                  kopiur_resource_phase{
+                    kind="Repository",
+                    namespace="kopiur-system",
+                    exported_namespace="home-assistant",
+                    name="kopiur-stpetersburg",
+                    phase="Ready"
+                  },
+                  "namespace", "$1", "exported_namespace", "(.+)"
+                ) == 1
               )
               and on (cluster, kind, namespace, name)
               max by (cluster, kind, namespace, name) (
-                kopiur_repository_consecutive_backend_failures{
-                  kind="Repository",
-                  namespace="home-assistant",
-                  name="kopiur-stpetersburg"
-                } == 0
+                label_replace(
+                  kopiur_repository_consecutive_backend_failures{
+                    kind="Repository",
+                    namespace="kopiur-system",
+                    exported_namespace="home-assistant",
+                    name="kopiur-stpetersburg"
+                  },
+                  "namespace", "$1", "exported_namespace", "(.+)"
+                ) == 0
               )
             )
           )

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
@@ -15,11 +15,11 @@ tests:
         values: "1+0x20"
       - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
         values: "900+0x20"
-      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg",phase="Ready"}'
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
         values: "1+0x20"
-      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "0+0x20"
-      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 15m
@@ -231,11 +231,11 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x20"
-      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg",phase="Ready"}'
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
         values: "1+0x20"
-      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "2+0x20"
-      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 4m


### PR DESCRIPTION
## What changed

The live St Petersburg Kopiur repository is healthy:

- `kopiur_resource_phase{kind="Repository",phase="Ready"}=1`
- `kopiur_repository_consecutive_backend_failures=0`
- Repository CR conditions `BackendReachable=True` and `Ready=True`

The alert still fired because the raw controller metrics use `namespace="kopiur-system"` and `exported_namespace="home-assistant"`, while `KopiurRepositoryUnreachable` selected `namespace="home-assistant"` directly. Its expected-inventory labels made the false alert look authoritative.

This follow-up:

- normalizes `exported_namespace` to the inventory `namespace` for both repository metrics before the health join;
- uses the observed controller label set in the healthy and backend-failure fixtures;
- ensures a selector regression fails: the old selector makes the healthy fixture spuriously fire and the failed fixture disappear.

## Verification

- `tools/check-mimir-promql.sh`: 33 rule files valid
- `rules/tests/run.sh`: 14 fixtures / 14 rule files passed
- `tools/check-mimir-rules.sh`: 33 files, 3 tenant loaders, 32 namespaces
- `tools/check.sh ot`: render OK
- Deliberately regressed repository selector: promtool exit 1

No live resources were changed.

#2924 fixed the two snapshot-alert joins. `KopiurCoverageMissing` remains a separate follow-up: its current firing is also false because the policy metric uses the same namespace/exported_namespace split while reporting a successful SnapshotPolicy.