### PR TITLE
fix(mimir): match Kopiur coverage metric labels

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/kopiur.yaml
@@ -170,10 +170,13 @@ groups:
             kopiur_expected_source_info
             unless on (cluster, namespace, policy)
             max by (cluster, namespace, policy) (
-              kopiur_snapshotpolicy_last_backup_success{
-                namespace="home-assistant",
-                policy="homeassistant-config"
-              }
+              label_replace(
+                kopiur_snapshotpolicy_last_backup_success{
+                  exported_namespace="home-assistant",
+                  policy="homeassistant-config"
+                },
+                "namespace", "$1", "exported_namespace", "(.+)"
+              )
             )
           )
           and on (cluster)

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/kopiur_test.yaml
@@ -4,6 +4,10 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
+  # Live Kopiur scrapes carry namespace="kopiur-system" from the scrape
+  # target and exported_namespace="home-assistant" from the controller's
+  # colliding label. Keep fixtures on that observed contract so a raw
+  # namespace="home-assistant" selector cannot pass these tests accidentally.
   # All four alerts stay quiet for a current successful backup, a healthy
   # repository, and an intentionally configured maintenance gauge. The
   # maintenance gauge is informational; it is not itself an incident.
@@ -11,15 +15,15 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x20"
-      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "1+0x20"
-      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "900+0x20"
-      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
         values: "1+0x20"
-      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "0+0x20"
-      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 15m
@@ -122,9 +126,9 @@ tests:
         values: "1+0x20"
       - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "1+0x20"
-      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Snapshot",namespace="home-assistant",name="homeassistant-config-old",phase="Failed",policy="homeassistant-config"}'
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Snapshot",exported_namespace="home-assistant",namespace="kopiur-system",name="homeassistant-config-old",phase="Failed",policy="homeassistant-config"}'
         values: "1+0x20"
-      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Snapshot",namespace="home-assistant",name="homeassistant-config-new",phase="Succeeded",policy="homeassistant-config"}'
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Snapshot",exported_namespace="home-assistant",namespace="kopiur-system",name="homeassistant-config-new",phase="Succeeded",policy="homeassistant-config"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 15m
@@ -138,9 +142,9 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x20"
-      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config"}'
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
         values: "1+0x20"
-      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",namespace="home-assistant",policy="excluded-policy"}'
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="excluded-policy"}'
         values: "0+0x20"
     alert_rule_test:
       - eval_time: 15m
@@ -231,11 +235,11 @@ tests:
     input_series:
       - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
         values: "1+0x20"
-      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
         values: "1+0x20"
-      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "2+0x20"
-      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",exported_namespace="home-assistant",kind="Repository",namespace="kopiur-system",name="kopiur-stpetersburg"}'
+      - series: 'kopiur_repository_maintenance_configured{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 4m


### PR DESCRIPTION
## Finding

The initial live sweep found **4 Kopiur alert rules** affected by the Prometheus `exported_namespace` collision. While this branch was being prepared, #2924 fixed `KopiurSnapshotFailed` and `KopiurSnapshotStale`, and #2925 fixed `KopiurRepositoryUnreachable`. This PR fixes the remaining affected rule, `KopiurCoverageMissing`; it is not a duplicate of either merged change.

The observed St. Petersburg Kopiur series carry `namespace="kopiur-system"` and `exported_namespace="home-assistant"`. The old coverage RHS selected `namespace="home-assistant"`, so it returned no series and the `unless` alert fired as a false positive. The rule now selects `exported_namespace` and uses `label_replace` to restore the inventory `namespace` before joining.

## Sweep evidence

Queried all three Mimir tenants with read-only instant queries:

- `exported_namespace`: 40 families in Ottawa, 30 in Robbinsdale, 59 in St. Petersburg; 64-family union.
- `exported_job`: 0 families; `exported_instance`: 0 families.
- `exported_pod`: 0/0/11 families (St. Petersburg DCGM GPU metrics); no rule selects `pod` on those families.
- The only other direct `namespace=` selectors on collision-bearing families are the three K8gb DNS alerts. Their live selectors return nonzero data in all three tenants (4 common endpoint series, 5 Ottawa-only endpoint series, and 10–12 error-counter series), so they are valid. Flux selectors use `exported_namespace` where needed.

For Kopiur in St. Petersburg, each old selector returned no series while its `exported_namespace` form returned one:

- Snapshot success and last-success timestamp: raw 0, observed-label 1.
- Repository Ready phase and backend-failure gauge: raw 0, observed-label 1.

The raw full `KopiurRepositoryUnreachable` expression returned one expected-repository series and the corrected expression returned empty; the raw full `KopiurCoverageMissing` expression did the same. That is why the former was firing despite a healthy repository and why the latter was firing despite a current successful policy result.

## Tests

Fixtures now use the observed label set rather than the assumed one. The live-label fixtures make a raw `namespace="home-assistant"` selector fail to exercise the intended path.

Passed locally:

- Mimir fixture runner: 17 fixtures, 15 rule files.
- `tools/check-mimir-promql.sh`.
- `tools/check-mimir-rules.sh`.
- Full `tools/check.sh` render gate on all three clusters.

Read-only live queries only; no cluster mutation.