### PR TITLE
test(mimir): cover Bhaiya two-pod heartbeat transitions

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/bhaiya_reconciler_test.yaml
@@ -76,6 +76,42 @@ tests:
         alertname: BhaiyaReconcileLastSuccessStale
         exp_alerts: []
 
+  # Both replicas disappear during the rollout, then both counters start from
+  # zero again. The former standby becomes the leader and advances its reset
+  # counter while the former leader remains the zero-valued standby. The
+  # cluster sum must see the new leader's progress and stay healthy.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="old-leader"}'
+        values: "1+1x4 _x2 0+0x30"
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="new-leader"}'
+        values: "0+0x4 _x2 1+1x30"
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+
+  # A leader handover can happen while both pods remain continuously scraped.
+  # The old leader stops at the same evaluation where the standby starts; a
+  # per-series zero-increase check would misread the old leader, but the
+  # cluster-level sum follows the active leader.
+  - interval: 1m
+    input_series:
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="old-leader"}'
+        values: "1+1x9 10+0x30"
+      - series: 'bhaiya_reconcile_heartbeat_total{cluster="talos-ottawa",job="bhaiya",container="bhaiya",instance="new-leader"}'
+        values: "0+0x9 1+1x30"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: BhaiyaReconcileLastSuccessStale
+        exp_alerts: []
+
   # A continuously running loop is healthy even when one workspace handler is
   # persistently failing. The fleet liveness signal stays clear while the
   # workspace/handler alert names the failing item.


### PR DESCRIPTION
## Summary\n\n- cover a simultaneous two-replica rollout: both heartbeat series disappear, counters reset, the former standby becomes leader, and the standby remains at zero\n- cover a continuous-scrape leader handover where the old leader stops as the new leader starts\n- assert BhaiyaReconcileLastSuccessStale stays clear in both cases under the merged cluster-aggregated heartbeat rule\n\n## Verification\n\n- PATH=/workspace/.cache/cos-promtool/3.14.0/prometheus-3.14.0.linux-amd64:/workspace/.codex/tmp/arg0/codex-arg0bo7oX7:/nix/store/zc6fy62c341aibk36p4ywff7rf9wn4wx-ripgrep-15.2.0/bin:/nix/store/v24sx9l1jmvvia3z8iznrd7jwhvc8kcf-bubblewrap-0.11.2/bin:/workspace/.local/bin:/workspace/go/bin:/bin kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/run.sh\n- tools/check.sh talos-ottawa\n\nPR #2907 is already merged; this is fixture-only follow-up coverage.