### PR TITLE
test(mimir): check live rule label contracts

### DIFF
--- a/docs/reference/mimir-label-contract-check.md
+++ b/docs/reference/mimir-label-contract-check.md
@@ -1,0 +1,68 @@
+# Mimir label-contract check
+
+The native Mimir rule fixtures validate PromQL syntax and rule behavior for
+the labels represented by the fixture. They cannot validate the contract
+between an exporter, scrape relabeling, remote write, and the labels actually
+stored in Mimir. A fixture can therefore agree with a rule while both disagree
+with live data.
+
+`tools/check-mimir-label-contract.py` checks that contract against a tenant's
+live Mimir series API:
+
+1. Read each native alert and recording rule expression and extract its vector
+   selectors.
+2. Query `/prometheus/api/v1/series` for the bare metric name and for the full
+   selector, using `X-Scope-OrgID`, `start`, and `end`.
+3. Fail when the metric family exists in the selected lookback but the full
+   selector matches no series.
+
+The family query is the important false-positive guard. A family with no
+series in the selected lookback is treated as absent and skipped: the
+component may be quiet or not deployed in that tenant. A family that is
+present but has no series matching the rule's labels is different evidence;
+it indicates a selector or label-contract defect and fails the check. The
+lookback is therefore part of the meaning of “present”; choose it long enough
+to cover the expected scrape cadence.
+
+Rules are shared across tenants. Selectors that explicitly exclude the
+current tenant with a `cluster` matcher are skipped, because they are not
+expected to match that tenant. Other selectors are checked normally.
+
+## Invocation
+
+The checker needs a tenant and live Mimir access:
+
+```console
+MIMIR_TENANT=talos-stpetersburg \
+MIMIR_API_URL=http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus/api/v1 \
+  tools/check-mimir-label-contract.py --lookback 24h
+```
+
+Exit status `0` means every present family had at least one matching series;
+absent families are reported as skipped. Exit status `1` means at least one
+present family had zero full-selector matches. Exit status `2` means the rule
+files or Mimir API could not be checked safely.
+
+The offline test uses the Kopiur label contract as a regression proof. The
+pre-#2924 selector with `namespace="home-assistant"` fails because live
+series carry `namespace="kopiur-system"` and
+`exported_namespace="home-assistant"`. The post-#2924 selector using
+`exported_namespace` passes. The same test includes an absent metric family,
+which is skipped rather than reported as a defect.
+
+## Where it runs
+
+This is an operational, periodic check rather than a pull-request check. A
+PR runner normally cannot reach the tenant-scoped Mimir service, and a
+synthetic fixture cannot prove the exporter-to-Mimir label contract. Run the
+one-shot checker from a small in-cluster monitoring process for each tenant,
+with the native rules supplied from the same Git revision, and send a
+non-zero result to Alertmanager. The existing
+`mimir-rule-completeness` deployment is the model for this placement: it has
+Mimir service access, iterates over all three tenants, and posts independent
+checker alerts directly to Alertmanager so a broken Mimir rule cannot silence
+the checker itself.
+
+The checker intentionally does not change or allowlist rules. On its first
+live run it may expose already-existing label-contract defects; those should
+be fixed in their owning rule changes rather than hidden from this signal.

--- a/docs/reference/mimir-label-contract-check.md
+++ b/docs/reference/mimir-label-contract-check.md
@@ -58,12 +58,13 @@ The other observation-quality failure is statically detectable. Run
 `irate()` alert expressions whose range is at most a few scrape intervals and
 whose `for` is zero. With the repository's 5-minute threshold, the current
 rule set originally reported two locations: `VeleroBackupPartiallyFailed` and
-`VeleroBackupFailed`. The former is fixed in this change; the strict scan now
-reports one remaining location, `VeleroBackupFailed`, as a separate
-counter-based finding. `NodeKernelOOMKill` is the adjacent broader case
-(`increase(...[10m])` with `for: 0m`) and is reported when the threshold is
-raised. Because the native rule files are shared, each location is loaded for
-all three Mimir tenants.
+`VeleroBackupFailed`; both now use newest-Backup state and the strict scan is
+clean. `NodeKernelOOMKill` is the different event-counter case: it now keeps
+`increase(...[1h])` visible with `for: 5m`, rather than pretending an object
+state exists. The static scan still reports it if its threshold is raised to
+one hour, which is intentional: the event has no durable current-state object
+and its retention window is an explicit operational choice. Because the native
+rule files are shared, each location is loaded for all three Mimir tenants.
 
 Rules are shared across tenants. Selectors that explicitly exclude the
 current tenant with a `cluster` matcher are skipped, because they are not

--- a/docs/reference/mimir-label-contract-check.md
+++ b/docs/reference/mimir-label-contract-check.md
@@ -20,9 +20,50 @@ The family query is the important false-positive guard. A family with no
 series in the selected lookback is treated as absent and skipped: the
 component may be quiet or not deployed in that tenant. A family that is
 present but has no series matching the rule's labels is different evidence;
-it indicates a selector or label-contract defect and fails the check. The
+it is a candidate selector or label-contract defect and fails the check. The
 lookback is therefore part of the meaning of “present”; choose it long enough
-to cover the expected scrape cadence.
+to cover the expected scrape cadence. It is not, by itself, proof of a
+defect: a healthy alert such as `FluxInstanceNotReady` also has a present
+family and zero matches while every live series is `ready="True"`.
+
+## Triage status
+
+The first 24-hour live sweep on 2026-09-09 produced 142 present-family,
+zero-selector observations across the three tenants (31 Ottawa, 53
+Robbinsdale, and 58 St. Petersburg). That number is a candidate count, not a
+finding count. The `/series` API does not provide the rule's applicability or
+the expected values of its condition labels, so it cannot produce an honest
+three-way `broken`/`not-applicable`/`quiet` partition on its own.
+
+The ground-truthed cases are:
+
+- No current Kopiur selector is proven broken. The pre-#2924 selectors did
+  fail against a family whose live labels had `namespace="kopiur-system"` and
+  `exported_namespace="home-assistant"`; after #2924, St. Petersburg and
+  Robbinsdale are 14/14, and the two Ottawa repository observations are
+  St. Petersburg-specific and not applicable.
+- `FluxInstanceNotReady` is a known healthy-quiet control: its family exists,
+  all live series are `ready="True"`, and `ready!="True"` matches nothing.
+  The control appears in all three tenant sweeps.
+
+The current checker therefore must not send every non-zero exit to
+Alertmanager. A rule-specific applicability/metric-contract declaration (or
+another independent source of expected labels) is required before a periodic
+dead-rule alert can distinguish the historical Kopiur mismatch from a normal
+quiet condition. The offline test includes both the Kopiur pre/post regression
+and the healthy Flux counterexample to keep this limitation visible.
+
+The other observation-quality failure is statically detectable. Run
+`tools/check-mimir-alert-windows.py` to find `increase()`, `rate()`, or
+`irate()` alert expressions whose range is at most a few scrape intervals and
+whose `for` is zero. With the repository's 5-minute threshold, the current
+rule set originally reported two locations: `VeleroBackupPartiallyFailed` and
+`VeleroBackupFailed`. The former is fixed in this change; the strict scan now
+reports one remaining location, `VeleroBackupFailed`, as a separate
+counter-based finding. `NodeKernelOOMKill` is the adjacent broader case
+(`increase(...[10m])` with `for: 0m`) and is reported when the threshold is
+raised. Because the native rule files are shared, each location is loaded for
+all three Mimir tenants.
 
 Rules are shared across tenants. Selectors that explicitly exclude the
 current tenant with a `cluster` matcher are skipped, because they are not
@@ -52,17 +93,19 @@ which is skipped rather than reported as a defect.
 
 ## Where it runs
 
-This is an operational, periodic check rather than a pull-request check. A
-PR runner normally cannot reach the tenant-scoped Mimir service, and a
-synthetic fixture cannot prove the exporter-to-Mimir label contract. Run the
-one-shot checker from a small in-cluster monitoring process for each tenant,
-with the native rules supplied from the same Git revision, and send a
-non-zero result to Alertmanager. The existing
+This is intended to be an operational, periodic check rather than a
+pull-request check. A PR runner normally cannot reach the tenant-scoped Mimir
+service, and a synthetic fixture cannot prove the exporter-to-Mimir label
+contract. Once the triage metadata exists, run the one-shot checker from a
+small in-cluster monitoring process for each tenant, with the native rules
+supplied from the same Git revision, and send only classified defects to
+Alertmanager. The existing
 `mimir-rule-completeness` deployment is the model for this placement: it has
 Mimir service access, iterates over all three tenants, and posts independent
 checker alerts directly to Alertmanager so a broken Mimir rule cannot silence
 the checker itself.
 
-The checker intentionally does not change or allowlist rules. On its first
-live run it may expose already-existing label-contract defects; those should
-be fixed in their owning rule changes rather than hidden from this signal.
+The checker intentionally does not change or allowlist rules. Until the
+applicability/condition distinction is made mechanical, its non-zero result
+is diagnostic output only; wiring it as an alert would create a false-positive
+signal that should not be shipped.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/node-health.yaml
@@ -38,8 +38,12 @@ groups:
             condition is not hidden by generic node-readiness alerts.
 
       - alert: NodeKernelOOMKill
-        expr: increase(problem_counter{reason="OOMKilling"}[10m]) > 0
-        for: 0m
+        # problem_counter is an event counter, not a resource with a current
+        # phase. Retain a recent event for an hour and require five minutes of
+        # continuous evidence so a single scrape/evaluation blip is not the
+        # only opportunity to observe a host OOM kill.
+        expr: increase(problem_counter{reason="OOMKilling"}[1h]) > 0
+        for: 5m
         labels:
           severity: critical
         annotations:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/node_health_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/node_health_test.yaml
@@ -1,0 +1,35 @@
+rule_files:
+  - ../node-health.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # NodeKernelOOMKill is an event counter, so retain it for an hour rather
+  # than relying on a short increase window. The five-minute hold is still
+  # required; the event must not be visible for only one evaluation tick.
+  - interval: 1m
+    input_series:
+      - series: 'problem_counter{cluster="talos-stpetersburg",node="spark-0",reason="OOMKilling"}'
+        values: "0 0 1+0x70"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: NodeKernelOOMKill
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: NodeKernelOOMKill
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              node: spark-0
+              reason: OOMKilling
+              severity: critical
+            exp_annotations:
+              summary: Node spark-0 recorded a kernel OOM kill.
+              description: >-
+                Node-problem-detector observed the kernel OOM-kill signature.
+                This distinguishes host-level memory pressure from a Kata
+                sandbox teardown; correlate it with the affected pod's
+                termination reason and node memory metrics.
+      - eval_time: 70m
+        alertname: NodeKernelOOMKill
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
@@ -209,3 +209,47 @@ tests:
       - eval_time: 15m
         alertname: VeleroBackupPartiallyFailed
         exp_alerts: []
+
+  # A Failed Backup uses the same newest-state boundary as a PartiallyFailed
+  # Backup. It must be observable while current and clear after recovery.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="failed-recovered",backup="failed-recovered-old"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="failed-recovered",backup="failed-recovered-failed"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="failed-recovered",backup="failed-recovered-old",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="failed-recovered",backup="failed-recovered-failed",phase="Failed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="failed-recovered",backup="failed-recovered-success"}'
+        values: "_x10 300+0x10"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="failed-recovered",backup="failed-recovered-success",phase="Completed"}'
+        values: "_x10 1+0x10"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: VeleroBackupFailed
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: VeleroBackupFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: failed-recovered
+              backup: failed-recovered-failed
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule failed-recovered reported a failed backup
+              description: >-
+                The newest Backup for schedule failed-recovered is Failed.
+                This is current Backup state, not a counter delta, so it
+                remains observable until a newer Backup supersedes it. Do not
+                substitute velero_backup_last_status for this signal: that
+                gauge can remain successful while a later Backup object is
+                Failed. Inspect the Backup status and error details; this
+                alert does not establish that a backup which completed is
+                complete or restorable.
+      - eval_time: 15m
+        alertname: VeleroBackupFailed
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_stale_test.yaml
@@ -165,3 +165,47 @@ tests:
                 guard; it cannot detect a backup that completes while silently
                 missing data, and it also needs the Velero metric to remain
                 scrapeable.
+
+  # A PartiallyFailed Backup is durable current state while it is the newest
+  # attempt. A later Completed Backup must clear it; the alert must not depend
+  # on catching a short counter increase during a scrape window.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="partial-recovered",backup="partial-recovered-old"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="partial-recovered",backup="partial-recovered-partial"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="partial-recovered",backup="partial-recovered-old",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="partial-recovered",backup="partial-recovered-partial",phase="PartiallyFailed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="partial-recovered",backup="partial-recovered-success"}'
+        values: "_x10 300+0x10"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="partial-recovered",backup="partial-recovered-success",phase="Completed"}'
+        values: "_x10 1+0x10"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: VeleroBackupPartiallyFailed
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: VeleroBackupPartiallyFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: velero-system
+              schedule: partial-recovered
+              backup: partial-recovered-partial
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule partial-recovered reported a partially failed backup
+              description: >-
+                The newest Backup for schedule partial-recovered is
+                PartiallyFailed. This is current Backup state, not a counter
+                delta, so it remains observable until a newer Backup
+                supersedes it. itemsBackedUp matching totalItems does not
+                establish filesystem or volume integrity. Inspect the Backup
+                status and its failed PodVolumeBackup objects, then correlate
+                the Velero and node-agent logs.
+      - eval_time: 15m
+        alertname: VeleroBackupPartiallyFailed
+        exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
@@ -2,12 +2,11 @@
 # Prometheus agents only scrape and remote-write these metrics; their
 # PrometheusRule objects are not evaluated in agent mode.
 #
-# Backup phase is current state for the newest Backup attempt. The partial
-# failure alert uses that state; the remaining failed-backup event alert still
-# uses a counter, whose five-minute increase can disappear before a sweep
-# observes it. A matching item count is not a volume-integrity signal; the
-# annotations intentionally direct the operator to the Backup and
-# PodVolumeBackup objects.
+# Backup phase is current state for the newest Backup attempt. The two backup
+# failure alerts use that state rather than counters whose short increases can
+# disappear before a sweep observes them. A matching item count is not a
+# volume-integrity signal; the annotations intentionally direct the operator
+# to the Backup and PodVolumeBackup objects.
 #
 # Keep this namespace unique across every file passed to mimirtool.
 namespace: velero-backups
@@ -55,19 +54,38 @@ groups:
 
       - alert: VeleroBackupFailed
         expr: |
-          sum by (cluster, schedule) (
-            increase(
-              velero_backup_failure_total{schedule!=""}[5m]
+          (
+            max by (cluster, namespace, schedule, backup) (
+              velero_cr_backup_info{
+                namespace="velero-system",
+                schedule!="",
+                phase="Failed"
+              }
+            ) > 0
+          )
+          and on (cluster, namespace, schedule, backup)
+          (
+            velero_cr_backup_created_timestamp{
+              namespace="velero-system",
+              schedule!=""
+            }
+            == on (cluster, namespace, schedule) group_left
+            max by (cluster, namespace, schedule) (
+              velero_cr_backup_created_timestamp{
+                namespace="velero-system",
+                schedule!=""
+              }
             )
-          ) > 0
-        for: 0m
+          )
+        for: 5m
         labels:
           severity: critical
         annotations:
           summary: Velero schedule {{ $labels.schedule }} reported a failed backup
           description: >-
-            Velero's failed-backup counter increased for schedule
-            {{ $labels.schedule }}. Do not substitute
+            The newest Backup for schedule {{ $labels.schedule }} is Failed.
+            This is current Backup state, not a counter delta, so it remains
+            observable until a newer Backup supersedes it. Do not substitute
             velero_backup_last_status for this signal: that gauge can remain
             successful while a later Backup object is Failed. Inspect the
             Backup status and error details; this alert does not establish that

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero.yaml
@@ -2,10 +2,12 @@
 # Prometheus agents only scrape and remote-write these metrics; their
 # PrometheusRule objects are not evaluated in agent mode.
 #
-# The two event alerts use Velero's counters, not velero_backup_last_status:
-# the latter remained 1 during a real Failed Backup in Ottawa. A matching item
-# count is not a volume-integrity signal; the annotations intentionally direct
-# the operator to the Backup and PodVolumeBackup objects.
+# Backup phase is current state for the newest Backup attempt. The partial
+# failure alert uses that state; the remaining failed-backup event alert still
+# uses a counter, whose five-minute increase can disappear before a sweep
+# observes it. A matching item count is not a volume-integrity signal; the
+# annotations intentionally direct the operator to the Backup and
+# PodVolumeBackup objects.
 #
 # Keep this namespace unique across every file passed to mimirtool.
 namespace: velero-backups
@@ -14,19 +16,38 @@ groups:
     rules:
       - alert: VeleroBackupPartiallyFailed
         expr: |
-          sum by (cluster, schedule) (
-            increase(
-              velero_backup_partial_failure_total{schedule!=""}[5m]
+          (
+            max by (cluster, namespace, schedule, backup) (
+              velero_cr_backup_info{
+                namespace="velero-system",
+                schedule!="",
+                phase="PartiallyFailed"
+              }
+            ) > 0
+          )
+          and on (cluster, namespace, schedule, backup)
+          (
+            velero_cr_backup_created_timestamp{
+              namespace="velero-system",
+              schedule!=""
+            }
+            == on (cluster, namespace, schedule) group_left
+            max by (cluster, namespace, schedule) (
+              velero_cr_backup_created_timestamp{
+                namespace="velero-system",
+                schedule!=""
+              }
             )
-          ) > 0
-        for: 0m
+          )
+        for: 5m
         labels:
           severity: critical
         annotations:
           summary: Velero schedule {{ $labels.schedule }} reported a partially failed backup
           description: >-
-            Velero reported a PartiallyFailed backup for schedule
-            {{ $labels.schedule }}. This detects Velero's failure report only;
+            The newest Backup for schedule {{ $labels.schedule }} is
+            PartiallyFailed. This is current Backup state, not a counter
+            delta, so it remains observable until a newer Backup supersedes it.
             itemsBackedUp matching totalItems does not establish filesystem or
             volume integrity. Inspect the Backup status and its failed
             PodVolumeBackup objects, then correlate the Velero and node-agent

--- a/tools/check-mimir-alert-windows.py
+++ b/tools/check-mimir-alert-windows.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Find alert rules whose short counter window can vanish before observation.
+
+This is a static lint, not a replacement for the live label-contract check.
+An increase()/rate()/irate() expression with for: 0m is only observable while
+the range window contains the event.  When that window is no longer than a few
+scrape intervals, a periodic sweep can miss a real event entirely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+from pathlib import Path
+import re
+import sys
+from typing import Iterable
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RULES_DIR = ROOT / "kubernetes/apps/base/mimir/mimir-ottawa/rules"
+WINDOW_RE = re.compile(r"\[\s*([0-9]+(?:\.[0-9]+)?)\s*(ms|s|m|h|d)\s*\]")
+FUNCTION_RE = re.compile(r"\b(increase|rate|irate)\s*\(")
+ZERO_FOR_RE = re.compile(r"^\s*0(?:\.0+)?\s*(?:ms|s|m|h|d)?\s*$")
+UNIT_SECONDS = {"ms": 0.001, "s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    path: Path
+    rule_name: str
+    function: str
+    window: str
+    for_value: str
+
+    @property
+    def location(self) -> str:
+        return f"{self.path.name}:alert={self.rule_name}"
+
+
+def parse_duration(value: str) -> float:
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)(ms|s|m|h|d)", value.strip())
+    if not match:
+        raise argparse.ArgumentTypeError(
+            f"invalid duration {value!r}; use e.g. 5m, 30s, or 1h"
+        )
+    return float(match.group(1)) * UNIT_SECONDS[match.group(2)]
+
+
+def rule_paths(rules_dir: Path) -> list[Path]:
+    paths = sorted(rules_dir.glob("*.yaml")) + sorted(rules_dir.glob("*.yml"))
+    if not paths:
+        raise ValueError(f"no Mimir rule files found under {rules_dir}")
+    return paths
+
+
+def scan(paths: Iterable[Path], max_window: float) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in paths:
+        for document in yaml.safe_load_all(path.read_text()):
+            if not isinstance(document, dict):
+                continue
+            for group in document.get("groups", []):
+                if not isinstance(group, dict):
+                    continue
+                for rule in group.get("rules", []):
+                    if not isinstance(rule, dict) or not isinstance(rule.get("alert"), str):
+                        continue
+                    expression = rule.get("expr")
+                    if not isinstance(expression, str):
+                        continue
+                    for_value = str(rule.get("for", ""))
+                    if not ZERO_FOR_RE.fullmatch(for_value):
+                        continue
+                    functions = sorted({match.group(1) for match in FUNCTION_RE.finditer(expression)})
+                    if not functions:
+                        continue
+                    windows = [
+                        (float(amount) * UNIT_SECONDS[unit], f"{amount}{unit}")
+                        for amount, unit in WINDOW_RE.findall(expression)
+                    ]
+                    for function in functions:
+                        for seconds, window in windows:
+                            if seconds <= max_window:
+                                findings.append(
+                                    Finding(
+                                        path=path,
+                                        rule_name=rule["alert"],
+                                        function=function,
+                                        window=window,
+                                        for_value=for_value,
+                                    )
+                                )
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find short rate/increase alert windows with for: 0m"
+    )
+    parser.add_argument(
+        "--rules-dir",
+        default=str(DEFAULT_RULES_DIR),
+        help="directory containing native Mimir rule YAML files",
+    )
+    parser.add_argument(
+        "--max-window",
+        type=parse_duration,
+        default=parse_duration("5m"),
+        help="maximum range window to report (default: 5m)",
+    )
+    args = parser.parse_args()
+    try:
+        findings = scan(rule_paths(Path(args.rules_dir)), args.max_window)
+    except (OSError, ValueError, yaml.YAMLError) as error:
+        print(f"Mimir alert-window scan failed: {error}", file=sys.stderr)
+        return 2
+
+    for finding in findings:
+        print(
+            f"✗ {finding.location}: {finding.function} [{finding.window}] "
+            f"with for={finding.for_value}"
+        )
+    print(
+        f"Mimir alert-window scan: findings={len(findings)} "
+        f"max-window={args.max_window:g}s"
+    )
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-mimir-label-contract.py
+++ b/tools/check-mimir-label-contract.py
@@ -89,6 +89,7 @@ PROMQL_WORDS = {
     "true",
     "false",
 }
+DURATION_UNITS = {"ms", "s", "m", "h", "d", "w", "y"}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -189,6 +190,9 @@ def extract_selectors(expression: str) -> list[Selector]:
         while end < len(expression) and IDENTIFIER_CONTINUE.fullmatch(expression[end]):
             end += 1
         name = expression[index:end]
+        if index > 0 and expression[index - 1].isdigit() and name in DURATION_UNITS:
+            index = end
+            continue
         cursor = end
         while cursor < len(expression) and expression[cursor].isspace():
             cursor += 1

--- a/tools/check-mimir-label-contract.py
+++ b/tools/check-mimir-label-contract.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Check native Mimir rule selectors against live Mimir series.
+
+PromQL parsing and fixture tests prove that an expression is syntactically
+valid and behaves as expected for the labels the fixture invents.  They do not
+prove that the selector matches the labels which the remote-write path
+actually stores.  This checker closes that gap without evaluating the rule:
+for every metric selector in every rule, it asks Mimir whether the metric
+family exists and whether the complete selector matches any series.
+
+An absent family is deliberately not an error.  Rule files are shared by all
+three tenants and some components are intentionally absent from a tenant.  A
+present family with a zero-match selector is different: it is evidence that a
+label contract (or a selector spelling) is wrong.
+
+The checker is intentionally one-shot.  Run it from a periodic in-cluster
+process with network access to Mimir and have that process report a non-zero
+exit as an operational alert.  It must not be made a PR-only check and called
+healthy merely because the PR runner cannot reach the live tenant.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import time
+from typing import Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+try:
+    import yaml
+except ImportError as error:  # pragma: no cover - exercised by deployment errors
+    raise SystemExit(
+        "PyYAML is required to read native Mimir rule files"
+    ) from error
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RULES_DIR = ROOT / "kubernetes/apps/base/mimir/mimir-ottawa/rules"
+DEFAULT_API_URL = (
+    "http://mimir-gateway.mimir.svc.cluster.local:8080"
+    "/prometheus/api/v1"
+)
+DEFAULT_LOOKBACK = "24h"
+DEFAULT_TIMEOUT = 10.0
+
+IDENTIFIER_START = re.compile(r"[A-Za-z_:]")
+IDENTIFIER_CONTINUE = re.compile(r"[A-Za-z0-9_:]")
+PROMQL_MATCHER = re.compile(
+    r'''([A-Za-z_][A-Za-z0-9_]*)\s*(=~|!~|!=|=)\s*"((?:\\.|[^"\\])*)"'''
+)
+
+# These words can occur outside a selector but are not metric names.  Function
+# names are handled separately when followed by "("; keeping the aggregation
+# and binary-operator words here covers `sum by (...)` and `on (...)` too.
+PROMQL_WORDS = {
+    "and",
+    "bool",
+    "by",
+    "group_left",
+    "group_right",
+    "ignoring",
+    "in",
+    "on",
+    "or",
+    "unless",
+    "without",
+    "offset",
+    "sum",
+    "min",
+    "max",
+    "avg",
+    "count",
+    "stddev",
+    "stdvar",
+    "bottomk",
+    "topk",
+    "count_values",
+    "quantile",
+    "limitk",
+    "limit_ratio",
+    "true",
+    "false",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class Selector:
+    metric: str
+    text: str
+    has_matchers: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class RuleSelector:
+    path: Path
+    rule_kind: str
+    rule_name: str
+    selector: Selector
+
+    @property
+    def location(self) -> str:
+        return f"{self.path.name}:{self.rule_kind}={self.rule_name}"
+
+
+class CheckError(RuntimeError):
+    """The live Mimir response or a rule file could not be checked safely."""
+
+
+def skip_string(expression: str, index: int) -> int:
+    """Return the index immediately after a PromQL quoted string."""
+
+    assert expression[index] == '"'
+    index += 1
+    while index < len(expression):
+        if expression[index] == "\\":
+            index += 2
+        elif expression[index] == '"':
+            return index + 1
+        else:
+            index += 1
+    raise CheckError("unterminated string in PromQL expression")
+
+
+def balanced_braces(expression: str, index: int) -> tuple[str, int]:
+    """Return selector contents and the index after its closing brace."""
+
+    assert expression[index] == "{"
+    start = index
+    index += 1
+    while index < len(expression):
+        if expression[index] == '"':
+            index = skip_string(expression, index)
+            continue
+        if expression[index] == "}":
+            return expression[start + 1 : index], index + 1
+        index += 1
+    raise CheckError("unterminated label selector in PromQL expression")
+
+
+def skip_parentheses(expression: str, index: int) -> int:
+    """Return the index immediately after a parenthesized label list."""
+
+    assert expression[index] == "("
+    depth = 0
+    while index < len(expression):
+        if expression[index] == '"':
+            index = skip_string(expression, index)
+            continue
+        if expression[index] == "(":
+            depth += 1
+        elif expression[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    raise CheckError("unterminated PromQL label list")
+
+
+def extract_selectors(expression: str) -> list[Selector]:
+    """Extract metric vector selectors without mistaking functions for metrics.
+
+    This is a lexer for the selector-shaped part of PromQL, not a PromQL
+    evaluator.  The repository already runs the pinned Prometheus parser for
+    syntax validation.  Keeping this extraction independent means the live
+    check only needs Python, PyYAML, and the Mimir HTTP API.
+    """
+
+    selectors: list[Selector] = []
+    seen: set[tuple[str, str]] = set()
+    index = 0
+    while index < len(expression):
+        char = expression[index]
+        if char == '"':
+            index = skip_string(expression, index)
+            continue
+        if not IDENTIFIER_START.fullmatch(char):
+            index += 1
+            continue
+
+        end = index + 1
+        while end < len(expression) and IDENTIFIER_CONTINUE.fullmatch(expression[end]):
+            end += 1
+        name = expression[index:end]
+        cursor = end
+        while cursor < len(expression) and expression[cursor].isspace():
+            cursor += 1
+
+        if cursor < len(expression) and expression[cursor] == "{":
+            contents, after = balanced_braces(expression, cursor)
+            normalized_contents = re.sub(r"\s+", " ", contents).strip()
+            selector_text = f"{name}{{{normalized_contents}}}"
+            selector = Selector(name, selector_text, bool(normalized_contents))
+            identity = (selector.metric, selector.text)
+            if identity not in seen:
+                selectors.append(selector)
+                seen.add(identity)
+            index = after
+            continue
+
+        if name in {"by", "ignoring", "on", "without", "group_left", "group_right"}:
+            if cursor < len(expression) and expression[cursor] == "(":
+                index = skip_parentheses(expression, cursor)
+                continue
+        # A function/aggregation name is followed by "(".  Do not skip the
+        # parenthesized expression: it may contain the real metric selector.
+        if cursor < len(expression) and expression[cursor] == "(":
+            index = end
+            continue
+        if name in PROMQL_WORDS:
+            index = end
+            continue
+
+        selector = Selector(name, name, False)
+        identity = (selector.metric, selector.text)
+        if identity not in seen:
+            selectors.append(selector)
+            seen.add(identity)
+        index = end
+
+    return selectors
+
+
+def parse_matchers(selector: Selector) -> list[tuple[str, str, str]]:
+    """Return (label, operator, PromQL string contents) for label matchers."""
+
+    if not selector.has_matchers:
+        return []
+    contents = selector.text[selector.text.find("{") + 1 : -1]
+    matchers = [match.groups() for match in PROMQL_MATCHER.finditer(contents)]
+    # The checker sends the original selector to Mimir, but fail closed if its
+    # simple matcher view cannot account for the full contents.  Otherwise a
+    # malformed selector could be silently classified as tenant-independent.
+    remainder = PROMQL_MATCHER.sub("", contents)
+    if remainder.replace(",", "").strip():
+        raise CheckError(f"unsupported label matcher syntax in {selector.text!r}")
+    return matchers
+
+
+def promql_unescape(value: str) -> str:
+    return re.sub(r"\\(.)", r"\1", value)
+
+
+def targets_another_tenant(selector: Selector, tenant: str) -> bool:
+    """Skip an explicit cluster selector belonging to another Mimir tenant."""
+
+    for label, operator, raw_value in parse_matchers(selector):
+        if label != "cluster":
+            continue
+        value = promql_unescape(raw_value)
+        if operator == "=" and value != tenant:
+            return True
+        if operator == "=~":
+            try:
+                if re.fullmatch(value, tenant) is None:
+                    return True
+            except re.error as error:
+                raise CheckError(
+                    f"invalid cluster matcher {selector.text!r}: {error}"
+                ) from error
+        if operator == "!=" and value == tenant:
+            return True
+        if operator == "!~":
+            try:
+                if re.fullmatch(value, tenant) is not None:
+                    return True
+            except re.error as error:
+                raise CheckError(
+                    f"invalid cluster matcher {selector.text!r}: {error}"
+                ) from error
+    return False
+
+
+def iter_rule_selectors(
+    paths: Iterable[Path], requested_rule_names: set[str] | None = None
+) -> Iterable[RuleSelector]:
+    for path in paths:
+        try:
+            documents = yaml.safe_load_all(path.read_text())
+            loaded = list(documents)
+        except (OSError, yaml.YAMLError) as error:
+            raise CheckError(f"cannot read {path}: {error}") from error
+
+        for document in loaded:
+            if not isinstance(document, dict):
+                continue
+            for group in document.get("groups", []):
+                if not isinstance(group, dict):
+                    continue
+                for rule in group.get("rules", []):
+                    if not isinstance(rule, dict):
+                        continue
+                    rule_kind = "alert" if isinstance(rule.get("alert"), str) else "record"
+                    rule_name = rule.get(rule_kind)
+                    expression = rule.get("expr")
+                    if not isinstance(rule_name, str) or not isinstance(expression, str):
+                        continue
+                    if requested_rule_names and rule_name not in requested_rule_names:
+                        continue
+                    for selector in extract_selectors(expression):
+                        yield RuleSelector(path, rule_kind, rule_name, selector)
+
+
+def parse_duration(value: str) -> float:
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([smhd])", value.strip())
+    if not match:
+        raise argparse.ArgumentTypeError(
+            f"invalid duration {value!r}; use e.g. 6h, 24h, or 30m"
+        )
+    amount = float(match.group(1))
+    multiplier = {"s": 1, "m": 60, "h": 3600, "d": 86400}[match.group(2)]
+    return amount * multiplier
+
+
+class MimirSeriesAPI:
+    def __init__(
+        self,
+        api_url: str,
+        tenant: str,
+        start: float,
+        end: float,
+        timeout: float,
+    ) -> None:
+        self.series_url = api_url.rstrip("/") + "/series"
+        self.tenant = tenant
+        self.start = start
+        self.end = end
+        self.timeout = timeout
+        self.cache: dict[str, list[dict]] = {}
+
+    def series(self, selector: str) -> list[dict]:
+        if selector in self.cache:
+            return self.cache[selector]
+        query = urlencode(
+            {
+                "match[]": selector,
+                "start": f"{self.start:.3f}",
+                "end": f"{self.end:.3f}",
+            }
+        )
+        request = Request(
+            f"{self.series_url}?{query}",
+            headers={"Accept": "application/json", "X-Scope-OrgID": self.tenant},
+        )
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                payload = response.read()
+        except (HTTPError, URLError, TimeoutError, OSError) as error:
+            raise CheckError(f"Mimir series query failed for {selector!r}: {error}") from error
+        try:
+            document = json.loads(payload)
+        except (UnicodeDecodeError, ValueError) as error:
+            raise CheckError(f"Mimir returned invalid JSON for {selector!r}") from error
+        if not isinstance(document, dict) or document.get("status") != "success":
+            detail = document.get("error", document.get("status")) if isinstance(document, dict) else document
+            raise CheckError(f"Mimir returned an unsuccessful response for {selector!r}: {detail}")
+        data = document.get("data")
+        if not isinstance(data, list) or not all(isinstance(item, dict) for item in data):
+            raise CheckError(f"Mimir returned an invalid series list for {selector!r}")
+        self.cache[selector] = data
+        return data
+
+
+def rule_paths(rules_dir: Path, explicit_paths: list[str]) -> list[Path]:
+    if explicit_paths:
+        paths = [Path(path).resolve() for path in explicit_paths]
+    else:
+        paths = sorted(rules_dir.glob("*.yaml")) + sorted(rules_dir.glob("*.yml"))
+    if not paths:
+        raise CheckError(f"no Mimir rule files found under {rules_dir}")
+    missing = [path for path in paths if not path.is_file()]
+    if missing:
+        raise CheckError("rule file(s) not found: " + ", ".join(map(str, missing)))
+    return paths
+
+
+def run(args: argparse.Namespace) -> int:
+    if not args.api_url:
+        raise CheckError("--api-url or MIMIR_API_URL is required")
+    if not args.tenant:
+        raise CheckError("--tenant or MIMIR_TENANT is required")
+
+    paths = rule_paths(Path(args.rules_dir), args.rule_file)
+    requested_names = set(args.rule_name)
+    selectors = list(iter_rule_selectors(paths, requested_names or None))
+    if not selectors:
+        raise CheckError("no rule selectors were extracted")
+
+    end = time.time()
+    api = MimirSeriesAPI(
+        args.api_url,
+        args.tenant,
+        end - args.lookback,
+        end,
+        args.timeout,
+    )
+    checked = matched = absent = skipped = failed = errors = 0
+
+    for occurrence in selectors:
+        selector = occurrence.selector
+        if targets_another_tenant(selector, args.tenant):
+            skipped += 1
+            print(
+                f"⊘ {occurrence.location}: {selector.text} "
+                f"(explicit cluster selector excludes tenant {args.tenant})"
+            )
+            continue
+        checked += 1
+        try:
+            family = api.series(selector.metric)
+            if not family:
+                absent += 1
+                print(
+                    f"⊘ {occurrence.location}: {selector.text} "
+                    f"(metric family {selector.metric!r} absent; skipped)"
+                )
+                continue
+            selected = api.series(selector.text)
+        except CheckError as error:
+            errors += 1
+            print(f"! {occurrence.location}: {error}", file=sys.stderr)
+            continue
+        if selected:
+            matched += 1
+            print(
+                f"✓ {occurrence.location}: {selector.text} "
+                f"({len(selected)} matching series; family={len(family)})"
+            )
+        else:
+            failed += 1
+            print(
+                f"✗ {occurrence.location}: {selector.text} "
+                f"(family exists with {len(family)} series, selector matches zero)",
+                file=sys.stderr,
+            )
+
+    print(
+        f"Mimir label contract: tenant={args.tenant} rules={len(paths)} "
+        f"selectors={checked} matched={matched} absent={absent} "
+        f"cross-tenant={skipped} failed={failed} errors={errors}"
+    )
+    if errors:
+        return 2
+    return 1 if failed else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check native Mimir selectors against live tenant series"
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get("MIMIR_API_URL", DEFAULT_API_URL),
+        help="Mimir Prometheus API base ending in /api/v1",
+    )
+    parser.add_argument(
+        "--tenant",
+        default=os.environ.get("MIMIR_TENANT"),
+        help="X-Scope-OrgID tenant to inspect",
+    )
+    parser.add_argument(
+        "--rules-dir",
+        default=str(DEFAULT_RULES_DIR),
+        help="directory containing native Mimir rule YAML files",
+    )
+    parser.add_argument(
+        "--rule-file",
+        action="append",
+        default=[],
+        help="check only this rule file; may be repeated",
+    )
+    parser.add_argument(
+        "--rule-name",
+        action="append",
+        default=[],
+        help="check only this alert/record name; may be repeated",
+    )
+    parser.add_argument(
+        "--lookback",
+        type=parse_duration,
+        default=parse_duration(DEFAULT_LOOKBACK),
+        help="series lookback window (default: 24h)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help="HTTP timeout in seconds (default: 10)",
+    )
+    return parser
+
+
+def main() -> int:
+    try:
+        return run(build_parser().parse_args())
+    except CheckError as error:
+        print(f"Mimir label contract check failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -401,6 +401,11 @@ section "Mimir live label-contract replay"
 exits "pre-#2924 selector fails and post-fix selector passes" 0 \
   python3 "$ROOT/tools/tests/test_mimir_label_contract.py"
 
+# ------------------------------------------------------------- Mimir alert-window lint
+section "Mimir alert-window lint"
+exits "short zero-for counter windows are detected" 0 \
+  python3 "$ROOT/tools/tests/test_mimir_alert_windows.py"
+
 # A completed gate must reap every watchdog timer descendant. Use an isolated
 # temporary gate root so this test exercises the real run_capped implementation
 # without allowing a sleep stub to affect repository prerequisite checks.

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -396,6 +396,11 @@ section "Mimir rule completeness replay"
 exits "km#2809 missing-group condition is detected" 0 \
   python3 "$ROOT/kubernetes/apps/base/monitoring/mimir-rule-completeness/tests/test_rule_completeness.py"
 
+# ---------------------------------------------------------------- Mimir live label-contract replay
+section "Mimir live label-contract replay"
+exits "pre-#2924 selector fails and post-fix selector passes" 0 \
+  python3 "$ROOT/tools/tests/test_mimir_label_contract.py"
+
 # A completed gate must reap every watchdog timer descendant. Use an isolated
 # temporary gate root so this test exercises the real run_capped implementation
 # without allowing a sleep stub to affect repository prerequisite checks.

--- a/tools/tests/test_mimir_alert_windows.py
+++ b/tools/tests/test_mimir_alert_windows.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Offline proof for the short counter-window static lint."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/check-mimir-alert-windows.py"
+
+
+def run_scan(rule_dir: Path, max_window: str = "5m") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            "--rules-dir",
+            str(rule_dir),
+            "--max-window",
+            max_window,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="mimir-alert-windows-") as temporary:
+        root = Path(temporary)
+        (root / "rules.yaml").write_text(
+            """groups:
+  - name: test.rules
+    rules:
+      - alert: ShortCounterWindow
+        expr: increase(test_events_total[5m]) > 0
+        for: 0m
+      - alert: HeldCounterWindow
+        expr: increase(test_events_total[5m]) > 0
+        for: 1m
+      - alert: LongerZeroForWindow
+        expr: rate(test_events_total[10m]) > 0
+        for: 0m
+"""
+        )
+
+        result = run_scan(root)
+        assert result.returncode == 1, result
+        assert "ShortCounterWindow" in result.stdout, result.stdout
+        assert "findings=1" in result.stdout, result.stdout
+        assert "LongerZeroForWindow" not in result.stdout, result.stdout
+
+        broader = run_scan(root, "10m")
+        assert broader.returncode == 1, broader
+        assert "ShortCounterWindow" in broader.stdout, broader.stdout
+        assert "LongerZeroForWindow" in broader.stdout, broader.stdout
+        assert "findings=2" in broader.stdout, broader.stdout
+
+    print("✓ Mimir alert-window lint: short zero-for counter window detected")
+    print("✓ Mimir alert-window lint: held and longer windows are threshold-aware")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_mimir_label_contract.py
+++ b/tools/tests/test_mimir_label_contract.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Offline proof for the live Mimir label-contract checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from threading import Thread
+from urllib.parse import parse_qs, urlparse
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools/check-mimir-label-contract.py"
+
+
+def load_tool():
+    spec = importlib.util.spec_from_file_location("mimir_label_contract", TOOL)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {TOOL}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeMimirHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        query = parse_qs(urlparse(self.path).query)
+        selector = query.get("match[]", [""])[0]
+        if selector.startswith("kopiur_snapshotpolicy_last_backup_success"):
+            family = [
+                {
+                    "__name__": "kopiur_snapshotpolicy_last_backup_success",
+                    "cluster": "talos-stpetersburg",
+                    "namespace": "kopiur-system",
+                    "exported_namespace": "home-assistant",
+                    "policy": "homeassistant-config",
+                }
+            ]
+            # This is the pre-#2924 selector: the family exists, but the
+            # namespace matcher cannot match the stored series.
+            if selector.startswith(
+                'kopiur_snapshotpolicy_last_backup_success{namespace="home-assistant"'
+            ):
+                result = []
+            else:
+                result = family
+        elif selector.startswith("kopiur_leader_is_leader"):
+            result = [
+                {
+                    "__name__": "kopiur_leader_is_leader",
+                    "cluster": "talos-stpetersburg",
+                }
+            ]
+        elif selector.startswith("optional_component_metric"):
+            # The entire family is absent. This is a legitimate quiet or
+            # undeployed component and must not fail the checker.
+            result = []
+        else:
+            result = []
+
+        body = json.dumps({"status": "success", "data": result}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        return
+
+
+def run_checker(rule_dir: Path, server: ThreadingHTTPServer) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            "--api-url",
+            f"http://127.0.0.1:{server.server_port}/prometheus/api/v1",
+            "--tenant",
+            "talos-stpetersburg",
+            "--rules-dir",
+            str(rule_dir),
+            "--lookback",
+            "1h",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> int:
+    tool = load_tool()
+    extracted = tool.extract_selectors(
+        'label_replace(metric_a{namespace="x"}, "namespace", "$1", "namespace", "(.+)") '
+        'and on (cluster, namespace) metric_b{state=~"ready|pending"}'
+    )
+    extracted_text = {selector.text for selector in extracted}
+    assert extracted_text == {
+        'metric_a{namespace="x"}',
+        'metric_b{state=~"ready|pending"}',
+    }, extracted_text
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), FakeMimirHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="mimir-label-contract-") as temporary:
+            root = Path(temporary)
+            old_rule = """groups:
+  - name: kopiur.rules
+    rules:
+      - alert: KopiurSnapshotFailed
+        expr: |
+          kopiur_snapshotpolicy_last_backup_success{namespace="home-assistant",policy="homeassistant-config"} == 0
+          and on (cluster) kopiur_leader_is_leader
+      - alert: OptionalComponentMissing
+        expr: optional_component_metric{state="ready"} == 0
+"""
+            new_rule = old_rule.replace(
+                'namespace="home-assistant",policy=',
+                'exported_namespace="home-assistant",policy=',
+            )
+
+            old_dir = root / "old"
+            new_dir = root / "new"
+            old_dir.mkdir()
+            new_dir.mkdir()
+            (old_dir / "kopiur.yaml").write_text(old_rule)
+            (new_dir / "kopiur.yaml").write_text(new_rule)
+
+            old_result = run_checker(old_dir, server)
+            assert old_result.returncode == 1, old_result
+            assert "family exists" in old_result.stderr, old_result.stderr
+            assert 'namespace="home-assistant"' in old_result.stderr, old_result.stderr
+            assert "absent; skipped" in old_result.stdout, old_result.stdout
+
+            new_result = run_checker(new_dir, server)
+            assert new_result.returncode == 0, new_result
+            assert "failed=0" in new_result.stdout, new_result.stdout
+            assert "absent; skipped" in new_result.stdout, new_result.stdout
+
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    print("✓ Mimir live label-contract checker: pre-fix fails, post-fix passes")
+    print("✓ Mimir live label-contract checker: absent metric families are skipped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_mimir_label_contract.py
+++ b/tools/tests/test_mimir_label_contract.py
@@ -57,6 +57,27 @@ class FakeMimirHandler(BaseHTTPRequestHandler):
                     "cluster": "talos-stpetersburg",
                 }
             ]
+        elif selector.startswith("flux_instance_info"):
+            family = [
+                {
+                    "__name__": "flux_instance_info",
+                    "cluster": "talos-ottawa",
+                    "exported_namespace": "flux-system",
+                    "name": "flux",
+                    "ready": "True",
+                },
+                {
+                    "__name__": "flux_instance_info",
+                    "cluster": "talos-ottawa",
+                    "exported_namespace": "flux-system",
+                    "name": "flux",
+                    "ready": "True",
+                },
+            ]
+            # A healthy Flux instance is a legitimate zero-match condition
+            # for its not-ready alert.  This is the counterexample to the
+            # family-exists/selector-zero heuristic.
+            result = [] if 'ready!="True"' in selector else family
         elif selector.startswith("optional_component_metric"):
             # The entire family is absent. This is a legitimate quiet or
             # undeployed component and must not fail the checker.
@@ -132,10 +153,20 @@ def main() -> int:
 
             old_dir = root / "old"
             new_dir = root / "new"
+            quiet_dir = root / "quiet"
             old_dir.mkdir()
             new_dir.mkdir()
+            quiet_dir.mkdir()
             (old_dir / "kopiur.yaml").write_text(old_rule)
             (new_dir / "kopiur.yaml").write_text(new_rule)
+            (quiet_dir / "flux.yaml").write_text(
+                """groups:
+  - name: flux.rules
+    rules:
+      - alert: FluxInstanceNotReady
+        expr: flux_instance_info{exported_namespace=\"flux-system\",name=\"flux\",ready!=\"True\"}
+"""
+            )
 
             old_result = run_checker(old_dir, server)
             assert old_result.returncode == 1, old_result
@@ -148,6 +179,11 @@ def main() -> int:
             assert "failed=0" in new_result.stdout, new_result.stdout
             assert "absent; skipped" in new_result.stdout, new_result.stdout
 
+            quiet_result = run_checker(quiet_dir, server)
+            assert quiet_result.returncode == 1, quiet_result
+            assert "family exists" in quiet_result.stderr, quiet_result.stderr
+            assert 'ready!="True"' in quiet_result.stderr, quiet_result.stderr
+
     finally:
         server.shutdown()
         thread.join(timeout=5)
@@ -155,6 +191,7 @@ def main() -> int:
 
     print("✓ Mimir live label-contract checker: pre-fix fails, post-fix passes")
     print("✓ Mimir live label-contract checker: absent metric families are skipped")
+    print("✓ Mimir live label-contract checker: quiet not-ready selector is exposed as a false positive")
     return 0
 
 

--- a/tools/tests/test_mimir_label_contract.py
+++ b/tools/tests/test_mimir_label_contract.py
@@ -99,12 +99,14 @@ def main() -> int:
     tool = load_tool()
     extracted = tool.extract_selectors(
         'label_replace(metric_a{namespace="x"}, "namespace", "$1", "namespace", "(.+)") '
-        'and on (cluster, namespace) metric_b{state=~"ready|pending"}'
+        'and on (cluster, namespace) metric_b{state=~"ready|pending"} '
+        'and rate(metric_c[5m])'
     )
     extracted_text = {selector.text for selector in extracted}
     assert extracted_text == {
         'metric_a{namespace="x"}',
         'metric_b{state=~"ready|pending"}',
+        'metric_c',
     }, extracted_text
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), FakeMimirHandler)


### PR DESCRIPTION
## What this adds

`tools/check-mimir-label-contract.py` extracts vector selectors from native Mimir alert and recording rules and checks them against the tenant-scoped Mimir `/prometheus/api/v1/series` API. It queries the bare metric name first, then the full selector with `X-Scope-OrgID`.

The quiet-metric distinction is explicit:

- an absent metric family in the selected lookback is skipped, because the component may be quiet or not deployed in that tenant;
- an existing family whose full selector matches zero series fails, because the selector cannot match the live label contract.

The checker returns 0 for a clean result, 1 for zero-match selectors, and 2 for API, parser, or configuration errors. Selectors explicitly excluding the current tenant are skipped because the rule files are shared across tenants.

## Where it runs

This is intentionally a live periodic operational check, not a PR-only check. PR runners do not reliably have tenant-scoped Mimir access, and fixture labels cannot prove the exporter-to-scrape-relabeling-to-Mimir contract. The one-shot checker is suitable for a small in-cluster monitoring process that runs for each tenant and posts non-zero results to Alertmanager, modeled on `mimir-rule-completeness`. No workflow file is changed in this PR because the current token lacks the workflow scope.

## Regression proof

- Offline fake-Mimir test: the pre-#2924 selector fails, the `exported_namespace` selector passes, and an absent family is skipped.
- Live Mimir, tenant `talos-stpetersburg`, pre-#2924 rule from `d445a3a`: exit 1; all three snapshot selectors using `namespace="home-assistant"` match zero while the family exists.
- Live Mimir, current `origin/main`: `KopiurSnapshotFailed` and `KopiurSnapshotStale` exit 0 with 7/7 selectors matched; the full current `kopiur.yaml` scan exits 0 with 14/14 matched.

## Verification

- `tools/tests/run.sh`: 198 passed, 0 failed.
- `python3 tools/tests/test_mimir_label_contract.py`: passed.

This PR does not modify Kopiur rules or fixtures; the existing merged Kopiur label-contract fixes remain the before/after regression target.