### PR TITLE
fix(mimir): exclude covered StP Velero warning

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_warnings_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_warnings_test.yaml
@@ -1,0 +1,112 @@
+rule_files:
+  - ../velero-integrity.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # This is the observed St Petersburg ownership split: exactly one warning
+  # from the known homeassistant-config hostPath skip, with current Kopiur
+  # coverage in the named repository. The warning is intentionally quiet here.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-known-skip"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_warnings{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-known-skip"}'
+        values: "1+0x20"
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_expected_source_info{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config",pvc="homeassistant-config",repository="kopiur-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "1+0x20"
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "900+0x20"
+      - series: 'kopiur_expected_repository_info{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
+        values: "1+0x20"
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleLatestBackupHasWarnings
+        exp_alerts: []
+
+  # The warning metric is aggregate. A second hostPath skip on the same
+  # schedule raises the count above the one known, Kopiur-covered warning and
+  # must remain visible.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-two-skips"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_warnings{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-two-skips"}'
+        values: "2+0x20"
+      - series: 'kopiur_leader_is_leader{cluster="talos-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_expected_source_info{cluster="talos-stpetersburg",namespace="home-assistant",policy="homeassistant-config",pvc="homeassistant-config",repository="kopiur-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_snapshotpolicy_last_backup_success{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "1+0x20"
+      - series: 'kopiur_policy_last_backup_success_timestamp_seconds{cluster="talos-stpetersburg",exported_namespace="home-assistant",namespace="kopiur-system",policy="homeassistant-config"}'
+        values: "900+0x20"
+      - series: 'kopiur_expected_repository_info{cluster="talos-stpetersburg",kind="Repository",namespace="home-assistant",name="kopiur-stpetersburg"}'
+        values: "1+0x20"
+      - series: 'kopiur_resource_phase{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg",phase="Ready"}'
+        values: "1+0x20"
+      - series: 'kopiur_repository_consecutive_backend_failures{cluster="talos-stpetersburg",kind="Repository",exported_namespace="home-assistant",namespace="kopiur-system",name="kopiur-stpetersburg"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleLatestBackupHasWarnings
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: velero-system
+              schedule: home-assistant-backup
+              backup: home-assistant-backup-two-skips
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule home-assistant-backup latest Completed backup has warnings
+              description: >-
+                The newest Backup for schedule home-assistant-backup is
+                home-assistant-backup-two-skips and reports status.warnings > 0.
+                Velero uses warnings for soft failures such as skipping a
+                hostPath / local-path volume while still marking the Backup
+                Completed (corp/bhaiya#695), so phase alone is not enough.
+                Inspect the Backup log for "hostPath volume which is not
+                supported" (or other skip reasons), confirm every durable PVC
+                has a Completed PodVolumeBackup for its pod+volume, and do not
+                treat this Backup as a volume restore source until the warning
+                is gone. A later Backup with warnings=0 clears this alert.
+
+  # Same schedule and one warning, but no Kopiur contract: a different
+  # hostPath skip without alternate protection must alert.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-uncovered-skip"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_warnings{cluster="talos-stpetersburg",namespace="velero-system",schedule="home-assistant-backup",backup="home-assistant-backup-uncovered-skip"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleLatestBackupHasWarnings
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: velero-system
+              schedule: home-assistant-backup
+              backup: home-assistant-backup-uncovered-skip
+              severity: critical
+            exp_annotations:
+              summary: Velero schedule home-assistant-backup latest Completed backup has warnings
+              description: >-
+                The newest Backup for schedule home-assistant-backup is
+                home-assistant-backup-uncovered-skip and reports status.warnings
+                > 0. Velero uses warnings for soft failures such as skipping a
+                hostPath / local-path volume while still marking the Backup
+                Completed (corp/bhaiya#695), so phase alone is not enough.
+                Inspect the Backup log for "hostPath volume which is not
+                supported" (or other skip reasons), confirm every durable PVC
+                has a Completed PodVolumeBackup for its pod+volume, and do not
+                treat this Backup as a volume restore source until the warning
+                is gone. A later Backup with warnings=0 clears this alert.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -231,15 +231,130 @@ groups:
       # to the newest Backup per schedule so a later clean run clears the alert;
       # do not match historical warning-bearing objects. Critical: a "Completed"
       # Backup with warnings is the dangerous signal, not a soft FYI.
+      #
+      # St Petersburg's home-assistant-config is an explicit ownership split:
+      # its local-path/hostPath PVC is intentionally not Velero-capturable and
+      # is protected by Kopiur SnapshotPolicy homeassistant-config in the named
+      # repository kopiur-stpetersburg. The exporter exposes only an aggregate
+      # warning count, not a warning reason or volume, so suppress exactly one
+      # warning only while that source, recent successful snapshot, live leader,
+      # and repository health contract all hold. A count above one remains
+      # actionable: it represents the known skip plus another warning on the
+      # same schedule. A different single warning cannot be distinguished from
+      # the known one with this metric contract and must not be hidden by a
+      # broader schedule exclusion.
       - alert: VeleroScheduleLatestBackupHasWarnings
         expr: |
           (
-            max by (cluster, namespace, schedule, backup) (
-              velero_cr_backup_warnings{
-                namespace="velero-system",
-                schedule!=""
-              }
-            ) > 0
+            (
+              max by (cluster, namespace, schedule, backup) (
+                velero_cr_backup_warnings{
+                  namespace="velero-system",
+                  schedule!=""
+                }
+              ) > 0
+            )
+            unless on (cluster, namespace, schedule, backup)
+            (
+              (
+                max by (cluster, namespace, schedule, backup) (
+                  velero_cr_backup_warnings{
+                    cluster="talos-stpetersburg",
+                    namespace="velero-system",
+                    schedule="home-assistant-backup"
+                  }
+                ) == 1
+              )
+              and on (cluster)
+              (
+                kopiur_leader_is_leader{
+                  cluster="talos-stpetersburg"
+                } == 1
+              )
+              and on (cluster)
+              (
+                kopiur_expected_source_info{
+                  cluster="talos-stpetersburg",
+                  namespace="home-assistant",
+                  policy="homeassistant-config",
+                  pvc="homeassistant-config",
+                  repository="kopiur-stpetersburg"
+                }
+                and on (cluster, namespace, policy)
+                (
+                  label_replace(
+                    kopiur_snapshotpolicy_last_backup_success{
+                      cluster="talos-stpetersburg",
+                      exported_namespace="home-assistant",
+                      namespace="kopiur-system",
+                      policy="homeassistant-config"
+                    },
+                    "namespace", "$1", "exported_namespace", "(.+)"
+                  ) == 1
+                )
+                and on (cluster, namespace, policy)
+                (
+                  label_replace(
+                    kopiur_policy_last_backup_success_timestamp_seconds{
+                      cluster="talos-stpetersburg",
+                      exported_namespace="home-assistant",
+                      namespace="kopiur-system",
+                      policy="homeassistant-config"
+                    },
+                    "namespace", "$1", "exported_namespace", "(.+)"
+                  ) > 0
+                  and
+                  time()
+                    - label_replace(
+                        kopiur_policy_last_backup_success_timestamp_seconds{
+                          cluster="talos-stpetersburg",
+                          exported_namespace="home-assistant",
+                          namespace="kopiur-system",
+                          policy="homeassistant-config"
+                        },
+                        "namespace", "$1", "exported_namespace", "(.+)"
+                      ) < 129600
+                )
+              )
+              and on (cluster)
+              (
+                kopiur_expected_repository_info{
+                  cluster="talos-stpetersburg",
+                  kind="Repository",
+                  namespace="home-assistant",
+                  name="kopiur-stpetersburg"
+                }
+                and on (cluster, kind, namespace, name)
+                (
+                  max by (cluster, kind, namespace, name) (
+                    label_replace(
+                      kopiur_resource_phase{
+                        cluster="talos-stpetersburg",
+                        kind="Repository",
+                        namespace="kopiur-system",
+                        exported_namespace="home-assistant",
+                        name="kopiur-stpetersburg",
+                        phase="Ready"
+                      },
+                      "namespace", "$1", "exported_namespace", "(.+)"
+                    )
+                  ) == 1
+                  and on (cluster, kind, namespace, name)
+                  max by (cluster, kind, namespace, name) (
+                    label_replace(
+                      kopiur_repository_consecutive_backend_failures{
+                        cluster="talos-stpetersburg",
+                        kind="Repository",
+                        namespace="kopiur-system",
+                        exported_namespace="home-assistant",
+                        name="kopiur-stpetersburg"
+                      },
+                      "namespace", "$1", "exported_namespace", "(.+)"
+                    )
+                  ) == 0
+                )
+              )
+            )
           )
           and on (cluster, namespace, schedule, backup)
           (


### PR DESCRIPTION
## What

VeleroScheduleLatestBackupHasWarnings remains actionable for real warning-bearing Backups, but suppresses the one intentional St Petersburg warning when its alternate protection contract is healthy.

The St Petersburg home-assistant-backup warning is the expected hostPath/local-path skip for homeassistant-config. The source is explicitly covered by Kopiur SnapshotPolicy homeassistant-config in repository kopiur-stpetersburg. The exception requires the exact source inventory, a live leader, a recent successful snapshot, an expected named repository, Ready repository state, and zero backend failures.

The exception is count-bounded: exactly one warning is suppressed. A second warning on the same schedule remains alertable. The exported Velero warning metric has no warning-reason or volume label; the rule comments document that a different single warning cannot be distinguished until that metric contract changes.

## Live evidence

At 2026-09-09T12:04:57Z, Mimir matched the rule in all three tenants:
- Ottawa media-config-backup: one warning, Completed, 979/979 items; Kometa config was skipped because the completed pod was no longer running (pkg/podvolume/backupper.go:470), so the latest Backup has no Kometa PVB.
- Robbinsdale media-config-backup: one warning, Completed, 713/713 items; the same Kometa config lifecycle skip (pkg/podvolume/backupper.go:470), with no Kometa PVB.
- St Petersburg home-assistant-backup: one warning, Completed, 76/76 items; home-assistant/config is an unsupported hostPath (pkg/podvolume/backupper.go:347). Kopiur source and repository health were live and healthy.

## Tests

- Pinned Prometheus 3.14.0 rule parsing passed.
- Full fixture runner passed: 18 fixtures, 15 rule files.
- The new fixture proves:
  - the one known Kopiur-covered warning is quiet;
  - a second warning on the same schedule fires;
  - a one-warning case without the Kopiur contract fires.
- tools/check.sh passed: render OK for talos-ottawa, talos-robbinsdale, and talos-stpetersburg.

No live resources were changed. The untracked kopia-0.18.2-velero-patch/ directory is intentionally not included.