### PR TITLE
fix(kopiur): project credentials for St Petersburg restore proof

### DIFF
--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore.yaml
@@ -13,6 +13,10 @@ spec:
     kind: Repository
     name: kopiur-stpetersburg
     namespace: home-assistant
+  # The proof runs in a fresh namespace; let Kopiur project the repository's
+  # password and backend credentials into the mover namespace.
+  credentialProjection:
+    enabled: true
   target:
     pvc:
       name: homeassistant-config-restore


### PR DESCRIPTION
## Summary

The St Petersburg Kopiur restore proof runs in a fresh namespace, but its Repository credential Secrets live in `home-assistant`. Enable Kopiur credential projection so the operator can create the owner-managed, namespace-local projection for the Restore mover.

The live HelmRelease already has `features.credentialProjection.enabled: true`; no Secret values are added or copied by this change.

## Verification

- `tools/check.sh talos-stpetersburg`
- `git diff --check`