### PR TITLE
fix(kopiur): authorize St Petersburg restore projection

### DIFF
--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -30,8 +30,8 @@ diagram in the [README](../../README.md#architecture).
 |---|---:|---:|---:|
 | `ottawa` | 4 | 62 | 126 |
 | `robbinsdale` | 3 | 43 | 87 |
-| `stpetersburg` | 3 | 41 | 84 |
-| **total** | **10** | **146** | **297** |
+| `stpetersburg` | 3 | 42 | 85 |
+| **total** | **10** | **147** | **298** |
 
 ## Ottawa — `talos-ottawa`
 
@@ -312,6 +312,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | Application workloads | `home-assistant` | `home-assistant` |
 | Application workloads | `homer-operator` | `homer-operator-install` |
 | Application workloads | `kopiur` | `home-assistant-kopiur` → ns `home-assistant`, `kopiur` → ns `kopiur-system` |
+| Application workloads | `kopiur-restore-projection` | `kopiur-restore-projection` → ns `kopiur-restore-proof-20260908-ha` |
 | Application workloads | `kopiur-restore-proof` | `kopiur-restore-proof` → ns `kopiur-restore-proof-20260908-ha` |
 
 Pointers whose objects land outside their directory's namespace — use the right-hand column with `kubectl -n`:
@@ -321,6 +322,7 @@ Pointers whose objects land outside their directory's namespace — use the righ
 | `actions-runner-controller-runners` | `arc-systems` | `arc-runners` |
 | `home-assistant-kopiur` | `kopiur` | `home-assistant` |
 | `kopiur` | `kopiur` | `kopiur-system` |
+| `kopiur-restore-projection` | `kopiur-restore-projection` | `kopiur-restore-proof-20260908-ha` |
 | `kopiur-restore-proof` | `kopiur-restore-proof` | `kopiur-restore-proof-20260908-ha` |
 | `rdma-shared-dp` | `rdma-shared-dp` | `rdma-system` |
 | `tinyauth-egress` | `tinyauth-egress` | `tinyauth` |

--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore.yaml
@@ -10,11 +10,10 @@ spec:
       name: homeassistant-config-20260908034331
       namespace: home-assistant
   repository:
-    kind: Repository
-    name: kopiur-stpetersburg
-    namespace: home-assistant
-  # The proof runs in a fresh namespace; let Kopiur project the repository's
-  # password and backend credentials into the mover namespace.
+    kind: ClusterRepository
+    name: kopiur-stpetersburg-restore-readonly
+  # The proof runs in a fresh namespace; the read-only ClusterRepository view
+  # explicitly permits Kopiur to project the writer repository's credentials.
   credentialProjection:
     enabled: true
   target:

--- a/kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection/clusterrepository.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection/clusterrepository.yaml
@@ -1,0 +1,44 @@
+---
+# Read-only cluster-scoped view of the St Petersburg Home Assistant repository.
+# The writer remains the namespaced Repository in home-assistant; this view
+# exists so the isolated restore namespace can use Kopiur's owner-approved
+# credential projection path.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: kopiur-stpetersburg-restore-readonly
+spec:
+  allowedNamespaces:
+    list:
+      - kopiur-restore-proof-20260908-ha
+  credentialProjection:
+    allowed: true
+  backend:
+    s3:
+      bucket: kopiur-stpetersburg
+      prefix: home-assistant/config/
+      endpoint: garage-gateway.garage.svc.cluster.local:3900
+      region: garage
+      tls:
+        disableTls: true
+      auth:
+        secretRef:
+          name: kopiur-stpetersburg-s3
+          namespace: home-assistant
+  encryption:
+    passwordSecretRef:
+      name: kopiur-stpetersburg-kopia-password
+      namespace: home-assistant
+      key: KOPIA_PASSWORD
+  mode: ReadOnly
+  create:
+    enabled: false
+  catalog:
+    adoption: Ignore
+    periodicRefresh: false
+    retain:
+      perIdentity: 50
+      maxAgeDays: 30
+  maintenance:
+    enabled: false
+  onNamespaceDelete: Orphan

--- a/kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrepository.yaml

--- a/kubernetes/apps/stpetersburg/kopiur-restore-projection/kopiur-restore-projection.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur-restore-projection/kopiur-restore-projection.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-restore-projection
+  namespace: flux-system
+spec:
+  targetNamespace: kopiur-restore-proof-20260908-ha
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kopiur-restore-projection
+      app.kubernetes.io/part-of: kopiur
+  dependsOn:
+    - name: kopiur
+    - name: home-assistant-kopiur
+    - name: kopiur-restore-proof
+  path: ./kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubernetes-manifests
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/stpetersburg/kopiur-restore-projection/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur-restore-projection/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kopiur-restore-projection.yaml

--- a/kubernetes/apps/stpetersburg/kustomization.yaml
+++ b/kubernetes/apps/stpetersburg/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./home-assistant
   - ./kopiur
   - ./kopiur-restore-proof
+  - ./kopiur-restore-projection
   - ./homer-operator
   - ./kro-system
   - ./kube-system


### PR DESCRIPTION
The St Petersburg restore-proof Restore is in a fresh namespace and needs Kopiur to project the existing Home Assistant repository credentials into its mover namespace.

PR #2930 enabled the Restore-side opt-in and passed CI, but the live Restore remains Pending because the deployed controller requires the owner allow gate for cross-namespace projection. A namespaced Repository has no owner-allow field. The working Ottawa proof uses the supported ClusterRepository shape.

This change adds a read-only ClusterRepository view of the same St Petersburg backend, explicitly allows only the restore-proof namespace, and points the Restore at that view. The existing namespaced Repository remains the only writer; no credential values are added or copied.

Verification:
- `tools/check.sh talos-stpetersburg`
- `git diff --check`
