### PR TITLE
fix(kopiur): break restore projection dependency cycle

### DIFF
--- a/kubernetes/apps/stpetersburg/kopiur-restore-projection/kopiur-restore-projection.yaml
+++ b/kubernetes/apps/stpetersburg/kopiur-restore-projection/kopiur-restore-projection.yaml
@@ -13,7 +13,6 @@ spec:
   dependsOn:
     - name: kopiur
     - name: home-assistant-kopiur
-    - name: kopiur-restore-proof
   path: ./kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection
   prune: true
   sourceRef:


### PR DESCRIPTION
PR #2933 added the supported St Petersburg ClusterRepository projection view, but its first deployment exposed a dependency cycle: the Restore Kustomization dry-runs the ClusterRepository reference before that object exists, while the projection Kustomization waited on the Restore Kustomization.

Remove the unnecessary restore-proof dependency. The projection now depends only on Kopiur and the source repository; the proof can reconcile after the cluster-scoped view is present.

Verification:
- `KMAN_CHECK_TIMEOUT=300 ./tools/check.sh talos-stpetersburg`
- `git diff --check`
