### PR TITLE
fix(monitoring): query all Mimir rule groups

### DIFF
--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/deployment.yaml
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           command: [python3, /scripts/rule_completeness.py]
           env:
             - name: MIMIR_RULES_URL
-              value: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus/api/v1/rules?type=alert
+              value: http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus/api/v1/rules
             - name: ALERTMANAGER_URL
               value: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093/api/v2/alerts
             - name: CHECKER_CLUSTER

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/rule_completeness.py
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/rule_completeness.py
@@ -27,7 +27,7 @@ DEFAULT_TENANTS = (
 DEFAULT_EXPECTED_PATH = "/scripts/expected-groups.tsv"
 DEFAULT_MIMIR_RULES_URL = (
     "http://mimir-gateway.mimir.svc.cluster.local:8080"
-    "/prometheus/api/v1/rules?type=alert"
+    "/prometheus/api/v1/rules"
 )
 DEFAULT_ALERTMANAGER_URL = (
     "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093"


### PR DESCRIPTION
## Summary

The Mimir rule completeness checker currently queries:

`/prometheus/api/v1/rules?type=alert`

but compares that filtered response with an inventory of all declared ruler groups. The filter returns 48 groups while the inventory contains 50, so it creates persistent false `MimirRuleGroupIncomplete` alerts.

This changes both the Deployment's `MIMIR_RULES_URL` and the Python fallback URL to the unfiltered `/prometheus/api/v1/rules` endpoint.

The two groups that appeared to be missing are recording-only groups:

- `kopiur-backups/kopiur-backups.inventory`
- `monitoring/packet-loss.rules`

The expected inventory must not be trimmed to 48: doing that would hide genuine omissions of recording rules. The checker should compare the complete live ruler group set against the complete GitOps inventory.

## Verification

- Replayed the existing `km#2809` completeness test successfully.
- Python byte-compilation succeeded.
- No production resources were changed.

## Scope

This PR changes only the endpoint filtering; it does not alter alert semantics, the expected inventory, or the grace/TTL behavior.