### PR TITLE
test(kopiur): add St Petersburg content restore proof

### DIFF
--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: kopiur-restore-proof-20260908-ha
 resources:
   - namespace.yaml
   - restore.yaml
+  - restore-content-r2.yaml

--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore-content-r2.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore-content-r2.yaml
@@ -1,0 +1,50 @@
+---
+# Content-only retry of the terminal first proof. The first Restore reached
+# the repository and began writing real HA files, then failed only because its
+# inherited non-root identity could not chown the original owners. This retry
+# intentionally proves file data, not ownership or permission metadata.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: homeassistant-config-restore-content-r2
+  namespace: kopiur-restore-proof-20260908-ha
+spec:
+  source:
+    snapshotRef:
+      name: homeassistant-config-20260908034331
+      namespace: home-assistant
+  repository:
+    kind: ClusterRepository
+    name: kopiur-stpetersburg-restore-readonly
+  credentialProjection:
+    enabled: true
+  target:
+    pvc:
+      name: homeassistant-config-restore-content-r2
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+      storageClassName: local-path
+  mover:
+    # Reuse the recorded non-root identity so the fresh PVC is writable via
+    # fsGroup. The options below deliberately avoid chown/chmod instead of
+    # widening this content check to a privileged ownership restore.
+    inheritSecurityContextFrom:
+      snapshot: {}
+  options:
+    enableFileDeletion: false
+    ignoreErrors: false
+    ignorePermissionErrors: false
+    parallel: 1
+    skipExisting: false
+    skipOwners: true
+    skipPermissions: true
+    skipTimes: false
+    writeFilesAtomically: true
+  policy:
+    onMissingSnapshot: Fail
+    waitTimeout: 5m
+  failurePolicy:
+    backoffLimit: 0
+    activeDeadlineSeconds: 1800
+    podStartupDeadlineSeconds: 300

--- a/kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection/clusterrepository.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-stpetersburg-restore-projection/clusterrepository.yaml
@@ -39,6 +39,26 @@ spec:
     retain:
       perIdentity: 50
       maxAgeDays: 30
+  # Restore movers use this read-only view. Keep the content-proof retry away
+  # from spark-0, whose live memory headroom is below 1%, and give it a bounded
+  # footprint so a capacity problem is distinguishable from a restore error.
+  moverDefaults:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                    - spark-0
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
   maintenance:
     enabled: false
   onNamespaceDelete: Orphan


### PR DESCRIPTION
## Summary
- add a distinct GitOps Restore retry for the terminal Home Assistant proof
- skip ownership and permission metadata restoration so the unprivileged mover proves file data
- constrain movers from the St Petersburg read-only repository view away from `spark-0` and bound their resources

The existing failed Restore is intentionally preserved. This retry targets the same pinned Snapshot and a new empty PVC. A successful `Completed` result proves repository access, snapshot resolution, enumeration, and file-data restoration; it does not prove original UID/GID or mode restoration. That limitation remains a separate recovery-path finding.

## Verification
- `git diff --check` passed
- `tools/check.sh sp` was attempted twice; both attempts hit the repository-documented Flate/Prometheus render timeout (`mimir-promql`, exits 124) before manifest rendering. The second attempt used `KMAN_CHECK_TIMEOUT=300` and was stopped after the same wedge persisted.