### PR TITLE
test(kopiur): skip restore timestamps in content proof

### DIFF
--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - restore.yaml
   - restore-content-r2.yaml
+  - restore-content-r3.yaml

--- a/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore-content-r3.yaml
+++ b/kubernetes/apps/base/kopiur/kopiur-restore-proof/restore-content-r3.yaml
@@ -1,0 +1,46 @@
+---
+# The r2 content proof restored the files but failed while applying the root
+# directory mtime. This retry skips all ownership, permission, and timestamp
+# metadata so a successful run is an explicit file-data proof only.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: homeassistant-config-restore-content-r3
+  namespace: kopiur-restore-proof-20260908-ha
+spec:
+  source:
+    snapshotRef:
+      name: homeassistant-config-20260908034331
+      namespace: home-assistant
+  repository:
+    kind: ClusterRepository
+    name: kopiur-stpetersburg-restore-readonly
+  credentialProjection:
+    enabled: true
+  target:
+    pvc:
+      name: homeassistant-config-restore-content-r3
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+      storageClassName: local-path
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+  options:
+    enableFileDeletion: false
+    ignoreErrors: false
+    ignorePermissionErrors: false
+    parallel: 1
+    skipExisting: false
+    skipOwners: true
+    skipPermissions: true
+    skipTimes: true
+    writeFilesAtomically: true
+  policy:
+    onMissingSnapshot: Fail
+    waitTimeout: 5m
+  failurePolicy:
+    backoffLimit: 0
+    activeDeadlineSeconds: 1800
+    podStartupDeadlineSeconds: 300


### PR DESCRIPTION
## Summary
- add a distinct r3 Restore retry for the terminal Home Assistant content proof
- skip timestamps in addition to ownership and permissions
- keep the same pinned Snapshot, projected credentials, non-spark-0 mover placement, and bounded resources from #2938

The r2 mover ran on `spark-1`, resolved the repository snapshot, and restored file data, but terminated on `chtimes /restore: operation not permitted`. This retry treats metadata as outside the content proof while retaining `ignorePermissionErrors=false` and `ignoreErrors=false`.

A successful r3 proves file-data restoration only. It does not prove original ownership, permissions, or timestamps; the r1/r2 failures show that an actual ownership-preserving recovery needs an explicitly privileged/root mover.

## Verification
- `git diff --check` passed
- targeted St Petersburg Flate render passed on the previous manifest and this change is limited to the same Kustomization/Restore path