### PR TITLE
alert: cover NVMe hwmon sensor temperatures

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/smartctl.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/smartctl.yaml
@@ -1,6 +1,6 @@
 # Ported from clusters/*/apps/smartctl-exporter/config/prometheusrule.yaml.
-# Loaded into every tenant; inert where smartctl_* metrics are absent
-# (e.g. stpetersburg has no smartctl-exporter).
+# Loaded into every tenant. The smartctl_* rules are inert where the exporter
+# is absent; the interim hwmon rules below use node-exporter instead.
 namespace: smartctl
 groups:
   - name: smartctl-exporter.rules
@@ -12,6 +12,69 @@ groups:
         annotations:
           summary: >-
             Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has a temperature higher than 65°C
+        labels:
+          severity: critical
+
+      # Interim per-sensor path for the smartctl-exporter gap tracked in #2936.
+      # node-exporter labels the NVMe hwmon sensors explicitly: temp1 is the
+      # composite, while temp2/temp3 are Sensor 1/Sensor 2. The temp_max and
+      # temp_crit series on temp1 carry each device's own reported component
+      # limits, so these comparisons do not use one fleet-wide temperature.
+      # This also supplies thermal coverage in St Petersburg, where
+      # smartctl-exporter is not deployed. Remove this path when the
+      # smartctl-exporter gains nested NVMe sensor support (upstream #303/#304).
+      - alert: SmartDeviceNVMeSensorHigh
+        expr: |-
+          (
+            node_hwmon_temp_celsius{chip=~"nvme_.*",sensor!="temp1"}
+            >= on (cluster, instance, chip) group_left
+              node_hwmon_temp_max_celsius{chip=~"nvme_.*",sensor="temp1"}
+          )
+          * on (cluster, instance, chip, sensor) group_left(label)
+            node_hwmon_sensor_label{
+              chip=~"nvme_.*",
+              sensor!="temp1",
+              label=~"Sensor .*",
+            }
+        for: 5m
+        annotations:
+          summary: >-
+            NVMe {{ $labels.chip }} on {{ $labels.instance }} has
+            {{ $labels.label }} at or above its device-reported warning temperature
+          description: >-
+            The {{ $labels.label }} reading for {{ $labels.chip }} is at or above
+            that device's node-exporter hwmon warning/component limit. This is
+            an interim per-sensor alert because smartctl-exporter v0.14.0
+            omits nested NVMe sensors; see manifests issue #2936 and upstream
+            smartctl-exporter issues #303/#304.
+        labels:
+          severity: warning
+
+      - alert: SmartDeviceNVMeSensorCritical
+        expr: |-
+          (
+            node_hwmon_temp_celsius{chip=~"nvme_.*",sensor!="temp1"}
+            >= on (cluster, instance, chip) group_left
+              node_hwmon_temp_crit_celsius{chip=~"nvme_.*",sensor="temp1"}
+          )
+          * on (cluster, instance, chip, sensor) group_left(label)
+            node_hwmon_sensor_label{
+              chip=~"nvme_.*",
+              sensor!="temp1",
+              label=~"Sensor .*",
+            }
+        for: 5m
+        annotations:
+          summary: >-
+            NVMe {{ $labels.chip }} on {{ $labels.instance }} has
+            {{ $labels.label }} at or above its device-reported critical
+            temperature
+          description: >-
+            The {{ $labels.label }} reading for {{ $labels.chip }} is at or above
+            that device's node-exporter hwmon critical/component limit. This
+            is an interim per-sensor alert because smartctl-exporter v0.14.0
+            omits nested NVMe sensors; see manifests issue #2936 and upstream
+            smartctl-exporter issues #303/#304.
         labels:
           severity: critical
 

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/smartctl_hwmon_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/smartctl_hwmon_test.yaml
@@ -1,0 +1,101 @@
+rule_files:
+  - ../smartctl.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      # Shiro's Sensor 1 is above its per-device warning limit but below its
+      # critical limit. It must fire the warning alert only.
+      - series: 'node_hwmon_temp_celsius{cluster="talos-ottawa",chip="nvme_nvme0",instance="192.168.169.116:9100",job="node-exporter",namespace="monitoring",pod="node-shiro",sensor="temp2",service="node-exporter"}'
+        values: "85+0x7 80+0x10"
+      - series: 'node_hwmon_temp_max_celsius{cluster="talos-ottawa",chip="nvme_nvme0",instance="192.168.169.116:9100",job="node-exporter",namespace="monitoring",pod="node-shiro",sensor="temp1",service="node-exporter"}'
+        values: "84+0x20"
+      - series: 'node_hwmon_temp_crit_celsius{cluster="talos-ottawa",chip="nvme_nvme0",instance="192.168.169.116:9100",job="node-exporter",namespace="monitoring",pod="node-shiro",sensor="temp1",service="node-exporter"}'
+        values: "88+0x20"
+      - series: 'node_hwmon_sensor_label{cluster="talos-ottawa",chip="nvme_nvme0",instance="192.168.169.116:9100",job="node-exporter",label="Sensor 1",namespace="monitoring",pod="node-shiro",sensor="temp2",service="node-exporter"}'
+        values: "1+0x20"
+
+      # Stone's Sensor 2 is above its per-device critical limit.
+      - series: 'node_hwmon_temp_celsius{cluster="talos-robbinsdale",chip="nvme_nvme0",instance="192.168.50.82:9100",job="node-exporter",namespace="monitoring",pod="node-stone",sensor="temp3",service="node-exporter"}'
+        values: "86+0x7 80+0x10"
+      - series: 'node_hwmon_temp_max_celsius{cluster="talos-robbinsdale",chip="nvme_nvme0",instance="192.168.50.82:9100",job="node-exporter",namespace="monitoring",pod="node-stone",sensor="temp1",service="node-exporter"}'
+        values: "82+0x20"
+      - series: 'node_hwmon_temp_crit_celsius{cluster="talos-robbinsdale",chip="nvme_nvme0",instance="192.168.50.82:9100",job="node-exporter",namespace="monitoring",pod="node-stone",sensor="temp1",service="node-exporter"}'
+        values: "85+0x20"
+      - series: 'node_hwmon_sensor_label{cluster="talos-robbinsdale",chip="nvme_nvme0",instance="192.168.50.82:9100",job="node-exporter",label="Sensor 2",namespace="monitoring",pod="node-stone",sensor="temp3",service="node-exporter"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: SmartDeviceNVMeSensorHigh
+        exp_alerts: []
+      - eval_time: 6m
+        alertname: SmartDeviceNVMeSensorHigh
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              chip: nvme_nvme0
+              instance: 192.168.169.116:9100
+              job: node-exporter
+              label: Sensor 1
+              namespace: monitoring
+              pod: node-shiro
+              sensor: temp2
+              service: node-exporter
+              severity: warning
+            exp_annotations:
+              summary: NVMe nvme_nvme0 on 192.168.169.116:9100 has Sensor 1 at or above its device-reported warning temperature
+              description: >-
+                The Sensor 1 reading for nvme_nvme0 is at or above that device's
+                node-exporter hwmon warning/component limit. This is an
+                interim per-sensor alert because smartctl-exporter v0.14.0
+                omits nested NVMe sensors; see manifests issue #2936 and
+                upstream smartctl-exporter issues #303/#304.
+          - exp_labels:
+              cluster: talos-robbinsdale
+              chip: nvme_nvme0
+              instance: 192.168.50.82:9100
+              job: node-exporter
+              label: Sensor 2
+              namespace: monitoring
+              pod: node-stone
+              sensor: temp3
+              service: node-exporter
+              severity: warning
+            exp_annotations:
+              summary: NVMe nvme_nvme0 on 192.168.50.82:9100 has Sensor 2 at or above its device-reported warning temperature
+              description: >-
+                The Sensor 2 reading for nvme_nvme0 is at or above that device's
+                node-exporter hwmon warning/component limit. This is an
+                interim per-sensor alert because smartctl-exporter v0.14.0
+                omits nested NVMe sensors; see manifests issue #2936 and
+                upstream smartctl-exporter issues #303/#304.
+      - eval_time: 6m
+        alertname: SmartDeviceNVMeSensorCritical
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-robbinsdale
+              chip: nvme_nvme0
+              instance: 192.168.50.82:9100
+              job: node-exporter
+              label: Sensor 2
+              namespace: monitoring
+              pod: node-stone
+              sensor: temp3
+              service: node-exporter
+              severity: critical
+            exp_annotations:
+              summary: NVMe nvme_nvme0 on 192.168.50.82:9100 has Sensor 2 at or above its device-reported critical temperature
+              description: >-
+                The Sensor 2 reading for nvme_nvme0 is at or above that device's
+                node-exporter hwmon critical/component limit. This is an
+                interim per-sensor alert because smartctl-exporter v0.14.0
+                omits nested NVMe sensors; see manifests issue #2936 and
+                upstream smartctl-exporter issues #303/#304.
+      - eval_time: 8m
+        alertname: SmartDeviceNVMeSensorHigh
+        exp_alerts: []
+      - eval_time: 8m
+        alertname: SmartDeviceNVMeSensorCritical
+        exp_alerts: []


### PR DESCRIPTION
## Summary

- Add interim warning and critical alerts from node-exporter `node_hwmon_temp_celsius` for non-composite NVMe sensors.
- Join `node_hwmon_temp_max_celsius` and `node_hwmon_temp_crit_celsius` from the same `(cluster, instance, chip)` so each drive supplies its own reported limits; no fleet-wide 65/85 C threshold is used.
- Validate the live hwmon mapping: `temp1=Composite`, `temp2=Sensor 1`, and `temp3=Sensor 2` on both Robbinsdale stone and Ottawa shiro.
- Current live data matches the intended true positives: stone Sensor 2 is above its critical limit; shiro Sensor 1 is above its warning limit but below critical.
- This is explicitly interim for manifests issue #2936. smartctl-exporter v0.14.0 drops the nested NVMe sensor array; upstream #303/#304 do not add that support.
- St Petersburg has no smartctl-exporter and zero `smartctl_device_temperature` series. The hwmon alert covers its node-exporter temperature data, but its smartctl health/temperature exporter gap remains tracked in #2936.

The alerts use `for: 5m`; after the rules are loaded, a persistent breach will be pending first and firing after roughly five minutes plus the next evaluation. Existing composite-temperature alerting is unchanged.

## Tests

- `tools/check.sh`
- `tools/check-mimir-promql.sh`
- `tools/check-mimir-rules.sh`
- Promtool fixture `smartctl_hwmon_test.yaml`: warning and critical cases fire after the hold time and both clear when the sensor values fall.

Refs #2936.