### PR TITLE
test(mimir): document ambiguous zero-byte PVBs

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -54,6 +54,29 @@ tests:
                 is covered or that a restore works. Clears when a later Backup
                 has a Completed PVB with matching byte counters.
 
+  # A Completed PVB with explicit 0/0 progress is byte-consistent, so it
+  # clears the missing-volume alert. The metric contract cannot distinguish a
+  # genuinely empty volume from a run that captured nothing; both cases have
+  # this same input shape and neither is content or restore proof.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-backup",backup="zero-byte-backup-latest"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-backup",backup="zero-byte-backup-latest",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-backup",phase="Enabled",paused="false"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="empty-or-uncaptured",pod_uid="pod-uid",volume="home",pod_volume_backup="zero-byte-pvb",backup="zero-byte-backup-latest",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="empty-or-uncaptured",pod_uid="pod-uid",volume="home",pod_volume_backup="zero-byte-pvb",backup="zero-byte-backup-latest",node="asuka"}'
+        values: "0+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",pod_namespace="home",pod_name="empty-or-uncaptured",pod_uid="pod-uid",volume="home",pod_volume_backup="zero-byte-pvb",backup="zero-byte-backup-latest",node="asuka"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleLatestBackupMissingVolumes
+        exp_alerts: []
+
   # A completed PVB with mismatched byte counters is a current target signal,
   # but a later clean attempt for the same pod and volume must clear the old
   # one-shot record.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -397,6 +397,14 @@ groups:
       # captured. Therefore 0/0 suppresses this alert by design, but is not
       # content or restore proof. A future emitter or restore check must add
       # that evidence before a zero-byte target can be called protected.
+      # The two schedule-level guards below only partially reduce this risk:
+      # VeleroScheduleExpectedVolumeDataMissing uses the hand-maintained
+      # volume_data_required=true boolean to require at least one positive PVB,
+      # not an expected per-volume inventory. VeleroScheduleVolumeCoverageRegressed
+      # compares observed PVB counts with a historical baseline and counts a
+      # Failed or 0/0 PVB as present. Neither catches one silent volume loss
+      # when another volume remains positive, nor proves the 0/0 volume's
+      # contents.
       # Covers metadata-only backups from opt-in misses (media-config before
       # #2757), scaled-to-zero apps with orphan PVCs (hermes), and similar
       # green-empty schedules (#703).

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -386,12 +386,17 @@ groups:
             and do not treat this Backup as a volume restore source until the
             warning is gone. A later Backup with warnings=0 clears this alert.
 
-      # A PVB object is not volume-data evidence until it is Completed and its
-      # byte counters agree. Prepared/InProgress/Canceled children can leave a
-      # Completed parent looking green without a usable archive. An empty
-      # volume is valid evidence when both counters are zero; this still does
-      # not establish that every expected PVC was included or that restore
-      # works.
+      # A PVB object is not a completed-volume attempt until it is Completed
+      # and its byte counters agree. Prepared/InProgress/Canceled children can
+      # leave a Completed parent looking green without a usable archive. This
+      # rule intentionally accepts 0/0 as byte-consistent, but that result is
+      # observationally identical here for a genuinely empty volume and for a
+      # run that captured nothing. An expected-volume inventory or PVC size
+      # describes intent/capacity, not source occupancy; a current file/used-
+      # byte observation or prior nonzero PVB is not evidence of what this run
+      # captured. Therefore 0/0 suppresses this alert by design, but is not
+      # content or restore proof. A future emitter or restore check must add
+      # that evidence before a zero-byte target can be called protected.
       # Covers metadata-only backups from opt-in misses (media-config before
       # #2757), scaled-to-zero apps with orphan PVCs (hermes), and similar
       # green-empty schedules (#703).


### PR DESCRIPTION
## Summary

- Document that a `Completed` PodVolumeBackup reporting `bytesDone=0` and `totalBytes=0` is fundamentally ambiguous: the available metrics cannot distinguish a genuinely empty volume from a backup that captured nothing.
- Preserve the existing byte-counter-consistency behavior so legitimate empty volumes do not false-page.
- Add an explicit promtool fixture for the zero-byte case.

The limitation is documented at `kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml:389`: `0/0` suppresses the missing-volume alert by design, but is not content or restore proof. The explicit fixture is at `kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml:57`.

This records the boundary relevant to #2729: “backup completed successfully” and “backup captured nothing” are the same observable state for an empty-looking volume unless backup-time source evidence or an isolated restore/content check exists.

## Coverage-guard audit

Neither `VeleroScheduleExpectedVolumeDataMissing` nor `VeleroScheduleVolumeCoverageRegressed` is a per-volume expected inventory:

- `volume_data_required=true` is a hand-maintained boolean copied from Schedule metadata by kube-state-metrics. `VeleroScheduleExpectedVolumeDataMissing` only requires at least one positive byte-complete PVB in the latest Completed Backup. It catches an all-zero schedule when the marker is present, but it is silent when another volume remains positive, and it does not evaluate a PartiallyFailed parent.
- `VeleroScheduleVolumeCoverageRegressed` compares the observed PVB object count with a historical Completed baseline. It has no expected PVC/PVB identity set and counts Failed and 0/0 PVB objects as present, so it cannot detect a selected volume that remains represented but captured nothing. A changed or stale selection policy can also make the historical baseline misleading.

For the Robbinsdale Kometa ground truth, neither rule would have caught the case: the parent Backup was PartiallyFailed, the media schedule had other positive PVBs, and the failed Kometa PVB still counted toward the observed PVB total. The separate `VeleroPodVolumeBackupFailed` and `VeleroScheduleLastBackupFailed` signals are the ones that identify this failure. The repository's intended-volume-coverage proposal records that the actual policy-evaluated set is not currently exported or derived.

## Verification

- `tools/check.sh ot`
- `git diff --check`

Related to #2729.