### PR TITLE
fix(monitoring): split NAS and JetKVM probes

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/blackbox_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/blackbox_test.yaml
@@ -1,0 +1,48 @@
+rule_files:
+  - ../blackbox.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # ProbeFailed must retain the labels from either split Probe. Keep the
+  # expression unscoped so a failure cannot disappear when a target gets its
+  # own label value.
+  - interval: 1m
+    input_series:
+      - series: 'probe_success{cluster="talos-ottawa",instance="nagato.killinit.internal:445",job="blackbox",namespace="monitoring",service="nodes",target="nas"}'
+        values: "0+0x10"
+      - series: 'probe_success{cluster="talos-ottawa",instance="jetkvm.killinit.internal:80",job="blackbox",namespace="monitoring",service="nodes",target="jetkvm"}'
+        values: "0+0x10"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: ProbeFailed
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: ProbeFailed
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              instance: nagato.killinit.internal:445
+              job: blackbox
+              namespace: monitoring
+              service: nodes
+              target: nas
+              severity: critical
+            exp_annotations:
+              summary: Probe failed for nagato.killinit.internal:445
+              description: >-
+                The blackbox probe targeting nagato.killinit.internal:445 has
+                been failing for 5 minutes.
+          - exp_labels:
+              cluster: talos-ottawa
+              instance: jetkvm.killinit.internal:80
+              job: blackbox
+              namespace: monitoring
+              service: nodes
+              target: jetkvm
+              severity: critical
+            exp_annotations:
+              summary: Probe failed for jetkvm.killinit.internal:80
+              description: >-
+                The blackbox probe targeting jetkvm.killinit.internal:80 has
+                been failing for 5 minutes.

--- a/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-nodes.yaml
+++ b/kubernetes/apps/base/monitoring/blackbox-exporter-ottawa/app/probes-nodes.yaml
@@ -19,7 +19,7 @@ spec:
         service: nodes
         target: kubelet-port
 ---
-# NAS (SMB) + JetKVM
+# NAS (SMB)
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
@@ -33,10 +33,27 @@ spec:
     staticConfig:
       static:
         - nagato.killinit.internal:445
-        - jetkvm.killinit.internal:80
       labels:
         service: nodes
         target: nas
+---
+# JetKVM
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-jetkvm-tcp
+spec:
+  jobName: blackbox
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - jetkvm.killinit.internal:80
+      labels:
+        service: nodes
+        target: jetkvm
 ---
 # ICMP reachability for nodes.
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
## Summary

Split the Ottawa TCP probes so:

- `nagato.killinit.internal:445` remains `service="nodes", target="nas"`
- `jetkvm.killinit.internal:80` is emitted by `app-jetkvm-tcp` as `service="nodes", target="jetkvm"`

This prevents a JetKVM outage from being reported as a NAS outage.

## Consumer audit

Before changing the label, I checked the repository consumers:

- The combined Probe was the only exact `target="nas"` producer/consumer path.
- Grafana blackbox dashboards use generic target variables and do not select `target="nas"`.
- Gatus has independent Nagato and JetKVM TCP endpoints; it does not consume the Prometheus target label.
- `ProbeFailed` remains exactly `probe_success == 0`, unscoped, with its existing five-minute hold.
- The packet-loss recording rule is generic; Garage and Zot alerts use their own service/target selectors.

No commissioned-or-retired decision is included.

## Validation

- `tools/check.sh ot` → `✓ render OK: talos-ottawa`
- The Mimir fixture runner passed all 21 fixtures and 18 rule files.
- The new fixture feeds failing series for both labels and asserts no alert at 4m and `ProbeFailed` for both exact target labels at 5m.
- `git diff --check` passes.