### PR TITLE
fix(mimir): exclude failed Velero PVBs from coverage counts

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -390,13 +390,15 @@ tests:
               summary: Velero schedule bhaiya-backup volume coverage regressed
               description: >-
                 The newest Backup bhaiya-backup-current for schedule
-                bhaiya-backup has fewer PodVolumeBackups than its previous
-                Completed baseline. Any lower PVB count is material because
-                each PVB represents one selected volume. This remains a
-                coverage regression even when Kubernetes item counts or the
-                parent Backup phase look normal. A warning-bearing Completed
-                Backup can still supply this count baseline; investigate its
-                warning separately. If no previous Completed baseline exists,
+                bhaiya-backup has fewer Completed PodVolumeBackups than its
+                previous Completed baseline. Any lower completed-PVB count is
+                material because a Failed PVB is not coverage. A Completed
+                0/0 PVB remains in the count because its bytes are ambiguous.
+                This remains a coverage regression even when Kubernetes item
+                counts or the parent Backup phase look normal. A
+                warning-bearing Completed Backup can still supply this count
+                baseline; investigate its warning separately. If no previous
+                Completed baseline exists,
                 this alert is intentionally silent: that means no comparable
                 baseline, not proof of zero-volume health. Schedules that
                 never produce a successful nonzero-volume baseline require the
@@ -420,13 +422,15 @@ tests:
               summary: Velero schedule home-assistant-backup volume coverage regressed
               description: >-
                 The newest Backup home-assistant-backup-current for schedule
-                home-assistant-backup has fewer PodVolumeBackups than its
-                previous Completed baseline. Any lower PVB count is material
-                because each PVB represents one selected volume. This remains
-                a coverage regression even when Kubernetes item counts or the
-                parent Backup phase look normal. A warning-bearing Completed
-                Backup can still supply this count baseline; investigate its
-                warning separately. If no previous Completed baseline exists,
+                home-assistant-backup has fewer Completed PodVolumeBackups than
+                its previous Completed baseline. Any lower completed-PVB count
+                is material because a Failed PVB is not coverage. A Completed
+                0/0 PVB remains in the count because its bytes are ambiguous.
+                This remains a coverage regression even when Kubernetes item
+                counts or the parent Backup phase look normal. A warning-
+                bearing Completed Backup can still supply this count baseline;
+                investigate its warning separately. If no previous Completed
+                baseline exists,
                 this alert is intentionally silent: that means no comparable
                 baseline, not proof of zero-volume health. Schedules that
                 never produce a successful nonzero-volume baseline require the
@@ -562,7 +566,9 @@ tests:
         values: "1+0x20"
       - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="expected-regressed",backup="expected-regressed-current",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-regressed-previous",pod_volume_backup="expected-regressed-pvb",node="asuka",phase="Prepared"}'
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-regressed-previous",pod_volume_backup="expected-regressed-pvb",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="expected-regressed-current",pod_volume_backup="expected-regressed-pvb",node="asuka",phase="Failed"}'
         values: "1+0x20"
     alert_rule_test:
       - eval_time: 15m
@@ -578,13 +584,15 @@ tests:
               summary: Velero schedule expected-regressed volume coverage regressed
               description: >-
                 The newest Backup expected-regressed-current for schedule
-                expected-regressed has fewer PodVolumeBackups than its previous
-                Completed baseline. Any lower PVB count is material because
-                each PVB represents one selected volume. This remains a
-                coverage regression even when Kubernetes item counts or the
-                parent Backup phase look normal. A warning-bearing Completed
-                Backup can still supply this count baseline; investigate its
-                warning separately. If no previous Completed baseline exists,
+                expected-regressed has fewer Completed PodVolumeBackups than
+                its previous Completed baseline. Any lower completed-PVB count
+                is material because a Failed PVB is not coverage. A Completed
+                0/0 PVB remains in the count because its bytes are ambiguous.
+                This remains a coverage regression even when Kubernetes item
+                counts or the parent Backup phase look normal. A warning-
+                bearing Completed Backup can still supply this count baseline;
+                investigate its warning separately. If no previous Completed
+                baseline exists,
                 this alert is intentionally silent: that means no comparable
                 baseline, not proof of zero-volume health. Schedules that
                 never produce a successful nonzero-volume baseline require the
@@ -600,4 +608,38 @@ tests:
                 timestamp to determine when the apparent regression began.
       - eval_time: 15m
         alertname: VeleroScheduleExpectedVolumeDataMissing
+        exp_alerts: []
+
+  # A Completed 0/0 PVB remains in the observed coverage count because the
+  # metrics cannot distinguish an empty source from a run that captured
+  # nothing. This is the other direction of the Failed-PVB regression test
+  # above: replacing a positive Completed PVB with a Completed 0/0 PVB must
+  # not create a count regression.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_schedule_info{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-count",phase="Enabled",paused="false"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-count",backup="zero-byte-count-previous"}'
+        values: "100+0x20"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-count",backup="zero-byte-count-current"}'
+        values: "200+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-count",backup="zero-byte-count-previous",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="zero-byte-count",backup="zero-byte-count-current",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="zero-byte-count-previous",pod_volume_backup="zero-byte-count-previous-pvb",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="zero-byte-count-previous",pod_volume_backup="zero-byte-count-previous-pvb",node="asuka"}'
+        values: "8192+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="zero-byte-count-previous",pod_volume_backup="zero-byte-count-previous-pvb",node="asuka"}'
+        values: "8192+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="zero-byte-count-current",pod_volume_backup="zero-byte-count-current-pvb",node="asuka",phase="Completed"}'
+        values: "1+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_done{cluster="talos-ottawa",namespace="velero-system",backup="zero-byte-count-current",pod_volume_backup="zero-byte-count-current-pvb",node="asuka"}'
+        values: "0+0x20"
+      - series: 'velero_cr_podvolumebackup_bytes_total{cluster="talos-ottawa",namespace="velero-system",backup="zero-byte-count-current",pod_volume_backup="zero-byte-count-current-pvb",node="asuka"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleVolumeCoverageRegressed
         exp_alerts: []

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -401,10 +401,10 @@ groups:
       # VeleroScheduleExpectedVolumeDataMissing uses the hand-maintained
       # volume_data_required=true boolean to require at least one positive PVB,
       # not an expected per-volume inventory. VeleroScheduleVolumeCoverageRegressed
-      # compares observed PVB counts with a historical baseline and counts a
-      # Failed or 0/0 PVB as present. Neither catches one silent volume loss
-      # when another volume remains positive, nor proves the 0/0 volume's
-      # contents.
+      # compares Completed-PVB counts with a historical baseline: it excludes
+      # Failed PVBs, but must count a Completed 0/0 PVB as present because its
+      # bytes are ambiguous. Neither identifies which expected volume is
+      # missing, nor proves the 0/0 volume's contents.
       # Covers metadata-only backups from opt-in misses (media-config before
       # #2757), scaled-to-zero apps with orphan PVCs (hermes), and similar
       # green-empty schedules (#703).
@@ -539,15 +539,18 @@ groups:
             )
           )
 
-      # Count each PVB object once, regardless of phase. A Prepared PVB is
-      # still evidence that the Backup selected one volume; the separate
-      # stalled-PVB alert owns whether that selected volume makes progress.
+      # Count each Completed PVB object once. A Failed PVB is unambiguous
+      # non-coverage and must not preserve the prior count. A Completed 0/0
+      # PVB remains counted deliberately: its bytes are ambiguous and can
+      # represent either a genuinely empty volume or a capture that produced
+      # nothing.
       - record: velero_backup_pod_volume_backup_count
         expr: |
           count by (cluster, namespace, backup) (
             max by (cluster, namespace, pod_volume_backup, backup) (
               velero_cr_podvolumebackup_info{
-                namespace="velero-system"
+                namespace="velero-system",
+                phase="Completed"
               }
             )
           )
@@ -618,12 +621,14 @@ groups:
           summary: Velero schedule {{ $labels.schedule }} volume coverage regressed
           description: >-
             The newest Backup {{ $labels.backup }} for schedule
-            {{ $labels.schedule }} has fewer PodVolumeBackups than its previous
-            Completed baseline. Any lower PVB count is material because each
-            PVB represents one selected volume. This remains a coverage
-            regression even when Kubernetes item counts or the parent Backup
-            phase look normal. A warning-bearing Completed Backup can still
-            supply this count baseline; investigate its warning separately.
+            {{ $labels.schedule }} has fewer Completed PodVolumeBackups than
+            its previous Completed baseline. Any lower completed-PVB count is
+            material because a Failed PVB is not coverage. A Completed 0/0 PVB
+            remains in the count because its bytes are ambiguous. This remains
+            a coverage regression even when Kubernetes item counts or the
+            parent Backup phase look normal. A warning-bearing Completed
+            Backup can still supply this count baseline; investigate its
+            warning separately.
             If no previous Completed baseline exists, this alert is
             intentionally silent: that means no comparable baseline, not
             proof of zero-volume health. Schedules that never produce a


### PR DESCRIPTION
## Summary

`velero_backup_pod_volume_backup_count` now counts only `phase="Completed"` PodVolumeBackups.

A Failed PVB is unambiguous non-coverage, so retaining it in the observed count under-reported coverage regressions. A Completed PVB with `bytesDone=0` and `totalBytes=0` remains counted: the available metrics cannot distinguish a genuinely empty volume from a run that captured nothing.

The limitation is documented at `kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml:389`. The explicit zero-byte fixture is at `kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml:57`.

## Tests

- The regression fixture proves a Completed PVB replaced by a Failed PVB lowers the count and fires `VeleroScheduleVolumeCoverageRegressed`.
- The explicit zero-byte fixture at `velero-integrity_test.yaml:57` proves a Completed 0/0 PVB remains byte-consistent for the existing missing-volume rule.
- The new zero-byte count fixture proves replacing a positive Completed PVB with a Completed 0/0 PVB does not lower the coverage count or fire the regression alert.
- `KMAN_CHECK_TIMEOUT=300 tools/check.sh ot` passes.

## Live audit and incident ground truth

- The hand-maintained `volume_data_required` schedule marker matches the Git-managed live schedules: five Ottawa schedules and two Robbinsdale schedules are marked; St. Petersburg Home Assistant is intentionally unmarked because its local-path/hostPath volume is not Velero-capturable. Dynamic Bhaiya workspace schedules are covered by separate rules.
- This fix would have caught the Kometa case. The old all-phase count saw 23 Completed + 1 Failed PVB (24) before and 21 Completed + 2 Failed + 1 Canceled (24) after. The Completed-only count drops from 23 to 21 and fires the coverage-regression alert.
- No per-volume expected inventory exists in these rules; `VeleroScheduleExpectedVolumeDataMissing` is a hand-maintained schedule-level boolean, and `VeleroScheduleVolumeCoverageRegressed` is a historical observed-count check. Neither can prove the contents of a Completed 0/0 PVB.

Related: #2729