### PR TITLE
feat(monitoring): make alert stability output triage-safe

### DIFF
--- a/docs/reference/mimir-alert-stability.md
+++ b/docs/reference/mimir-alert-stability.md
@@ -5,14 +5,22 @@ alert rules whose condition churns without surviving its `for` duration. It is
 not a `PrometheusRule`, does not emit an Alertmanager signal, is not deployed
 as a Kubernetes workload, and does not make findings fail CI. Exit status `2`
 means the live sweep was incomplete; findings still exit `0`. A human must
-interpret the output before changing a rule.
+interpret every candidate before changing a rule.
+
+The default output is deliberately candidate-oriented. It filters out
+resolution-level one-sample activity and leaves edge-censored observations in
+the inconclusive bucket. Use `--all` when the raw observations or evaluator
+state details are needed; the filter hides noise from the normal report, not
+from the diagnostic.
 
 For every native alert rule and tenant, it evaluates the complete expression
 through Mimir's `query_range` API. It applies the rule labels to the vector
 result and groups samples by the resulting alert output labels, rather than by
 each source metric label or response item. That is important for Flux:
 `revision` and `reason` can change while `(cluster, namespace, name, path)`
-remains the same logical Kustomization.
+remains the same logical Kustomization. Flux-escaped `$$` sequences in native
+rule expressions are reduced to their deployed literal `$` form before the
+live query, so the diagnostic evaluates the expression Mimir actually runs.
 
 The report contains these measurements for a candidate instance:
 
@@ -26,19 +34,52 @@ The report contains these measurements for a candidate instance:
   evaluation. `duration_censored=true` means an active run touches the start or
   end of the range and may continue outside it.
 
-An instance is reported as `high-churn, never-sustained` when it has at least
-two active runs, a positive `for`, a ratio below one, and no edge-censored run.
-The same evidence with an edge-censored run is reported as
-`high-churn, range-censored`; extend the lookback before calling it
-never-sustained. A quiet rule and one new condition that has not yet reached
-its hold are not findings.
+The raw observation is `high-churn, never-sustained` when it has at least two
+active runs, a positive `for`, a ratio below one, and no edge-censored run. The
+same evidence with an edge-censored run is `high-churn, range-censored`; extend
+the lookback before calling it never-sustained. A quiet rule and one new
+condition that has not yet reached its hold are not observations.
+
+## Candidate output and triage
+
+The default minimum active-duration floor is one complete sample step. With a
+one-minute step, a one-sample run has `max_active=0s`; when it is part of a
+raw churn observation it is classified as `suppressed-short-activity`. A
+single new run is also not a candidate because there is not yet enough
+activity to establish churn. Two adjacent active samples span one minute and
+can be a candidate. Override the floor with `--min-active-duration`, or use
+`--all` to print every raw high-churn observation regardless of the floor.
+The summary always reports the counts for `candidates`,
+`suppressed_short_activity`, and `inconclusive_range_censored`.
+
+Default output categories have deliberately non-alerting names:
+
+- `candidate` means sustained activity was observed, but it fell short of the
+  configured `for` duration. It is a question for human triage, not a defect
+  verdict and not permission to retune the rule.
+- `suppressed-short-activity` means the raw churn evidence did not clear the
+  minimum duration floor. It is available in `--all` output and is not a rule
+  finding.
+- `inconclusive-range-censored` means the active run touched a query-range
+  edge. Extend the sample before deciding anything.
+- `state-mismatch` means Mimir reported a pending or firing alert while the
+  full expression was currently inactive. This is evaluator/state evidence,
+  not proof that the rule is unreachable.
+
+The KubeletDown fixture makes the intended discrimination executable:
+`up{job="kubelet"} == 0` active for three minutes against `for: 15m` is a
+`candidate` with ratio `0.2`, while separated one-sample spikes are
+`suppressed-short-activity` with `max_active=0s`. The live Robbinsdale
+KubeletDown case was ultimately a threshold question—real `up == 0` activity
+on `tank`, but no evidence that the current-state rule shape was wrong—not an
+automatic fix request.
 
 The diagnostic also reads Mimir's current rules API and reports a separate
-finding when Mimir says an alert is `pending` or `firing` while the full
-expression is currently inactive for that same output-label set. The rules API
-snapshot is taken after the range queries so the two observations are close in
-time. This is evidence to investigate evaluator timing, stale state, or label
-identity; it is never converted into a new alert by this tool.
+`state-mismatch` line when Mimir says an alert is `pending` or `firing` while
+the full expression is currently inactive for that same output-label set. The
+rules API snapshot is taken after the range queries so the two observations
+are close in time. This is evidence to investigate evaluator timing, stale
+state, or label identity; it is never converted into a new alert by this tool.
 
 ## Invocation
 
@@ -51,9 +92,11 @@ MIMIR_API_URL=http://mimir-gateway.mimir.svc.cluster.local:8080/prometheus/api/v
 ```
 
 Use repeated `--tenant` or `MIMIR_TENANTS` to select tenants, `--rule-name` to
-focus on a rule, and `--lookback`/`--step` to change the sampling window. The
-live sweep is intentionally bounded and concurrent, but remains an operator
-diagnostic rather than a merge gate.
+focus on a rule, `--lookback`/`--step` to change the sampling window,
+`--min-active-duration` to change the default candidate floor, and `--all` to
+show suppressed observations and state mismatches. The live sweep is
+intentionally bounded and concurrent, but remains an operator diagnostic
+rather than a merge gate.
 
 ## Fixture proof
 
@@ -66,6 +109,13 @@ proves that split response items with the same output labels are merged, that
 pending and firing state is reported when the expression is inactive, and that
 a current matching expression is not called stale.
 
+`tools/tests/fixtures/alert-stability-kubeletdown.json` pairs a three-minute
+KubeletDown flap against `for: 15m` with separated one-sample spikes. The
+first is a candidate; the second is explicitly suppressed by the one-step
+floor. This prevents a future change from treating a silently empty default
+report as proof that the diagnostic is broken, while also preventing a
+single-sample probe blip from being presented as a rule defect.
+
 ## FluxKustomizationUnknown
 
 The diagnostic deliberately does not change
@@ -77,19 +127,20 @@ human can see their frequency, but that is not evidence to extend the hold or
 to require raw-series identity. The rule's aggregation keeps the logical
 Kustomization stable while source `revision` and `reason` labels churn.
 
-This is deliberately a diagnostic finding, not a recommendation to alter the
+This is deliberately diagnostic output, not a recommendation to alter the
 alert. The already-reviewed behavior remains: `for: 30m` is doing its job, the
 flap is fleet-wide rather than Robbinsdale-specific, and requiring same-series
 identity would break on legitimate revision/reason churn.
 
-## Live sweep snapshot
+## Historical live sweep snapshot (unfiltered)
 
-On 2026-09-09 at 19:42 UTC, the default six-hour/one-minute sweep ran all 177
-native alert rules against all three tenants: 531/531 expression queries
-completed. It reported 124 `high-churn, never-sustained` instances, 2
+On 2026-09-09 at 19:42 UTC, the six-hour/one-minute sweep ran all 177 native
+alert rules against all three tenants: 531/531 expression queries completed.
+This was captured before the candidate filter and is equivalent to the raw
+`--all` view: it reported 124 `high-churn, never-sustained` instances, 2
 `high-churn, range-censored` instances, and 1 pending/firing-state mismatch.
-The candidate counts were Ottawa 21, Robbinsdale 91, and St. Petersburg 14;
-the counts are observations, not alert conditions.
+The raw high-churn observation counts were Ottawa 21, Robbinsdale 91, and St.
+Petersburg 14; the counts are observations, not alert conditions.
 
 Besides `FluxKustomizationUnknown` (78 instances), the high-churn report
 contained:

--- a/tools/check-mimir-alert-stability.py
+++ b/tools/check-mimir-alert-stability.py
@@ -3,14 +3,18 @@
 
 This is deliberately a report-only diagnostic.  It evaluates the complete
 alert expression against live Mimir samples, groups samples by the labels the
-alert instance would actually have, and reports high-churn instances whose
-longest observed active run is shorter than the rule's ``for`` duration.  It
-also reports when Mimir says an alert is pending or firing while the expression
-is currently inactive.
+alert instance would actually have, and reports candidate instances whose
+longest observed active run is shorter than the rule's ``for`` duration.  By
+default, a candidate must span at least one sampling step; shorter
+high-churn observations are still available with ``--all``.  It also reports
+when Mimir says an alert is pending or firing while the expression is
+currently inactive.
 
 The diagnostic does not emit Prometheus samples, change rules, or use its exit
 status for findings.  Exit 2 means the live sweep could not be completed; a
-non-zero finding count is still a successful diagnostic run.
+non-zero finding count is still a successful diagnostic run.  A candidate is
+a question for human triage, never a defect verdict or a recommendation to
+retune an alert.
 """
 
 from __future__ import annotations
@@ -50,6 +54,12 @@ DEFAULT_LOOKBACK = "6h"
 DEFAULT_STEP = "1m"
 DEFAULT_WORKERS = 8
 DEFAULT_TIMEOUT = 15.0
+
+RAW_NEVER_SUSTAINED = "high-churn, never-sustained"
+RAW_RANGE_CENSORED = "high-churn, range-censored"
+CANDIDATE = "candidate"
+SUPPRESSED_SHORT_ACTIVITY = "suppressed-short-activity"
+INCONCLUSIVE_RANGE_CENSORED = "inconclusive-range-censored"
 
 DURATION_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?)(ms|s|m|h|d|w|y)")
 UNIT_SECONDS = {
@@ -117,12 +127,39 @@ class StabilityObservation:
         ):
             return None
         if self.duration_censored:
-            return "high-churn, range-censored"
-        return "high-churn, never-sustained"
+            return RAW_RANGE_CENSORED
+        return RAW_NEVER_SUSTAINED
+
+    def is_candidate(self, min_active_duration: float) -> bool:
+        """Return whether this raw churn observation merits default output.
+
+        ``max_active_seconds`` is measured as the span between adjacent
+        samples, so a one-sample spike has a duration of zero. Requiring at
+        least one complete sample interval filters that resolution-level
+        noise without hiding a multi-minute flap such as KubeletDown.
+        """
+
+        return (
+            self.classification == RAW_NEVER_SUSTAINED
+            and self.max_active_seconds >= min_active_duration
+        )
+
+    def report_category(self, min_active_duration: float) -> str | None:
+        """Classify an observation for the human-facing report."""
+
+        if self.classification == RAW_RANGE_CENSORED:
+            return INCONCLUSIVE_RANGE_CENSORED
+        if self.classification == RAW_NEVER_SUSTAINED:
+            return (
+                CANDIDATE
+                if self.is_candidate(min_active_duration)
+                else SUPPRESSED_SHORT_ACTIVITY
+            )
+        return None
 
     @property
     def high_churn_never_sustained(self) -> bool:
-        return self.classification == "high-churn, never-sustained"
+        return self.classification == RAW_NEVER_SUSTAINED
 
 
 @dataclasses.dataclass(frozen=True)
@@ -159,6 +196,19 @@ def format_duration(seconds: float) -> str:
     return f"{seconds:g}s"
 
 
+def query_expression(expression: str) -> str:
+    """Convert Flux-escaped dollars in a native rule to its live form.
+
+    The rule ConfigMap is rendered through Flux envsubst. Native manifests
+    therefore write ``$$`` when the deployed PromQL must contain a literal
+    ``$`` (for example, the ``$1`` replacement in ``label_replace``). The
+    diagnostic queries Mimir directly and must apply that same one-pass
+    rendering before sending the expression.
+    """
+
+    return expression.replace("$$", "$")
+
+
 def load_rules(rules_dir: Path, requested_names: set[str]) -> list[AlertRule]:
     paths = sorted(rules_dir.glob("*.yaml")) + sorted(rules_dir.glob("*.yml"))
     if not paths:
@@ -192,7 +242,7 @@ def load_rules(rules_dir: Path, requested_names: set[str]) -> list[AlertRule]:
                                 path=path,
                                 group=group_name,
                                 name=name,
-                                expression=expression,
+                                expression=query_expression(expression),
                                 for_seconds=parse_rule_duration(rule.get("for")),
                                 labels=labels,
                             )
@@ -447,6 +497,15 @@ def run(args: argparse.Namespace) -> int:
         raise DiagnosticError(
             "lookback must be at least one positive whole step and step must be positive"
         )
+    configured_min_active_duration = getattr(args, "min_active_duration", None)
+    min_active_duration = (
+        step
+        if configured_min_active_duration is None
+        else configured_min_active_duration
+    )
+    if min_active_duration < 0:
+        raise DiagnosticError("minimum active duration must not be negative")
+    show_all = bool(getattr(args, "show_all", False))
     end = int(time.time())
     start = end - lookback
 
@@ -510,13 +569,28 @@ def run(args: argparse.Namespace) -> int:
         for mismatch in state_mismatches:
             mismatches.append((tenant, rule, mismatch))
 
+    candidates = [
+        item for item in findings if item[2].is_candidate(min_active_duration)
+    ]
+    suppressed_short_activity = [
+        item
+        for item in findings
+        if item[2].report_category(min_active_duration) == SUPPRESSED_SHORT_ACTIVITY
+    ]
+    inconclusive_range_censored = [
+        item
+        for item in findings
+        if item[2].report_category(min_active_duration) == INCONCLUSIVE_RANGE_CENSORED
+    ]
+    observations_to_print = findings if show_all else candidates
     for tenant, rule, observation in sorted(
-        findings,
+        observations_to_print,
         key=lambda item: (item[0], item[1].name, labels_text(item[2].labels)),
     ):
         ratio = observation.ratio if observation.ratio is not None else 0.0
         print(
-            f"! tenant={tenant} {rule.location}: {observation.classification} "
+            f"{observation.report_category(min_active_duration)} "
+            f"tenant={tenant} {rule.location}: {observation.classification} "
             f"max_active={format_duration(observation.max_active_seconds)} "
             f"for={format_duration(observation.for_seconds)} "
             f"active_duration_for_ratio={ratio:.3f} "
@@ -526,32 +600,28 @@ def run(args: argparse.Namespace) -> int:
             f"duration_censored={str(observation.duration_censored).lower()} "
             f"labels={labels_text(observation.labels)}"
         )
-    for tenant, rule, mismatch in sorted(
-        mismatches,
-        key=lambda item: (item[0], item[1].name, item[2].state, labels_text(item[2].labels)),
-    ):
-        print(
-            f"! tenant={tenant} {rule.location}: {mismatch.state} state while "
-            f"expression is currently inactive labels={labels_text(mismatch.labels)}"
-        )
+    if show_all:
+        for tenant, rule, mismatch in sorted(
+            mismatches,
+            key=lambda item: (item[0], item[1].name, item[2].state, labels_text(item[2].labels)),
+        ):
+            print(
+                f"state-mismatch tenant={tenant} {rule.location}: {mismatch.state} "
+                f"while expression is currently inactive labels={labels_text(mismatch.labels)}"
+            )
     for error in sorted(errors):
         print(f"! {error}", file=sys.stderr)
 
-    never_sustained = sum(
-        observation.classification == "high-churn, never-sustained"
-        for _, _, observation in findings
-    )
-    range_censored = sum(
-        observation.classification == "high-churn, range-censored"
-        for _, _, observation in findings
-    )
     print(
         f"Mimir alert stability diagnostic: tenants={len(tenants)} "
         f"rules={len(rules)} queries={completed}/{len(tasks)} "
-        f"high_churn_never_sustained={never_sustained} "
-        f"high_churn_range_censored={range_censored} "
+        f"candidates={len(candidates)} "
+        f"suppressed_short_activity={len(suppressed_short_activity)} "
+        f"inconclusive_range_censored={len(inconclusive_range_censored)} "
         f"state_mismatches={len(mismatches)} errors={len(errors)} "
-        f"lookback={format_duration(lookback)} step={format_duration(step)}"
+        f"lookback={format_duration(lookback)} step={format_duration(step)} "
+        f"min_active_duration={format_duration(min_active_duration)} "
+        f"mode={'all' if show_all else 'candidates'}"
     )
     # Findings are report data, not a CI or Alertmanager condition. Only an
     # incomplete live sweep is exceptional.
@@ -583,6 +653,18 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help="inspect only this alert name; may be repeated",
+    )
+    parser.add_argument(
+        "--min-active-duration",
+        type=parse_duration,
+        default=None,
+        help="minimum observed active span for a default candidate (default: one step)",
+    )
+    parser.add_argument(
+        "--all",
+        dest="show_all",
+        action="store_true",
+        help="show suppressed short activity, range-censored observations, and state mismatches",
     )
     parser.add_argument(
         "--lookback",

--- a/tools/tests/fixtures/alert-stability-kubeletdown.json
+++ b/tools/tests/fixtures/alert-stability-kubeletdown.json
@@ -1,0 +1,92 @@
+{
+  "rule": {
+    "name": "KubeletDown",
+    "for": "15m",
+    "labels": {
+      "severity": "critical"
+    }
+  },
+  "start": 0,
+  "end": 900,
+  "step": 60,
+  "cases": [
+    {
+      "name": "three-minute-flap",
+      "results": [
+        {
+          "metric": {
+            "cluster": "talos-robbinsdale",
+            "node": "tank"
+          },
+          "values": [
+            [60, "1"],
+            [120, "1"],
+            [180, "1"],
+            [240, "1"],
+            [600, "1"],
+            [660, "1"]
+          ]
+        }
+      ],
+      "expected": {
+        "raw_kind": "high-churn, never-sustained",
+        "report_category": "candidate",
+        "active_runs": 2,
+        "max_active_seconds": 180,
+        "ratio": 0.2,
+        "transition_count": 4,
+        "current_active": false,
+        "duration_censored": false
+      }
+    },
+    {
+      "name": "single-one-minute-sample",
+      "results": [
+        {
+          "metric": {
+            "cluster": "talos-robbinsdale",
+            "node": "single"
+          },
+          "values": [
+            [300, "1"]
+          ]
+        }
+      ],
+      "expected": {
+        "raw_kind": null,
+        "report_category": null,
+        "active_runs": 1,
+        "max_active_seconds": 0,
+        "ratio": 0.0,
+        "transition_count": 2,
+        "current_active": false,
+        "duration_censored": false
+      }
+    },
+    {
+      "name": "single-sample-spikes",
+      "results": [
+        {
+          "metric": {
+            "cluster": "talos-robbinsdale",
+            "node": "quiet"
+          },
+          "values": [
+            [60, "1"],
+            [240, "1"]
+          ]
+        }
+      ],
+      "expected": {
+        "raw_kind": "high-churn, never-sustained",
+        "report_category": "suppressed-short-activity",
+        "active_runs": 2,
+        "max_active_seconds": 0,
+        "ratio": 0.0,
+        "transition_count": 4,
+        "current_active": false,
+        "duration_censored": false
+      }
+    }
+  ]
+}

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -408,7 +408,7 @@ exits "short zero-for counter windows are detected" 0 \
 
 # ------------------------------------------------------------- Mimir alert-stability diagnostic
 section "Mimir alert-stability diagnostic"
-exits "high-churn toggle and stale pending state are reported" 0 \
+exits "candidate filter, KubeletDown fixture, and stale pending state" 0 \
   python3 "$ROOT/tools/tests/test_mimir_alert_stability.py"
 
 # A completed gate must reap every watchdog timer descendant. Use an isolated

--- a/tools/tests/test_mimir_alert_stability.py
+++ b/tools/tests/test_mimir_alert_stability.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[2]
 TOOL = ROOT / "tools/check-mimir-alert-stability.py"
 FIXTURE = ROOT / "tools/tests/fixtures/alert-stability-unknown-toggle.json"
+KUBELET_FIXTURE = ROOT / "tools/tests/fixtures/alert-stability-kubeletdown.json"
 
 
 def load_tool():
@@ -63,6 +64,52 @@ def main() -> int:
     )
     assert observation.current_active == fixture["expected"]["current_active"]
     assert observation.duration_censored == fixture["expected"]["duration_censored"]
+
+    # A multi-minute KubeletDown flap is a candidate for human triage, while
+    # one-sample spikes are resolution-level noise. The latter still has two
+    # separated runs and therefore exercises the active-duration floor rather
+    # than being discarded by the existing run-count guard.
+    kubelet_fixture = json.loads(KUBELET_FIXTURE.read_text())
+    kubelet_rule = tool.AlertRule(
+        path=Path("node-health.yaml"),
+        group="node-health.rules",
+        name=kubelet_fixture["rule"]["name"],
+        expression='up{job="kubelet"} == 0',
+        for_seconds=tool.parse_duration(kubelet_fixture["rule"]["for"]),
+        labels=kubelet_fixture["rule"]["labels"],
+    )
+    for case in kubelet_fixture["cases"]:
+        case_observations, case_mismatches = tool.analyze_query_result(
+            kubelet_rule,
+            case["results"],
+            kubelet_fixture["start"],
+            kubelet_fixture["end"],
+            kubelet_fixture["step"],
+        )
+        assert not case_mismatches, case_mismatches
+        assert len(case_observations) == 1, case_observations
+        case_observation = case_observations[0]
+        expected = case["expected"]
+        assert case_observation.classification == expected["raw_kind"]
+        assert (
+            case_observation.report_category(kubelet_fixture["step"])
+            == expected["report_category"]
+        )
+        assert case_observation.is_candidate(kubelet_fixture["step"]) == (
+            expected["report_category"] == "candidate"
+        )
+        assert case_observation.active_runs == expected["active_runs"]
+        assert case_observation.max_active_seconds == expected["max_active_seconds"]
+        assert case_observation.ratio == expected["ratio"]
+        assert case_observation.transitions == expected["transition_count"]
+        assert case_observation.current_active == expected["current_active"]
+        assert case_observation.duration_censored == expected["duration_censored"]
+
+    # Native manifests use $$ to carry a literal $ through Flux substitution;
+    # live queries must use the deployed expression form.
+    assert tool.query_expression('label_replace(vector(1), "name", "$$1", "x", ".*")') == (
+        'label_replace(vector(1), "name", "$1", "x", ".*")'
+    )
 
     # Mimir can split a matrix response into more than one item while the
     # output label set remains the same. The alert identity must be merged by
@@ -150,17 +197,21 @@ def main() -> int:
     )
     assert not active_state, active_state
 
-    # Findings are informational: a complete sweep with a finding must still
+    # Findings are informational: a complete sweep with a candidate must still
     # return success. This guards the report-only contract against accidentally
-    # becoming a CI/Alertmanager condition.
+    # becoming a CI/Alertmanager condition. The default output omits a pair of
+    # one-sample spikes and a stale evaluator state; --all restores both.
     with tempfile.TemporaryDirectory(prefix="mimir-alert-stability-") as temporary:
         rules_dir = Path(temporary)
         (rules_dir / "rules.yaml").write_text(
             """groups:
   - name: test.rules
     rules:
-      - alert: Toggle
+      - alert: ToggleCandidate
         expr: vector(1)
+        for: 5m
+      - alert: ToggleShort
+        expr: vector(2)
         for: 5m
 """
         )
@@ -170,21 +221,39 @@ def main() -> int:
                 del api_url, tenant, timeout
 
             def query_range(self, expression, start, end, step):
-                assert expression == "vector(1)"
+                if expression == "vector(1)":
+                    values = [
+                        [start + step, "1"],
+                        [start + 2 * step, "1"],
+                        [start + 4 * step, "1"],
+                        [start + 5 * step, "1"],
+                    ]
+                else:
+                    assert expression == "vector(2)"
+                    values = [
+                        [start + step, "1"],
+                        [start + 4 * step, "1"],
+                    ]
                 return [
                     {
                         "metric": {"cluster": "talos-test"},
-                        "values": [
-                            [start + step, "1"],
-                            [start + 2 * step, "1"],
-                            [start + 4 * step, "1"],
-                            [start + 5 * step, "1"],
-                        ],
+                        "values": values,
                     }
                 ]
 
             def alert_states(self):
-                return {"Toggle": []}
+                return {
+                    "ToggleCandidate": [],
+                    "ToggleShort": [
+                        {
+                            "state": "pending",
+                            "labels": {
+                                "alertname": "ToggleShort",
+                                "cluster": "talos-test",
+                            },
+                        }
+                    ],
+                }
 
         original_api = tool.MimirAPI
         tool.MimirAPI = FakeAPI
@@ -201,15 +270,51 @@ def main() -> int:
                         step=60,
                         workers=2,
                         timeout=1,
+                        min_active_duration=None,
+                        show_all=False,
                     )
                 )
             assert result == 0
-            assert "high-churn, never-sustained" in output.getvalue()
-            assert "queries=1/1" in output.getvalue()
+            default_output = output.getvalue()
+            assert "candidate tenant=talos-test" in default_output
+            assert "ToggleCandidate" in default_output
+            assert "ToggleShort" not in default_output
+            assert "candidates=1" in default_output
+            assert "suppressed_short_activity=1" in default_output
+            assert "state_mismatches=1" in default_output
+            assert "mode=candidates" in default_output
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                result = tool.run(
+                    SimpleNamespace(
+                        rules_dir=str(rules_dir),
+                        rule_name=[],
+                        tenant=["talos-test"],
+                        api_url="http://mimir.test/api/v1",
+                        lookback=360,
+                        step=60,
+                        workers=2,
+                        timeout=1,
+                        min_active_duration=None,
+                        show_all=True,
+                    )
+                )
+            assert result == 0
+            all_output = output.getvalue()
+            assert "candidate tenant=talos-test" in all_output
+            assert "suppressed-short-activity tenant=talos-test" in all_output
+            assert "ToggleShort" in all_output
+            assert "state-mismatch tenant=talos-test" in all_output
+            assert "mode=all" in all_output
         finally:
             tool.MimirAPI = original_api
 
     print("✓ Mimir alert stability: Unknown -> True -> Unknown is high-churn, never-sustained")
+    print(
+        "✓ Mimir alert stability: KubeletDown 3m is a candidate; "
+        "one-sample spikes are suppressed"
+    )
     print("✓ Mimir alert stability: output labels merge split response items")
     print("✓ Mimir alert stability: pending/firing state while expression is inactive is reported")
     return 0


### PR DESCRIPTION
## Summary

- Make the live alert-stability diagnostic default to `candidate` output: raw high-churn observations must span at least one complete sample step.
- Classify shorter raw churn as `suppressed-short-activity`, edge-censored runs as `inconclusive-range-censored`, and evaluator-only pending/firing discrepancies as `state-mismatch`.
- Keep the complete raw view available with `--all`; the default filter changes visibility, not the sampled evidence.
- Add the KubeletDown fixture: a 3m run against `for: 15m` is a candidate (ratio 0.200), while a single 1m sample is not.
- Normalize Flux-escaped `$$` in native PromQL before querying Mimir, so expressions such as qBittorrent’s deployed `$1` label replacement are evaluated as loaded.

## Triage contract

A `candidate` is a question for a human, not a defect verdict, alert, or automatic retune. The Robbinsdale KubeletDown result remains a threshold choice: real `up == 0` activity on `tank`, but the current-state rule shape is correct. Raj must decide what duration is actionable.

`FluxKustomizationUnknown` is deliberately NOT changed. Its `for: 30m` persistence guard and output-label aggregation remain correct for normal fleet-wide `Unknown -> True -> Unknown` reconciliation churn; requiring raw same-series revision/reason identity would break legitimate revision/reason changes. This diagnostic’s output is not a recommendation to alter that rule.

This remains report-only: it is not a `PrometheusRule`, emits no Alertmanager signal, and findings do not affect exit status or CI. Only an incomplete live sweep is exceptional.

## Validation

- `python3 tools/tests/test_mimir_alert_stability.py`
- `tools/tests/run.sh`
- `tools/check.sh` (all three cluster renders)
- Live smoke: default mode retained Robbinsdale KubeletDown at `3m/15m/0.200`; `--all` retained the one-sample probe as `suppressed-short-activity`.