### PR TITLE
fix(zot): retain long-lived workload images for six months

### DIFF
--- a/kubernetes/apps/base/zot/zot/helmrelease.yaml
+++ b/kubernetes/apps/base/zot/zot/helmrelease.yaml
@@ -82,6 +82,10 @@ spec:
     # storage GetReferrers still O(n) S3-scans the repo index (~14s on corp/bhaiya);
     # GraphQL Referrers via MetaDB stays fast. Real OCI referrers speed needs
     # upstream MetaDB-backed GetReferrers or a smaller repo.
+    # Keep a finite six-month age window as well as the recent-tag floor. The
+    # count-only protection lets cached, long-lived workloads outlive their
+    # registry manifest; 180 days covers that class without retaining every
+    # historical build indefinitely.
     configFiles:
       config.json: |-
         {
@@ -108,8 +112,8 @@ spec:
                 "keepTags": [{
                   "mostRecentlyPushedCount": 10,
                   "mostRecentlyPulledCount": 10,
-                  "pulledWithin": "720h",
-                  "pushedWithin": "720h"
+                  "pulledWithin": "4320h",
+                  "pushedWithin": "4320h"
                 }]
               }]
             },


### PR DESCRIPTION
## Proposal

Extend Zot retention age windows from 720h (30 days) to 4320h (180 days), while retaining the existing most-recently-pushed and most-recently-pulled count floors of 10. This addresses the failure mode where a long-lived workload is pinned to an old digest whose manifest is garbage-collected after its tag stops being recent.

An age window is the least coupled option: Zot does not need Kubernetes awareness, and retention does not depend on maintaining a repository allowlist that can silently miss a new workload. It is finite rather than keep-everything-forever.

## Storage tradeoff

This retains eligible content for up to six months instead of one month, so the registry will retain more old manifests/layers. The current Zot bucket is 118,916,322,111 bytes (about 110.8 GiB) across 4,691 objects. The exact incremental cost cannot be derived safely from the retention configuration alone; it depends on the age and deduplication shape of the objects that would otherwise be collected. The six-month window bounds the policy, and bucket usage should be watched after rollout.

## Scope

This PR changes only the GitOps Zot ConfigMap. It does not apply or alter the live registry. The workload-image detection is in separate PR #2952 so it can land independently.

Please review the retention/storage tradeoff before merging.