### PR TITLE
fix(monitoring): make running workload image detection effective

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/running-workload-images.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/running-workload-images.yaml
@@ -1,6 +1,7 @@
-# A missing registry manifest is actionable only when a running workload still
-# references it. The exporter distinguishes a definitive 404 from an unknown
-# result so registry reachability problems never page as image deletion.
+# A missing internal-registry manifest is actionable only when a running
+# workload still references it. The probe intentionally emits only the Zot
+# registry's images; keep the registry matcher here as a defense-in-depth
+# boundary so external-registry noise cannot page as image deletion.
 namespace: running-workload-images
 groups:
   - name: running-workload-images.rules
@@ -10,7 +11,7 @@ groups:
       # Promote after the existing missing references are resolved.
       - alert: RunningWorkloadImageMissing
         expr: |
-          running_workload_image_registry_probe_references{status="missing"} > 0
+          running_workload_image_registry_probe_references{registry="oci.cdn.keiretsu.top",status="missing"} > 0
         for: 15m
         labels:
           severity: warning
@@ -28,7 +29,7 @@ groups:
 
       - alert: RunningWorkloadImageProbeUnknown
         expr: |
-          running_workload_image_registry_probe_references{status="unknown"} > 0
+          running_workload_image_registry_probe_references{registry="oci.cdn.keiretsu.top",status="unknown"} > 0
         for: 15m
         labels:
           severity: warning

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/running_workload_images_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/running_workload_images_test.yaml
@@ -72,7 +72,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'running_workload_image_registry_probe_references{cluster="talos-ottawa",image="ghcr.io/example/app:old",registry="ghcr.io",status="unknown"}'
+      - series: 'running_workload_image_registry_probe_references{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/keiretsu/app:old",registry="oci.cdn.keiretsu.top",status="unknown"}'
         values: "1+0x20"
       - series: 'running_workload_image_registry_probe_scan_success{cluster="talos-ottawa"}'
         values: "1+0x20"
@@ -82,8 +82,8 @@ tests:
         exp_alerts:
           - exp_labels:
               cluster: talos-ottawa
-              image: ghcr.io/example/app:old
-              registry: ghcr.io
+              image: oci.cdn.keiretsu.top/keiretsu/app:old
+              registry: oci.cdn.keiretsu.top
               severity: warning
               status: unknown
             exp_annotations:
@@ -95,6 +95,19 @@ tests:
                 rate-limit, or registry-server error, not evidence that the
                 image is missing. Restore probe reachability before treating
                 it as an image-loss incident.
+
+  # External registries are outside this detector's retention boundary and
+  # must not create an actionable unknown alert even if a stale sample exists.
+  - interval: 1m
+    input_series:
+      - series: 'running_workload_image_registry_probe_references{cluster="talos-ottawa",image="ghcr.io/example/app:old",registry="ghcr.io",status="unknown"}'
+        values: "1+0x20"
+      - series: 'running_workload_image_registry_probe_scan_success{cluster="talos-ottawa"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RunningWorkloadImageProbeUnknown
+        exp_alerts: []
 
   - interval: 1m
     input_series:

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/running_workload_images_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/running_workload_images_test.yaml
@@ -23,13 +23,24 @@ tests:
               registry: oci.cdn.keiretsu.top
               severity: warning
               status: missing
+            exp_annotations:
+              summary: Running workload image is missing from its registry
+              description: >-
+                oci.cdn.keiretsu.top/keiretsu/vault:old is referenced by 2
+                running pod container(s), but its OCI manifest endpoint has
+                returned a definitive 404 for at least 15 minutes. A cached
+                pod may continue running until restart, eviction, drain, or
+                rescheduling makes the missing image an outage. Query
+                running_workload_image_registry_probe_reference_info with the
+                image label to enumerate affected pods before changing the
+                workload or registry.
 
   # The condition is current state, not an event: once the registry serves the
   # manifest again, the missing series goes stale and the alert must clear.
   - interval: 1m
     input_series:
       - series: 'running_workload_image_registry_probe_references{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/keiretsu/vault:old",registry="oci.cdn.keiretsu.top",status="missing"}'
-        values: "2+0x15 _x5"
+        values: "2+0x15 stale"
       - series: 'running_workload_image_registry_probe_references{cluster="talos-ottawa",image="oci.cdn.keiretsu.top/keiretsu/vault:old",registry="oci.cdn.keiretsu.top",status="present"}'
         values: "_x16 2+0x4"
       - series: 'running_workload_image_registry_probe_scan_success{cluster="talos-ottawa"}'
@@ -44,6 +55,17 @@ tests:
               registry: oci.cdn.keiretsu.top
               severity: warning
               status: missing
+            exp_annotations:
+              summary: Running workload image is missing from its registry
+              description: >-
+                oci.cdn.keiretsu.top/keiretsu/vault:old is referenced by 2
+                running pod container(s), but its OCI manifest endpoint has
+                returned a definitive 404 for at least 15 minutes. A cached
+                pod may continue running until restart, eviction, drain, or
+                rescheduling makes the missing image an outage. Query
+                running_workload_image_registry_probe_reference_info with the
+                image label to enumerate affected pods before changing the
+                workload or registry.
       - eval_time: 16m
         alertname: RunningWorkloadImageMissing
         exp_alerts: []
@@ -64,6 +86,15 @@ tests:
               registry: ghcr.io
               severity: warning
               status: unknown
+            exp_annotations:
+              summary: Running workload image registry status is unknown
+              description: >-
+                The registry probe cannot determine whether
+                ghcr.io/example/app:old is pullable for 1 running pod
+                container(s). This is a network, TLS, authentication,
+                rate-limit, or registry-server error, not evidence that the
+                image is missing. Restore probe reachability before treating
+                it as an image-loss incident.
 
   - interval: 1m
     input_series:
@@ -79,3 +110,10 @@ tests:
           - exp_labels:
               cluster: talos-ottawa
               severity: warning
+            exp_annotations:
+              summary: Running workload image probe is unavailable
+              description: >-
+                The running-workload image probe has not completed a
+                successful Kubernetes/API and registry scan for at least 15
+                minutes. Image deletion detection is blind until the probe is
+                healthy again.

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/probe.py
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/probe.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""Expose whether images used by running pods are still pullable.
+"""Expose whether internal-registry images used by running pods are still pullable.
 
 The probe intentionally uses only the Kubernetes read API and OCI manifest
 HEAD requests.  It never pulls an image, reads a layer, or changes either
-cluster state or registry state.  A 404 is reported as ``missing``; every
-other HTTP, DNS, TLS, or Kubernetes error is ``unknown`` so a connectivity
-problem can never masquerade as image deletion.
+cluster state or registry state.  Only the configured internal registry is
+checked; external images are outside this detector's retention boundary.  A
+404 is reported as ``missing``; every other HTTP, DNS, TLS, or Kubernetes error
+is ``unknown`` so a connectivity problem can never masquerade as image
+deletion.
 """
 
 from __future__ import annotations
@@ -30,6 +32,7 @@ API_PATH = "/api/v1/pods"
 SERVICE_ACCOUNT_DIR = "/var/run/secrets/kubernetes.io/serviceaccount"
 TOKEN_PATH = f"{SERVICE_ACCOUNT_DIR}/token"
 CA_PATH = f"{SERVICE_ACCOUNT_DIR}/ca.crt"
+TARGET_REGISTRY = "oci.cdn.keiretsu.top"
 MANIFEST_ACCEPT = (
     "application/vnd.oci.image.manifest.v1+json, "
     "application/vnd.oci.image.index.v1+json, "
@@ -111,8 +114,21 @@ def read_token() -> str:
         return token_file.read().strip()
 
 
-def tls_context() -> ssl.SSLContext:
+def kubernetes_tls_context() -> ssl.SSLContext:
+    """Trust the cluster CA for the Kubernetes API server only."""
+
     return ssl.create_default_context(cafile=CA_PATH)
+
+
+def registry_tls_context() -> ssl.SSLContext:
+    """Trust public/system CAs for the external registry HTTPS endpoint.
+
+    The mounted ServiceAccount CA authenticates the Kubernetes API server; it
+    is not a trust bundle for arbitrary HTTPS destinations such as Zot.
+    """
+
+    # The ServiceAccount CA is for kubernetes.default.svc, not arbitrary HTTPS.
+    return ssl.create_default_context()
 
 
 def api_get(path: str, token: str, context: ssl.SSLContext) -> dict[str, Any]:
@@ -240,13 +256,20 @@ def probe_manifest(image: ImageReference, context: ssl.SSLContext) -> str:
 def probe_images(
     images: set[str], context: ssl.SSLContext, workers: int
 ) -> dict[str, tuple[str, str]]:
+    """Probe only images served by the registry this detector owns."""
+
     results: dict[str, tuple[str, str]] = {}
     normalized: dict[str, ImageReference] = {}
     for image in images:
         try:
-            normalized[image] = normalize_image(image)
+            parsed = normalize_image(image)
         except ValueError:
-            results[image] = ("unknown", "unknown")
+            if image.startswith(f"{TARGET_REGISTRY}/"):
+                results[image] = ("unknown", TARGET_REGISTRY)
+            continue
+        if parsed.registry != TARGET_REGISTRY:
+            continue
+        normalized[image] = parsed
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {
@@ -299,8 +322,11 @@ def render_metrics(
         )
     )
 
+    monitored_references = [
+        reference for reference in references if reference.image in statuses
+    ]
     by_image: dict[str, list[WorkloadReference]] = {}
-    for reference in references:
+    for reference in monitored_references:
         by_image.setdefault(reference.image, []).append(reference)
 
     if scan_success:
@@ -316,7 +342,7 @@ def render_metrics(
                 f"{count_name}{{{count_labels}}} {len(by_image.get(image, []))}"
             )
 
-        for reference in references:
+        for reference in monitored_references:
             labels = metric_labels(
                 {
                     "container": reference.container,
@@ -394,9 +420,13 @@ def scan_once(state: MetricsState, workers: int) -> None:
     started = time.time()
     try:
         token = read_token()
-        context = tls_context()
-        references = workload_references(running_pods(token, context))
-        statuses = probe_images({reference.image for reference in references}, context, workers)
+        api_context = kubernetes_tls_context()
+        references = workload_references(running_pods(token, api_context))
+        statuses = probe_images(
+            {reference.image for reference in references},
+            registry_tls_context(),
+            workers,
+        )
         now = time.time()
         state.replace(
             render_metrics(

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/service.yaml
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: running-workload-image-probe
   labels:
     app.kubernetes.io/name: running-workload-image-probe
+    app.kubernetes.io/component: running-workload-image-probe
 spec:
   selector:
     app.kubernetes.io/name: running-workload-image-probe

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/servicemonitor.yaml
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/servicemonitor.yaml
@@ -8,7 +8,9 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: running-workload-image-probe
+      # Flux commonMetadata owns app.kubernetes.io/name on the Service and
+      # changes it to the parent Kustomization name.  component is stable.
+      app.kubernetes.io/component: running-workload-image-probe
   endpoints:
     - port: metrics
       path: /metrics

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/tests/test_probe.py
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/tests/test_probe.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import importlib.util
 import pathlib
+import ssl
 import sys
 import unittest
+from unittest import mock
 
 
 MODULE_PATH = pathlib.Path(__file__).parents[1] / "probe.py"
@@ -55,6 +57,31 @@ class ProbeTest(unittest.TestCase):
         )
         self.assertTrue(all(item.owner_name == "worker" for item in references))
 
+    def test_only_probes_the_internal_registry(self) -> None:
+        with mock.patch.object(
+            probe, "probe_manifest", return_value="present"
+        ) as check:
+            statuses = probe.probe_images(
+                {
+                    "oci.cdn.keiretsu.top/keiretsu/app:v1",
+                    "ghcr.io/example/app:v1",
+                    "alpine:3.18",
+                },
+                ssl.create_default_context(),
+                workers=2,
+            )
+
+        self.assertEqual(
+            statuses,
+            {
+                "oci.cdn.keiretsu.top/keiretsu/app:v1": (
+                    "present",
+                    "oci.cdn.keiretsu.top",
+                )
+            },
+        )
+        check.assert_called_once()
+
     def test_missing_status_includes_actionable_reference_labels(self) -> None:
         reference = probe.WorkloadReference(
             image="oci.cdn.keiretsu.top/keiretsu/vault:old",
@@ -77,6 +104,38 @@ class ProbeTest(unittest.TestCase):
         self.assertIn('namespace="keiretsu"', metrics)
         self.assertIn('pod="vault-0"', metrics)
         self.assertIn("running_workload_image_registry_probe_references", metrics)
+
+    def test_unmonitored_registry_reference_is_not_emitted(self) -> None:
+        internal = probe.WorkloadReference(
+            image="oci.cdn.keiretsu.top/keiretsu/app:v1",
+            namespace="demo",
+            pod="app-0",
+            container="app",
+            container_type="regular",
+            owner_kind="StatefulSet",
+            owner_name="app",
+        )
+        external = probe.WorkloadReference(
+            image="ghcr.io/example/app:v1",
+            namespace="demo",
+            pod="external-0",
+            container="app",
+            container_type="regular",
+            owner_kind="StatefulSet",
+            owner_name="external",
+        )
+        metrics = probe.render_metrics(
+            [internal, external],
+            {internal.image: ("present", "oci.cdn.keiretsu.top")},
+            True,
+            100.0,
+            0.5,
+            100.0,
+        )
+
+        self.assertIn('image="oci.cdn.keiretsu.top/keiretsu/app:v1"', metrics)
+        self.assertNotIn('image="ghcr.io/example/app:v1"', metrics)
+        self.assertIn("running_workload_image_registry_probe_images 1", metrics)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this fixes

- Use the system trust store for Zot registry HTTPS while retaining the ServiceAccount CA for the Kubernetes API.
- Select the probe Service by stable app.kubernetes.io/component metadata so Flux commonMetadata cannot break scraping.
- Probe and emit metrics only for oci.cdn.keiretsu.top; external registry images are intentionally outside this retention detector.
- Keep the missing/unknown rules registry-scoped and add unit/fixture coverage for external-image suppression.

## Live evidence

Before this change, all three probes ran but returned unknown for every image, and the endpoint was in Prometheus droppedTargets. With the system CA, the 13 Ottawa internal images resolve to 11 present and 2 missing: vault and websearch-source.

## Separate finding

websearch-source is a manually applied, unlabeled, single-replica StatefulSet in keiretsu, with no Git/Flux reference, Service, or HTTPRoute. Its only PVC is a 1Gi ceph-block-replicated tsnet-state claim; its Secret contains TS_AUTHKEY only. The missing image is its sole container image.

Live activeTargets/Mimir verification will follow Flux adoption of this PR.