### PR TITLE
fix(mimir): ignore in-flight Velero coverage counts

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero-integrity_test.yaml
@@ -334,7 +334,7 @@ tests:
         values: "200+0x20"
       - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-previous",phase="Completed"}'
         values: "1+0x20"
-      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current",phase="PartiallyFailed"}'
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="bhaiya-backup",backup="bhaiya-backup-current",phase="Completed"}'
         values: "1+0x20"
       - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="bhaiya-backup-previous",pod_volume_backup="previous-pvb-1",node="asuka",phase="Completed"}'
         values: "1+0x20"
@@ -444,6 +444,36 @@ tests:
                 PVB identities before escalating. The condition starts with
                 the Backup creation time, not when this alert fires; use that
                 timestamp to determine when the apparent regression began.
+
+  # A newest Backup with New/InProgress PVBs is unresolved, not a coverage
+  # regression. Once the parent and its PVB complete, the count catches up to
+  # the prior baseline and remains quiet. The old expression would page at
+  # 15m while this synthetic Backup was still in flight.
+  - interval: 1m
+    input_series:
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="in-flight-backup",backup="in-flight-backup-previous"}'
+        values: "100+0x40"
+      - series: 'velero_cr_backup_created_timestamp{cluster="talos-ottawa",namespace="velero-system",schedule="in-flight-backup",backup="in-flight-backup-current"}'
+        values: "200+0x40"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="in-flight-backup",backup="in-flight-backup-previous",phase="Completed"}'
+        values: "1+0x40"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="in-flight-backup",backup="in-flight-backup-current",phase="InProgress"}'
+        values: "1+0x19 _x21"
+      - series: 'velero_cr_backup_info{cluster="talos-ottawa",namespace="velero-system",schedule="in-flight-backup",backup="in-flight-backup-current",phase="Completed"}'
+        values: "_x20 1+0x20"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="in-flight-backup-previous",pod_volume_backup="in-flight-previous-pvb",node="asuka",phase="Completed"}'
+        values: "1+0x40"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="in-flight-backup-current",pod_volume_backup="in-flight-current-pvb",node="asuka",phase="InProgress"}'
+        values: "1+0x19 _x21"
+      - series: 'velero_cr_podvolumebackup_info{cluster="talos-ottawa",namespace="velero-system",backup="in-flight-backup-current",pod_volume_backup="in-flight-current-pvb",node="asuka",phase="Completed"}'
+        values: "_x20 1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: VeleroScheduleVolumeCoverageRegressed
+        exp_alerts: []
 
   # A marked Schedule with completed zero-volume history must alert. The
   # unmarked Schedule is deliberately identical otherwise and remains out of
@@ -589,8 +619,8 @@ tests:
                 is material because a Failed PVB is not coverage. A Completed
                 0/0 PVB remains in the count because its bytes are ambiguous.
                 This remains a coverage regression even when Kubernetes item
-                counts or the parent Backup phase look normal. A warning-
-                bearing Completed Backup can still supply this count baseline;
+                counts or the parent Backup phase look normal. A warning-bearing
+                Completed Backup can still supply this count baseline;
                 investigate its warning separately. If no previous Completed
                 baseline exists,
                 this alert is intentionally silent: that means no comparable

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-integrity.yaml
@@ -489,8 +489,10 @@ groups:
       # volume-count comparison, a Completed run with warnings is still a
       # useful observed baseline; VeleroScheduleLatestBackupHasWarnings owns
       # the separate quality signal. The alert deliberately observes the
-      # produced-PVB count while the Backup is queued/running; phase and item
-      # counters are not allowed to hide a volume gap.
+      # produced-PVB count only after the newest parent Backup is Completed.
+      # While the Backup is queued/running, its absent or partial Completed-PVB
+      # count is unresolved; phase and item counters must not turn that
+      # in-progress state into a coverage regression.
       - record: velero_schedule_latest_backup_created_timestamp
         expr: |
           max by (cluster, namespace, schedule, backup) (
@@ -555,6 +557,24 @@ groups:
             )
           )
 
+      # The newest Backup timestamp deliberately follows the newest attempt,
+      # including Queued and InProgress Backups. The count above deliberately
+      # follows only Completed PVBs. Do not compare those two states: while a
+      # Backup is running, an absent or partial Completed count is unresolved,
+      # not evidence that coverage was lost. Gate both the real count and its
+      # zero fallback on the newest parent Backup being Completed.
+      - record: velero_schedule_latest_completed_backup_created_timestamp
+        expr: |
+          velero_schedule_latest_backup_created_timestamp
+          and on (cluster, namespace, schedule, backup)
+          max by (cluster, namespace, schedule, backup) (
+            velero_cr_backup_info{
+              namespace="velero-system",
+              schedule!="",
+              phase="Completed"
+            }
+          )
+
       - record: velero_schedule_latest_pod_volume_backup_count
         expr: |
           (
@@ -569,11 +589,11 @@ groups:
               )
             )
             and on (cluster, namespace, schedule, backup)
-            velero_schedule_latest_backup_created_timestamp
+            velero_schedule_latest_completed_backup_created_timestamp
           )
           or on (cluster, namespace, schedule, backup)
           (
-            velero_schedule_latest_backup_created_timestamp * 0
+            velero_schedule_latest_completed_backup_created_timestamp * 0
           )
 
       - record: velero_schedule_previous_successful_pod_volume_backup_count


### PR DESCRIPTION
Follow-up to #2947.

## What was missed

#2947 correctly changed `velero_backup_pod_volume_backup_count` to count only `phase="Completed"` PVBs, so Failed PVBs no longer preserve false coverage. It missed the third PVB state: New/InProgress. The downstream rule selected the newest parent Backup while it was still running, so its zero or partial Completed-PVB count was compared with the previous full run and emitted a false coverage regression.

## Fix

Gate both the current Completed-PVB count and its zero fallback on the newest Backup itself being `phase="Completed"`. A queued or in-progress Backup is unresolved and produces no coverage verdict. Failed PVBs remain excluded once the parent is Completed, while Completed 0/0 PVBs remain counted because that state is still observationally ambiguous. This keeps the #2947 improvement and removes the in-flight false positive.

## Tests

- Kept the Failed-PVB regression fixture: it fires when coverage genuinely drops.
- Added an in-flight fixture: no alert at 15 minutes while the parent/PVB are InProgress, and no alert after both complete at 20 minutes when coverage catches up.
- Pinned Prometheus parsing and both focused fixtures pass.
- `tools/check-mimir-rules.sh` passes.
- `tools/check.sh ot` was attempted but the local `mimir-promql` render process hit its known CPU-spin timeout; it produced no manifest diagnostics.

Post-merge, verify the five Ottawa Bhaiya schedules clear after their completed backups and verify that the coverage rule selectors still match live series; silence alone is not sufficient evidence.