### PR TITLE
feat(velero): schedule Firefly uploads and Vault data

### DIFF
--- a/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
+++ b/kubernetes/apps/base/velero/velero/pvc-schedule-exemptions.yaml
@@ -29,13 +29,6 @@ exemptions:
       "immich is backed up."
 
   - cluster: ottawa
-    namespace: firefly
-    reason: >-
-      UNRESOLVED: corp/bhaiya#718 — firefly-upload PVC and firefly-postgres have
-      no Velero Schedule; CNPG S3 covers the DB only. Upload volume coverage
-      undecided.
-
-  - cluster: ottawa
     namespace: woodpecker
     reason: >-
       UNRESOLVED: corp/bhaiya#718 — woodpecker server/workspace/nix-cache PVCs and

--- a/kubernetes/apps/ottawa/velero/schedules/firefly-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/firefly-backup.yaml
@@ -1,0 +1,24 @@
+---
+# Firefly's PostgreSQL data already has CNPG/Barman coverage. Select only the
+# Firefly application pod and upload PVC so this schedule closes the filesystem
+# attachment gap without duplicating the database backup.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: firefly-backup
+  namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
+spec:
+  schedule: "0 11 * * *"
+  template:
+    ttl: 168h
+    includedNamespaces:
+      - firefly
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: firefly
+    defaultVolumesToFsBackup: true
+    resourcePolicy:
+      kind: configmap
+      name: fs-backup-resource-policy

--- a/kubernetes/apps/ottawa/velero/schedules/keiretsu-vault-backup.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/keiretsu-vault-backup.yaml
@@ -1,0 +1,23 @@
+---
+# The vault workload is in the keiretsu namespace. Select its pod and PVCs
+# without also opting the researcher or websearch-source workloads in.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: keiretsu-vault-backup
+  namespace: velero-system
+  labels:
+    keiretsu.top/volume-data-required: "true"
+spec:
+  schedule: "0 12 * * *"
+  template:
+    ttl: 168h
+    includedNamespaces:
+      - keiretsu
+    labelSelector:
+      matchLabels:
+        app: vault
+    defaultVolumesToFsBackup: true
+    resourcePolicy:
+      kind: configmap
+      name: fs-backup-resource-policy

--- a/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
+++ b/kubernetes/apps/ottawa/velero/schedules/kustomization.yaml
@@ -6,5 +6,7 @@ resources:
   - ./home-backup.yaml
   - ./bhaiya-backup.yaml
   - ./cliproxy-backup.yaml
+  - ./firefly-backup.yaml
   - ./forgejo-backup.yaml
   - ./forgejo-backup-bootstrap.yaml
+  - ./keiretsu-vault-backup.yaml


### PR DESCRIPTION
## Proposal

Draft for Raj's capacity decision. This adds two Ottawa Velero Schedules that write filesystem backups to the default `garage` BackupStorageLocation. It does not include Immich or Kometa.

- `firefly-backup` runs daily at 11:00 UTC and selects the Firefly application pod, including `firefly-upload`; Firefly PostgreSQL remains covered by CNPG/Barman and is not duplicated here.
- `keiretsu-vault-backup` runs daily at 12:00 UTC and selects the Vault pod and its filesystem volumes.
- Both retain backups for 168h (seven days), so Garage receives recurring filesystem-backup writes. Actual Garage growth depends on Kopia compression/deduplication and changed bytes across retained snapshots; the source usage below is not a claim that Garage will consume the full PVC allocations.

## Current capacity cost

Read-only live measurements from `kubelet_volume_stats_*` on Ottawa:

| PVC | Provisioned | Used now |
| --- | ---: | ---: |
| `firefly/firefly-upload` | 20 GiB | 24 KiB (24,576 bytes) |
| `keiretsu/data-vault-0` | 5 GiB | 41.9 MiB (43,995,136 bytes) |
| `keiretsu/tsnet-state-vault-0` | 1 GiB | 32 KiB (32,768 bytes) |

The third row is included deliberately: the `app: vault` selector matches the Vault pod, which mounts both `data-vault-0` and `tsnet-state-vault-0`. The current selected payload is therefore about 42 MiB, before Kopia metadata/compression and retention effects.

## Scope and limitation

This makes Vault's filesystem DATA covered by Velero. It does not make the Vault container IMAGE recoverable: a restore still depends on retrieving the image from its OCI registry. Those are independent failure paths; backed-up Vault data must not be read as “Vault is fully safe.”

The Firefly attachment gap is an opt-in miss, and today's upload PVC is effectively empty; the schedule prevents that gap from becoming material when attachments arrive. No live objects were applied.

## Validation

- `tools/check-velero-pvc-coverage.sh` passes.
- Live label/PVC inspection confirms both selectors match their intended Ottawa pods and PVCs.
- `tools/check.sh ot` was attempted but stopped at the known local `mimir-promql` CPU-spin timeout before rendering; it produced no manifest diagnostics.