### PR TITLE
feat(monitoring): detect Velero PVC selection gaps

### DIFF
--- a/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/kustomization.yaml
@@ -53,5 +53,6 @@ configMapGenerator:
       - rules/velero-volume-progress.yaml
       - rules/velero-node-saturation.yaml
       - rules/velero-restore-admission.yaml
+      - rules/velero-pvc-selection.yaml
       - rules/running-workload-images.yaml
       - rules/zot.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/loader-job.yaml
@@ -58,6 +58,7 @@ spec:
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
             - /rules/velero-restore-admission.yaml
+            - /rules/velero-pvc-selection.yaml
             - /rules/running-workload-images.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
@@ -105,6 +106,7 @@ spec:
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
             - /rules/velero-restore-admission.yaml
+            - /rules/velero-pvc-selection.yaml
             - /rules/running-workload-images.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml
@@ -148,6 +150,7 @@ spec:
             - /rules/node-clock.yaml
             - /rules/velero-node-saturation.yaml
             - /rules/velero-restore-admission.yaml
+            - /rules/velero-pvc-selection.yaml
             - /rules/running-workload-images.yaml
             - /rules/payments.yaml
             - /rules/smartctl.yaml

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_pvc_selection_test.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/tests/velero_pvc_selection_test.yaml
@@ -1,0 +1,138 @@
+rule_files:
+  - ../velero-pvc-selection.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # The exporter emits this series while no Schedule selects the PVC. Adding
+  # the PVC's namespace to a Schedule removes the current-state series and
+  # must clear the alert; this is not an event counter.
+  - interval: 1m
+    input_series:
+      - series: 'velero_pvc_backup_selection_gap{cluster="talos-ottawa",namespace="keiretsu",pvc="data-vault-0",reason="no_schedule",storage_class="ceph-block-replicated"}'
+        values: "1+0x60 _x6"
+    alert_rule_test:
+      - eval_time: 59m
+        alertname: VeleroPVCBackupSelectionGap
+        exp_alerts: []
+      - eval_time: 60m
+        alertname: VeleroPVCBackupSelectionGap
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              namespace: keiretsu
+              pvc: data-vault-0
+              reason: no_schedule
+              severity: warning
+              storage_class: ceph-block-replicated
+            exp_annotations:
+              summary: Velero PVC keiretsu/data-vault-0 has no effective volume selection
+              description: >-
+                PVC keiretsu/data-vault-0 on talos-ottawa (storage class
+                ceph-block-replicated) has remained outside effective
+                Velero filesystem-backup selection for at least one hour.
+                reason=no_schedule: no_schedule means no live Schedule selects
+                its namespace/resource/labels; no_volume_selection means a
+                Schedule selects metadata but no eligible Pod volume data
+                (unmounted, annotation opt-in missing, or explicitly
+                excluded). This is a selector finding, not proof that any
+                completed Backup contains bytes. Do not change a Schedule
+                until capacity and priority have been reviewed.
+      - eval_time: 66m
+        alertname: VeleroPVCBackupSelectionGap
+        exp_alerts: []
+
+  # The exporter emits this distinct reason when namespace/PVC metadata is
+  # selected but no Pod volume is eligible. Adding the Pod volume annotation
+  # removes the current-state series and must clear it independently.
+  - interval: 1m
+    input_series:
+      - series: 'velero_pvc_backup_selection_gap{cluster="talos-robbinsdale",namespace="media",pvc="kometa",reason="no_volume_selection",storage_class="ceph-block-replicated-nvme"}'
+        values: "1+0x60 _x6"
+    alert_rule_test:
+      - eval_time: 59m
+        alertname: VeleroPVCBackupSelectionGap
+        exp_alerts: []
+      - eval_time: 60m
+        alertname: VeleroPVCBackupSelectionGap
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-robbinsdale
+              namespace: media
+              pvc: kometa
+              reason: no_volume_selection
+              severity: warning
+              storage_class: ceph-block-replicated-nvme
+            exp_annotations:
+              summary: Velero PVC media/kometa has no effective volume selection
+              description: >-
+                PVC media/kometa on talos-robbinsdale (storage class
+                ceph-block-replicated-nvme) has remained outside effective
+                Velero filesystem-backup selection for at least one hour.
+                reason=no_volume_selection: no_schedule means no live Schedule
+                selects its namespace/resource/labels; no_volume_selection
+                means a Schedule selects metadata but no eligible Pod volume
+                data (unmounted, annotation opt-in missing, or explicitly
+                excluded). This is a selector finding, not proof that any
+                completed Backup contains bytes. Do not change a Schedule
+                until capacity and priority have been reviewed.
+      - eval_time: 66m
+        alertname: VeleroPVCBackupSelectionGap
+        exp_alerts: []
+
+  # Structural exclusions are not emitted as either selection-gap reason.
+  - interval: 1m
+    input_series:
+      - series: 'velero_pvc_backup_structural_exclusion{cluster="talos-stpetersburg",namespace="home-assistant",pvc="homeassistant-config",reason="hostpath",storage_class="local-path"}'
+        values: "1+0x60 _x6"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: VeleroPVCBackupSelectionGap
+        exp_alerts: []
+      - eval_time: 60m
+        alertname: VeleroPVCBackupStructuralExclusion
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-stpetersburg
+              namespace: home-assistant
+              pvc: homeassistant-config
+              reason: hostpath
+              severity: warning
+              storage_class: local-path
+            exp_annotations:
+              summary: Velero cannot capture PVC home-assistant/homeassistant-config with filesystem backup
+              description: >-
+                PVC home-assistant/homeassistant-config on
+                talos-stpetersburg uses a hostpath storage path (storage class
+                local-path). Velero filesystem backup structurally refuses
+                hostPath/local-path at pkg/podvolume/backupper.go:347; no
+                Schedule or annotation can fix this. Protect it with a
+                different mechanism and keep this infrastructure condition
+                separate from opt-in selection gaps.
+      - eval_time: 66m
+        alertname: VeleroPVCBackupStructuralExclusion
+        exp_alerts: []
+
+  # A failed emitter must not look like a clean zero-gap inventory.
+  - interval: 1m
+    input_series:
+      - series: 'velero_pvc_backup_selection_scan_success{cluster="talos-ottawa"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: VeleroPVCBackupSelectionProbeUnavailable
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: VeleroPVCBackupSelectionProbeUnavailable
+        exp_alerts:
+          - exp_labels:
+              cluster: talos-ottawa
+              severity: warning
+            exp_annotations:
+              summary: Velero PVC selection probe is unavailable
+              description: >-
+                The polling Deployment has not completed a successful PVC, PV,
+                Pod, and Velero Schedule selection scan for at least 15
+                minutes. Its gap series are not current while this condition
+                holds; restore probe/API access before treating an empty
+                inventory as coverage.

--- a/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-pvc-selection.yaml
+++ b/kubernetes/apps/base/mimir/mimir-ottawa/rules/velero-pvc-selection.yaml
@@ -1,0 +1,72 @@
+# This is a current selector inventory, not proof that a completed Backup
+# contains bytes. The exporter evaluates every PVC against every live Velero
+# Schedule and separates namespace/resource selection from Pod-volume data
+# selection.
+#
+# Baseline inventory captured on 2026-09-09: 65 no_schedule plus 34
+# no_volume_selection series, or 99 selection-gap instances. That noisy
+# day-one baseline is expected: namespace selection is opt-in and the existing
+# fleet contains these gaps. Keep this at warning deliberately; a 99-instance
+# critical alert would be muted as noise and hide future changes. Raj must
+# decide which volumes to add to schedules after capacity and priority review.
+# The same replay found 15 structural hostPath/local-path exclusions. They are
+# a separate infrastructure condition below, not a third selection-gap reason.
+#
+# Prometheus runs in agent mode here; Mimir evaluates these rules. The probe
+# availability guard prevents a dead emitter from looking like a clean empty
+# inventory.
+namespace: velero-pvc-selection
+groups:
+  - name: velero-pvc-selection.rules
+    rules:
+      - alert: VeleroPVCBackupSelectionGap
+        expr: |
+          velero_pvc_backup_selection_gap > 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: Velero PVC {{ $labels.namespace }}/{{ $labels.pvc }} has no effective volume selection
+          description: >-
+            PVC {{ $labels.namespace }}/{{ $labels.pvc }} on
+            {{ $labels.cluster }} (storage class {{ $labels.storage_class }})
+            has remained outside effective Velero filesystem-backup selection
+            for at least one hour. reason={{ $labels.reason }}:
+            no_schedule means no live Schedule selects its namespace/resource/labels;
+            no_volume_selection means a Schedule selects metadata but
+            no eligible Pod volume data (unmounted, annotation opt-in missing,
+            or explicitly excluded). This is a selector finding, not proof
+            that any completed Backup contains bytes. Do not change a Schedule
+            until capacity and priority have been reviewed.
+
+      - alert: VeleroPVCBackupStructuralExclusion
+        expr: |
+          velero_pvc_backup_structural_exclusion > 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: Velero cannot capture PVC {{ $labels.namespace }}/{{ $labels.pvc }} with filesystem backup
+          description: >-
+            PVC {{ $labels.namespace }}/{{ $labels.pvc }} on
+            {{ $labels.cluster }} uses a {{ $labels.reason }} storage path
+            (storage class {{ $labels.storage_class }}). Velero filesystem
+            backup structurally refuses hostPath/local-path at
+            pkg/podvolume/backupper.go:347; no Schedule or annotation can fix
+            this. Protect it with a different mechanism and keep this
+            infrastructure condition separate from opt-in selection gaps.
+
+      - alert: VeleroPVCBackupSelectionProbeUnavailable
+        expr: |
+          absent(velero_pvc_backup_selection_scan_success)
+          or velero_pvc_backup_selection_scan_success == 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Velero PVC selection probe is unavailable
+          description: >-
+            The polling Deployment has not completed a successful PVC, PV, Pod,
+            and Velero Schedule selection scan for at least 15 minutes. Its
+            gap series are not current while this condition holds; restore
+            probe/API access before treating an empty inventory as coverage.

--- a/kubernetes/apps/base/monitoring/mimir-rule-completeness/expected-groups.tsv
+++ b/kubernetes/apps/base/monitoring/mimir-rule-completeness/expected-groups.tsv
@@ -50,6 +50,7 @@ velero-integrity	velero-integrity.rules
 velero-node-saturation	velero-node-saturation.rules
 velero-restore-admission	velero.restore-admission.rules
 velero-volume-progress	velero.volume-progress.rules
+velero-pvc-selection	velero-pvc-selection.rules
 velero-backups	velero-backups.rules
 running-workload-images	running-workload-images.rules
 zot	zot.rules

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/deployment.yaml
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/deployment.yaml
@@ -31,6 +31,8 @@ spec:
           imagePullPolicy: IfNotPresent
           command: [python3, /scripts/probe.py]
           env:
+            - name: CLUSTER_NAME
+              value: "${CLUSTER_NAME}"
             - name: METRICS_PORT
               value: "9095"
             - name: SCAN_INTERVAL_SECONDS

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/probe.py
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/probe.py
@@ -29,6 +29,9 @@ from urllib.request import Request, urlopen
 
 API_BASE = "https://kubernetes.default.svc"
 API_PATH = "/api/v1/pods"
+PVC_API_PATH = "/api/v1/persistentvolumeclaims"
+PV_API_PATH = "/api/v1/persistentvolumes"
+VELERO_SCHEDULE_API_PATH = "/apis/velero.io/v1/schedules"
 SERVICE_ACCOUNT_DIR = "/var/run/secrets/kubernetes.io/serviceaccount"
 TOKEN_PATH = f"{SERVICE_ACCOUNT_DIR}/token"
 CA_PATH = f"{SERVICE_ACCOUNT_DIR}/ca.crt"
@@ -64,6 +67,31 @@ class WorkloadReference:
     container_type: str
     owner_kind: str
     owner_name: str
+
+
+@dataclass(frozen=True)
+class PodVolumeReference:
+    namespace: str
+    pvc: str
+    volume: str
+    labels: dict[str, str]
+    annotations: dict[str, str]
+
+
+@dataclass(frozen=True)
+class PVCSelectionGap:
+    namespace: str
+    pvc: str
+    storage_class: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PVCStructuralExclusion:
+    namespace: str
+    pvc: str
+    storage_class: str
+    reason: str
 
 
 def normalize_image(image: str) -> ImageReference:
@@ -143,21 +171,70 @@ def api_get(path: str, token: str, context: ssl.SSLContext) -> dict[str, Any]:
     return payload
 
 
-def running_pods(token: str, context: ssl.SSLContext) -> list[dict[str, Any]]:
-    pods: list[dict[str, Any]] = []
+def list_resources(
+    path: str,
+    token: str,
+    context: ssl.SSLContext,
+    query: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """List every object at a Kubernetes collection endpoint."""
+
+    resources: list[dict[str, Any]] = []
     continue_token = ""
     while True:
-        query = {"fieldSelector": "status.phase=Running", "limit": "500"}
+        params = {"limit": "500", **(query or {})}
         if continue_token:
-            query["continue"] = continue_token
-        payload = api_get(f"{API_PATH}?{urlencode(query)}", token, context)
+            params["continue"] = continue_token
+        payload = api_get(f"{path}?{urlencode(params)}", token, context)
         items = payload.get("items", [])
         if not isinstance(items, list):
-            raise RuntimeError("Kubernetes API returned a non-list items field")
-        pods.extend(item for item in items if isinstance(item, dict))
-        continue_token = payload.get("metadata", {}).get("continue", "")
-        if not continue_token:
-            return pods
+            raise RuntimeError(f"Kubernetes API returned non-list items for {path}")
+        resources.extend(item for item in items if isinstance(item, dict))
+        metadata = payload.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise RuntimeError(f"Kubernetes API returned invalid metadata for {path}")
+        continue_token = metadata.get("continue", "")
+        if not isinstance(continue_token, str) or not continue_token:
+            return resources
+
+
+def running_pods(token: str, context: ssl.SSLContext) -> list[dict[str, Any]]:
+    return list_resources(
+        API_PATH,
+        token,
+        context,
+        {"fieldSelector": "status.phase=Running"},
+    )
+
+
+def object_labels(obj: dict[str, Any]) -> dict[str, str]:
+    metadata = obj.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return {}
+    labels = metadata.get("labels", {})
+    if not isinstance(labels, dict):
+        return {}
+    return {str(key): str(value) for key, value in labels.items()}
+
+
+def object_annotations(obj: dict[str, Any]) -> dict[str, str]:
+    metadata = obj.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return {}
+    annotations = metadata.get("annotations", {})
+    if not isinstance(annotations, dict):
+        return {}
+    return {str(key): str(value) for key, value in annotations.items()}
+
+
+def object_namespace(obj: dict[str, Any]) -> str:
+    metadata = obj.get("metadata", {})
+    return str(metadata.get("namespace", "")) if isinstance(metadata, dict) else ""
+
+
+def object_name(obj: dict[str, Any]) -> str:
+    metadata = obj.get("metadata", {})
+    return str(metadata.get("name", "")) if isinstance(metadata, dict) else ""
 
 
 def controller_owner(metadata: dict[str, Any]) -> tuple[str, str]:
@@ -207,6 +284,257 @@ def workload_references(pods: list[dict[str, Any]]) -> list[WorkloadReference]:
                     )
                 )
     return references
+
+
+def pvc_volume_references(
+    pods: list[dict[str, Any]],
+) -> dict[tuple[str, str], list[PodVolumeReference]]:
+    """Index Pod PVC volumes by namespace and claim name.
+
+    Keep completed Pod objects here. Velero selects Kubernetes objects from
+    the API, and a completed Job Pod can still be the only object describing
+    the PVC volume and its backup annotations (for example, a one-shot
+    workload). The image probe separately remains limited to running Pods.
+    """
+
+    references: dict[tuple[str, str], list[PodVolumeReference]] = {}
+    for pod in pods:
+        namespace = object_namespace(pod)
+        spec = pod.get("spec", {})
+        if not namespace or not isinstance(spec, dict):
+            continue
+        volumes = spec.get("volumes", [])
+        if not isinstance(volumes, list):
+            continue
+        labels = object_labels(pod)
+        annotations = object_annotations(pod)
+        for volume in volumes:
+            if not isinstance(volume, dict):
+                continue
+            claim = volume.get("persistentVolumeClaim", {})
+            if not isinstance(claim, dict):
+                continue
+            pvc = claim.get("claimName")
+            volume_name = volume.get("name")
+            if not isinstance(pvc, str) or not pvc or not isinstance(volume_name, str):
+                continue
+            reference = PodVolumeReference(
+                namespace=namespace,
+                pvc=pvc,
+                volume=volume_name,
+                labels=labels,
+                annotations=annotations,
+            )
+            references.setdefault((namespace, pvc), []).append(reference)
+    return references
+
+
+def selector_matches(labels: dict[str, str], selector: Any) -> bool:
+    """Evaluate the Kubernetes LabelSelector shape used by Velero."""
+
+    if not isinstance(selector, dict):
+        return True
+    match_labels = selector.get("matchLabels", {})
+    if isinstance(match_labels, dict):
+        for key, value in match_labels.items():
+            if labels.get(str(key)) != str(value):
+                return False
+
+    expressions = selector.get("matchExpressions", [])
+    if not isinstance(expressions, list):
+        return False
+    for expression in expressions:
+        if not isinstance(expression, dict):
+            return False
+        key = str(expression.get("key", ""))
+        operator = expression.get("operator")
+        values = expression.get("values", [])
+        if not key or not isinstance(values, list):
+            values = []
+        value = labels.get(key)
+        if operator == "In" and (value is None or value not in {str(item) for item in values}):
+            return False
+        if operator == "NotIn" and value is not None and value in {
+            str(item) for item in values
+        }:
+            return False
+        if operator == "Exists" and value is None:
+            return False
+        if operator == "DoesNotExist" and value is not None:
+            return False
+        if operator not in ("In", "NotIn", "Exists", "DoesNotExist"):
+            return False
+    return True
+
+
+def resource_selector_matches(resources: Any, resource: str) -> bool:
+    if not resources:
+        return False
+    if not isinstance(resources, list):
+        return False
+    for item in resources:
+        name = str(item).lower().split("/", 1)[-1]
+        if name in ("*", resource.lower()):
+            return True
+    return False
+
+
+def schedule_selects(
+    schedule: dict[str, Any],
+    namespace: str,
+    labels: dict[str, str],
+    resource: str,
+) -> bool:
+    """Apply a live Velero Schedule's namespace/resource/label selector."""
+
+    spec = schedule.get("spec", {})
+    if not isinstance(spec, dict):
+        return False
+    template = spec.get("template", {})
+    if not isinstance(template, dict):
+        return False
+    if spec.get("paused") is True:
+        return False
+
+    included_namespaces = template.get("includedNamespaces", [])
+    if included_namespaces and "*" not in included_namespaces:
+        if not isinstance(included_namespaces, list) or namespace not in included_namespaces:
+            return False
+    excluded_namespaces = template.get("excludedNamespaces", [])
+    if isinstance(excluded_namespaces, list) and (
+        "*" in excluded_namespaces or namespace in excluded_namespaces
+    ):
+        return False
+    included_resources = template.get("includedResources")
+    if included_resources and not resource_selector_matches(included_resources, resource):
+        return False
+    if resource_selector_matches(template.get("excludedResources"), resource):
+        return False
+    return selector_matches(labels, template.get("labelSelector"))
+
+
+def annotation_names(annotations: dict[str, str], key: str) -> set[str]:
+    value = annotations.get(key, "")
+    if not value:
+        return set()
+    return {item.strip() for item in value.split(",") if item.strip()}
+
+
+def schedule_selects_volume(schedule: dict[str, Any], mount: PodVolumeReference) -> bool:
+    template = schedule.get("spec", {}).get("template", {})
+    if not isinstance(template, dict):
+        return False
+    if mount.volume in annotation_names(
+        mount.annotations, "backup.velero.io/backup-volumes-excludes"
+    ):
+        return False
+    if template.get("defaultVolumesToFsBackup") is True:
+        return True
+    return mount.volume in annotation_names(
+        mount.annotations, "backup.velero.io/backup-volumes"
+    )
+
+
+def structural_exclusion_reason(
+    pvc: dict[str, Any], pv: dict[str, Any] | None,
+) -> str | None:
+    spec = pvc.get("spec", {})
+    if not isinstance(spec, dict):
+        spec = {}
+    storage_class = str(spec.get("storageClassName", ""))
+    if storage_class == "local-path":
+        if isinstance(pv, dict):
+            pv_spec = pv.get("spec", {})
+            if isinstance(pv_spec, dict) and pv_spec.get("hostPath") is not None:
+                return "hostpath"
+        return "local_path"
+    if isinstance(pv, dict):
+        pv_spec = pv.get("spec", {})
+        if isinstance(pv_spec, dict) and pv_spec.get("hostPath") is not None:
+            return "hostpath"
+    return None
+
+
+def evaluate_pvc_selection(
+    pvcs: list[dict[str, Any]],
+    pvs: list[dict[str, Any]],
+    pods: list[dict[str, Any]],
+    schedules: list[dict[str, Any]],
+) -> tuple[list[PVCSelectionGap], list[PVCStructuralExclusion]]:
+    """Evaluate effective Velero PVC data selection from current API objects.
+
+    A Schedule can select a PVC object while selecting no Pod volume data. That
+    is intentionally a separate ``no_volume_selection`` result: the successful
+    Backup in that case is still a metadata-only false positive.
+    """
+
+    pv_by_name = {
+        object_name(pv): pv for pv in pvs if object_name(pv)
+    }
+    mounted = pvc_volume_references(pods)
+    gaps: list[PVCSelectionGap] = []
+    structural: list[PVCStructuralExclusion] = []
+
+    for pvc in pvcs:
+        namespace = object_namespace(pvc)
+        name = object_name(pvc)
+        status = pvc.get("status", {})
+        if not namespace or not name or (
+            isinstance(status, dict)
+            and status.get("phase") not in (None, "Bound")
+        ):
+            continue
+        spec = pvc.get("spec", {})
+        if not isinstance(spec, dict):
+            spec = {}
+        storage_class = str(spec.get("storageClassName", ""))
+        pv = pv_by_name.get(str(spec.get("volumeName", "")))
+
+        structural_reason = structural_exclusion_reason(pvc, pv)
+        if structural_reason is not None:
+            structural.append(
+                PVCStructuralExclusion(namespace, name, storage_class, structural_reason)
+            )
+            continue
+
+        annotations = object_annotations(pvc)
+        pvc_labels = object_labels(pvc)
+        if (
+            annotations.get("velero.io/exclude-from-backup", "").lower() == "true"
+            or pvc_labels.get("velero.io/exclude-from-backup", "").lower() == "true"
+        ):
+            continue
+
+        mounts = mounted.get((namespace, name), [])
+        matching_schedules: set[str] = set()
+        data_schedules: set[str] = set()
+        for schedule in schedules:
+            schedule_name = object_name(schedule)
+            if not schedule_name:
+                continue
+            pvc_selected = schedule_selects(
+                schedule, namespace, pvc_labels, "persistentvolumeclaims"
+            )
+            pod_selected = False
+            for mount in mounts:
+                if not schedule_selects(schedule, mount.namespace, mount.labels, "pods"):
+                    continue
+                pod_selected = True
+                if schedule_selects_volume(schedule, mount):
+                    data_schedules.add(schedule_name)
+            if pvc_selected or pod_selected:
+                matching_schedules.add(schedule_name)
+
+        if not matching_schedules:
+            gaps.append(PVCSelectionGap(namespace, name, storage_class, "no_schedule"))
+        elif not data_schedules:
+            gaps.append(
+                PVCSelectionGap(namespace, name, storage_class, "no_volume_selection")
+            )
+
+    gaps.sort(key=lambda item: (item.namespace, item.pvc, item.reason))
+    structural.sort(key=lambda item: (item.namespace, item.pvc, item.reason))
+    return gaps, structural
 
 
 def classify_response(response_code: int) -> str:
@@ -294,6 +622,93 @@ def text_metric(name: str, help_text: str, metric_type: str) -> list[str]:
     ]
 
 
+def render_selection_metrics(
+    gaps: list[PVCSelectionGap],
+    structural_exclusions: list[PVCStructuralExclusion],
+    scan_success: bool,
+    scan_timestamp: float,
+    last_success_timestamp: float,
+    cluster: str | None = None,
+) -> str:
+    """Render the current PVC-selection state collected by this probe."""
+
+    cluster = os.environ.get("CLUSTER_NAME", "") if cluster is None else cluster
+    lines: list[str] = []
+    gap_name = "velero_pvc_backup_selection_gap"
+    lines.extend(
+        text_metric(
+            gap_name,
+            "Current PVCs with no effective Velero filesystem backup selection.",
+            "gauge",
+        )
+    )
+    structural_name = "velero_pvc_backup_structural_exclusion"
+    lines.extend(
+        text_metric(
+            structural_name,
+            "Current PVCs structurally excluded from Velero filesystem backup.",
+            "gauge",
+        )
+    )
+    if scan_success:
+        for gap in gaps:
+            labels = metric_labels(
+                {
+                    "cluster": cluster,
+                    "namespace": gap.namespace,
+                    "pvc": gap.pvc,
+                    "reason": gap.reason,
+                    "storage_class": gap.storage_class,
+                }
+            )
+            lines.append(f"{gap_name}{{{labels}}} 1")
+        for exclusion in structural_exclusions:
+            labels = metric_labels(
+                {
+                    "cluster": cluster,
+                    "namespace": exclusion.namespace,
+                    "pvc": exclusion.pvc,
+                    "reason": exclusion.reason,
+                    "storage_class": exclusion.storage_class,
+                }
+            )
+            lines.append(f"{structural_name}{{{labels}}} 1")
+
+    scan_name = "velero_pvc_backup_selection_scan_success"
+    lines.extend(
+        text_metric(
+            scan_name,
+            "Whether the last PVC Velero-selection scan succeeded.",
+            "gauge",
+        )
+    )
+    lines.append(f"{scan_name}{{cluster=\"{label_escape(cluster)}\"}} {int(scan_success)}")
+    timestamp_name = "velero_pvc_backup_selection_last_scan_timestamp_seconds"
+    lines.extend(
+        text_metric(
+            timestamp_name,
+            "Unix timestamp of the last PVC selection scan.",
+            "gauge",
+        )
+    )
+    lines.append(
+        f"{timestamp_name}{{cluster=\"{label_escape(cluster)}\"}} {scan_timestamp:.3f}"
+    )
+    success_name = "velero_pvc_backup_selection_last_success_timestamp_seconds"
+    lines.extend(
+        text_metric(
+            success_name,
+            "Unix timestamp of the last successful PVC selection scan.",
+            "gauge",
+        )
+    )
+    lines.append(
+        f"{success_name}{{cluster=\"{label_escape(cluster)}\"}} "
+        f"{last_success_timestamp:.3f}"
+    )
+    return "\n".join(lines) + "\n"
+
+
 def render_metrics(
     references: list[WorkloadReference],
     statuses: dict[str, tuple[str, str]],
@@ -301,6 +716,12 @@ def render_metrics(
     scan_timestamp: float,
     scan_duration: float,
     last_success_timestamp: float,
+    selection_gaps: list[PVCSelectionGap] | None = None,
+    structural_exclusions: list[PVCStructuralExclusion] | None = None,
+    selection_scan_success: bool = False,
+    selection_scan_timestamp: float = 0.0,
+    selection_last_success_timestamp: float = 0.0,
+    selection_cluster: str | None = None,
 ) -> str:
     lines: list[str] = []
     status_name = "running_workload_image_registry_probe_status"
@@ -373,7 +794,16 @@ def render_metrics(
     images_name = "running_workload_image_registry_probe_images"
     lines.extend(text_metric(images_name, "Number of unique images in the last scan.", "gauge"))
     lines.append(f"{images_name} {len(statuses) if scan_success else 0}")
-    return "\n".join(lines) + "\n"
+    image_metrics = "\n".join(lines) + "\n"
+    selection_metrics = render_selection_metrics(
+        selection_gaps or [],
+        structural_exclusions or [],
+        selection_scan_success,
+        selection_scan_timestamp,
+        selection_last_success_timestamp,
+        selection_cluster,
+    )
+    return image_metrics + selection_metrics
 
 
 class MetricsState:
@@ -421,11 +851,27 @@ def scan_once(state: MetricsState, workers: int) -> None:
     try:
         token = read_token()
         api_context = kubernetes_tls_context()
-        references = workload_references(running_pods(token, api_context))
+        # Image liveness is intentionally running-Pod-only. PVC selection must
+        # inspect every Pod object because a completed Job can still be the
+        # selected Pod/volume pair that Velero backs up.
+        pods = list_resources(API_PATH, token, api_context)
+        running = [
+            pod
+            for pod in pods
+            if isinstance(pod.get("status"), dict)
+            and pod["status"].get("phase") == "Running"
+        ]
+        references = workload_references(running)
         statuses = probe_images(
             {reference.image for reference in references},
             registry_tls_context(),
             workers,
+        )
+        pvcs = list_resources(PVC_API_PATH, token, api_context)
+        pvs = list_resources(PV_API_PATH, token, api_context)
+        schedules = list_resources(VELERO_SCHEDULE_API_PATH, token, api_context)
+        selection_gaps, structural_exclusions = evaluate_pvc_selection(
+            pvcs, pvs, pods, schedules
         )
         now = time.time()
         state.replace(
@@ -436,10 +882,15 @@ def scan_once(state: MetricsState, workers: int) -> None:
                 now,
                 now - started,
                 now,
+                selection_gaps,
+                structural_exclusions,
+                True,
+                now,
+                now,
             )
         )
     except Exception as error:
-        print(f"image probe scan failed: {error}", file=sys.stderr, flush=True)
+        print(f"monitoring probe scan failed: {error}", file=sys.stderr, flush=True)
         now = time.time()
         state.replace(render_metrics([], {}, False, now, now - started, 0.0))
 

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/rbac.yaml
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/rbac.yaml
@@ -7,6 +7,13 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs:
+      - list
+  - apiGroups: [velero.io]
+    resources:
+      - schedules
     verbs:
       - list
 ---

--- a/kubernetes/apps/base/monitoring/running-workload-image-probe/tests/test_probe.py
+++ b/kubernetes/apps/base/monitoring/running-workload-image-probe/tests/test_probe.py
@@ -16,6 +16,64 @@ SPEC.loader.exec_module(probe)
 
 
 class ProbeTest(unittest.TestCase):
+    @staticmethod
+    def bound_pvc(
+        namespace: str = "keiretsu",
+        name: str = "data-vault-0",
+        storage_class: str = "ceph-block-replicated",
+        volume_name: str = "pv-data-vault-0",
+        annotations: dict[str, str] | None = None,
+    ) -> dict:
+        return {
+            "metadata": {
+                "namespace": namespace,
+                "name": name,
+                "annotations": annotations or {},
+            },
+            "spec": {
+                "storageClassName": storage_class,
+                "volumeName": volume_name,
+            },
+            "status": {"phase": "Bound"},
+        }
+
+    @staticmethod
+    def csi_pv(name: str = "pv-data-vault-0") -> dict:
+        return {
+            "metadata": {"name": name},
+            "spec": {"csi": {"driver": "rook-ceph.rbd.csi.ceph.com"}},
+        }
+
+    @staticmethod
+    def mounted_pod(annotations: dict[str, str] | None = None) -> dict:
+        return {
+            "metadata": {
+                "namespace": "keiretsu",
+                "name": "vault-0",
+                "labels": {"app": "vault"},
+                "annotations": annotations or {},
+            },
+            "status": {"phase": "Running"},
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "data",
+                        "persistentVolumeClaim": {"claimName": "data-vault-0"},
+                    }
+                ]
+            },
+        }
+
+    @staticmethod
+    def schedule(
+        name: str = "vault-backup",
+        default_volumes: bool | None = True,
+    ) -> dict:
+        template = {"includedNamespaces": ["keiretsu"]}
+        if default_volumes is not None:
+            template["defaultVolumesToFsBackup"] = default_volumes
+        return {"metadata": {"name": name}, "spec": {"template": template}}
+
     def test_normalizes_implicit_docker_hub_names(self) -> None:
         image = probe.normalize_image("alpine")
         self.assertEqual(image.registry, "docker.io")
@@ -136,6 +194,116 @@ class ProbeTest(unittest.TestCase):
         self.assertIn('image="oci.cdn.keiretsu.top/keiretsu/app:v1"', metrics)
         self.assertNotIn('image="ghcr.io/example/app:v1"', metrics)
         self.assertIn("running_workload_image_registry_probe_images 1", metrics)
+
+    def test_no_schedule_gap_clears_when_schedule_covers_pvc(self) -> None:
+        pvc = self.bound_pvc()
+        pv = self.csi_pv()
+        pod = self.mounted_pod()
+
+        gaps, structural = probe.evaluate_pvc_selection([pvc], [pv], [pod], [])
+        self.assertEqual(
+            [(gap.pvc, gap.reason) for gap in gaps],
+            [("data-vault-0", "no_schedule")],
+        )
+        self.assertEqual(structural, [])
+
+        gaps, structural = probe.evaluate_pvc_selection(
+            [pvc], [pv], [pod], [self.schedule()]
+        )
+        self.assertEqual(gaps, [])
+        self.assertEqual(structural, [])
+
+    def test_no_volume_selection_gap_clears_when_pod_annotation_covers_it(self) -> None:
+        pvc = self.bound_pvc(namespace="media", name="kometa", volume_name="pv-kometa")
+        pv = self.csi_pv("pv-kometa")
+        pod = self.mounted_pod()
+        pod["metadata"]["namespace"] = "media"
+        pod["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] = "kometa"
+        schedule = self.schedule(name="media-config-backup", default_volumes=False)
+        schedule["spec"]["template"]["includedNamespaces"] = ["media"]
+
+        gaps, structural = probe.evaluate_pvc_selection(
+            [pvc], [pv], [pod], [schedule]
+        )
+        self.assertEqual(
+            [(gap.pvc, gap.reason) for gap in gaps],
+            [("kometa", "no_volume_selection")],
+        )
+        self.assertEqual(structural, [])
+
+        pod["metadata"]["annotations"] = {
+            "backup.velero.io/backup-volumes": "data"
+        }
+        gaps, structural = probe.evaluate_pvc_selection(
+            [pvc], [pv], [pod], [schedule]
+        )
+        self.assertEqual(gaps, [])
+        self.assertEqual(structural, [])
+
+    def test_completed_pod_still_proves_volume_selection(self) -> None:
+        pvc = self.bound_pvc(namespace="media", name="kometa", volume_name="pv-kometa")
+        pv = self.csi_pv("pv-kometa")
+        pod = self.mounted_pod(annotations={"backup.velero.io/backup-volumes": "data"})
+        pod["metadata"]["namespace"] = "media"
+        pod["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] = "kometa"
+        pod["status"]["phase"] = "Succeeded"
+        schedule = self.schedule(name="media-config-backup", default_volumes=False)
+        schedule["spec"]["template"]["includedNamespaces"] = ["media"]
+
+        gaps, structural = probe.evaluate_pvc_selection(
+            [pvc], [pv], [pod], [schedule]
+        )
+        self.assertEqual(gaps, [])
+        self.assertEqual(structural, [])
+
+    def test_explicit_pvc_exclusion_is_not_a_selection_gap(self) -> None:
+        pvc = self.bound_pvc()
+        pvc["metadata"]["labels"] = {"velero.io/exclude-from-backup": "true"}
+        pv = self.csi_pv()
+        pod = self.mounted_pod()
+        schedule = self.schedule()
+
+        gaps, structural = probe.evaluate_pvc_selection(
+            [pvc], [pv], [pod], [schedule]
+        )
+        self.assertEqual(gaps, [])
+        self.assertEqual(structural, [])
+
+    def test_structural_hostpath_is_separate_from_selection_gap(self) -> None:
+        pvc = self.bound_pvc(
+            namespace="home-assistant",
+            name="homeassistant-config",
+            storage_class="local-path",
+            volume_name="pv-homeassistant",
+        )
+        pv = {
+            "metadata": {"name": "pv-homeassistant"},
+            "spec": {"hostPath": {"path": "/var/lib/local-path"}},
+        }
+        schedule = self.schedule(name="home-assistant-backup")
+        schedule["spec"]["template"]["includedNamespaces"] = ["home-assistant"]
+
+        gaps, structural = probe.evaluate_pvc_selection(
+            [pvc], [pv], [], [schedule]
+        )
+        self.assertEqual(gaps, [])
+        self.assertEqual(
+            [(item.pvc, item.reason) for item in structural],
+            [("homeassistant-config", "hostpath")],
+        )
+
+    def test_selection_metric_has_required_labels_and_reason(self) -> None:
+        gap = probe.PVCSelectionGap(
+            "keiretsu", "data-vault-0", "ceph-block-replicated", "no_schedule"
+        )
+        metrics = probe.render_selection_metrics(
+            [gap], [], True, 100.0, 100.0, "talos-ottawa"
+        )
+        self.assertIn(
+            'velero_pvc_backup_selection_gap{cluster="talos-ottawa",namespace="keiretsu",'
+            'pvc="data-vault-0",reason="no_schedule",storage_class="ceph-block-replicated"} 1',
+            metrics,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Extend the existing running-workload-image-probe polling Deployment to list every PVC, PV, Pod, and Velero Schedule in each cluster and evaluate the effective namespace/resource/label and Pod-volume selectors.
- Emit `velero_pvc_backup_selection_gap` with separate `no_schedule` and `no_volume_selection` reasons.
- Emit hostPath/local-path cases as the separate `velero_pvc_backup_structural_exclusion` infrastructure condition.
- Add warning alerts with `for: 1h`, probe availability protection, RBAC, loader wiring, and both-direction rule fixtures. No Velero Schedule is changed.

## Expected baseline

The inventory captured on 2026-09-09 finds 65 `no_schedule` plus 34 `no_volume_selection` instances: 99 selection-gap warnings on day one. It also finds 15 separate structural hostPath/local-path warnings. The 99-instance baseline is expected because namespace selection is opt-in; warning severity is deliberate so the known first-day noise does not train operators to mute a critical alert. Raj can review capacity and priority before adding volumes to schedules.

## Verification

- 12 running-workload probe unit tests pass.
- Mimir rule load-path check passes: 35 rule files, 3 tenant loaders.
- Pinned Prometheus 3.14.0 PromQL check passes for all 35 rule files.
- The new PVC selection fixture passes under the repository fixture runner; that runner still reports two unrelated pre-existing fixture mismatches.
- `tools/check.sh talos-ottawa` reached the unchanged baseline but hit the documented Flate renderer timeout, with no manifest diagnostic.