### PR TITLE
fix(renovate): restore bhaiya dependency ownership

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -70,7 +70,7 @@
       "automerge": true
     },
     {
-      "description": "Require human review for safety-relevant CNI, storage/CSI, backup, and operator families; routine application updates remain eligible for automerge",
+      "description": "Require human review for safety-relevant CNI, storage/CSI, backup, and operator families; routine application and CLIProxy updates remain eligible for automerge",
       "matchFileNames": [
         "clusters/**/bootstrap/**",
         "clusters/**/flux/**",
@@ -96,7 +96,6 @@
         "clusters/**/apps/cert-manager/**",
         "kubernetes/**/bootstrap/**",
         "kubernetes/apps/**/flux-system*/**",
-        "kubernetes/apps/**/cliproxy*/**",
         "kubernetes/apps/**/cilium-*/**",
         "kubernetes/apps/**/whereabouts*/**",
         "kubernetes/apps/**/spiderpool*/**",
@@ -164,7 +163,7 @@
       ]
     },
     {
-      "description": "Do not update runtime images independently inside generated or vendored manifests; regenerate the complete upstream bundle instead.",
+      "description": "Do not update runtime images independently inside generated or vendored manifests; regenerate the complete upstream bundle instead. Review-by: 2026-10-10.",
       "matchDatasources": ["docker"],
       "matchFileNames": [
         "kubernetes/apps/base/agent-sandbox/agent-sandbox/app/raw-manifest.yaml",

--- a/docs/reference/renovate-exclusions.md
+++ b/docs/reference/renovate-exclusions.md
@@ -1,0 +1,18 @@
+# Renovate exclusions
+
+This is the review ledger for the small set of dependencies that Renovate is
+explicitly forbidden to update. An exclusion is a temporary engineering
+constraint, not a maintenance policy: `tools/check-renovate-exclusions.sh`
+requires every disabled rule to name a review date and to appear in this
+ledger. An expired date fails the repository's offline self-tests.
+
+## Current exclusions
+
+| Rule and paths | Why Renovate is disabled | Exit condition | Review by |
+| --- | --- | --- | --- |
+| `.github/renovate.json` generated/vendor rule: `kubernetes/apps/base/agent-sandbox/agent-sandbox/app/raw-manifest.yaml`; `kubernetes/apps/base/node-feature-discovery/nfd-common/install/intel-nfd.yaml`; `kubernetes/apps/base/kube-system/cilium-*/app/descheduler-cronjob.yaml`; `kubernetes/apps/base/local-path-storage/local-path-storage-*/app/local-path-provisioner.yaml` | These are vendored or generated upstream bundles. A one-line image edit can leave the controller, CRDs, or companion manifests on a different upstream release. The Agent Sandbox controller is running `v0.5.4`; the compatible release line has reached `v0.5.6`, while `v1.0.1` is a separate major line. | Add a reproducible upstream-bundle regeneration command and a render/schema test for each bundle, then replace the broad exclusion with a manager that updates the source reference and regenerates the complete bundle. | 2026-10-10 |
+
+The Agent Sandbox row is the Bhaiya/workspace-relevant item. It is currently a
+legitimate hold, not a claim that `v0.5.4` is current. The next owner should
+either return the bundle to Renovate with that generator/test or record a new,
+dated decision before this date expires.

--- a/kubernetes/apps/base/zot/zot/helmrelease.yaml
+++ b/kubernetes/apps/base/zot/zot/helmrelease.yaml
@@ -43,6 +43,9 @@ spec:
   values:
     replicaCount: 2
     image:
+      # Keep the registry image under Renovate's Docker manager. The chart's
+      # appVersion and this explicit override are independent inputs.
+      # renovate: datasource=docker depName=ghcr.io/project-zot/zot
       tag: "v2.1.20"
     startupProbe:
       initialDelaySeconds: 30

--- a/tools/check-renovate-exclusions.sh
+++ b/tools/check-renovate-exclusions.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# check-renovate-exclusions.sh — keep disabled Renovate rules visible and dated.
+#
+# Every enabled:false package rule must be represented in the review ledger and
+# carry a future Review-by date. This keeps a safe temporary hold from becoming
+# an invisible permanent pin.
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="${RENOVATE_CONFIG_PATH:-$ROOT/.github/renovate.json}"
+LEDGER="${RENOVATE_EXCLUSIONS_DOC:-$ROOT/docs/reference/renovate-exclusions.md}"
+TODAY="${RENOVATE_EXCLUSIONS_TODAY:-$(date -u +%F)}"
+
+python3 - "$CONFIG" "$LEDGER" "$TODAY" <<'PY'
+import datetime as dt
+import json
+import pathlib
+import re
+import sys
+
+config_path = pathlib.Path(sys.argv[1])
+ledger_path = pathlib.Path(sys.argv[2])
+today_text = sys.argv[3]
+
+try:
+    today = dt.date.fromisoformat(today_text)
+except ValueError:
+    print(f"invalid review date: {today_text!r}", file=sys.stderr)
+    raise SystemExit(2)
+
+if not config_path.is_file():
+    print(f"missing Renovate config: {config_path}", file=sys.stderr)
+    raise SystemExit(2)
+if not ledger_path.is_file():
+    print(f"missing Renovate exclusion ledger: {ledger_path}", file=sys.stderr)
+    raise SystemExit(2)
+
+config = json.loads(config_path.read_text())
+ledger = ledger_path.read_text()
+disabled = [
+    (index, rule)
+    for index, rule in enumerate(config.get("packageRules", []))
+    if rule.get("enabled") is False
+]
+errors = []
+for index, rule in disabled:
+    description = rule.get("description", "")
+    match = re.search(r"\bReview-by:\s*(\d{4}-\d{2}-\d{2})\b", description, re.I)
+    if not match:
+        errors.append(f"packageRules[{index}] has no Review-by date")
+        continue
+    try:
+        review_by = dt.date.fromisoformat(match.group(1))
+    except ValueError:
+        errors.append(f"packageRules[{index}] has invalid Review-by date {match.group(1)}")
+        continue
+    if review_by <= today:
+        errors.append(
+            f"packageRules[{index}] Review-by {review_by.isoformat()} has expired"
+        )
+    paths = rule.get("matchFileNames", [])
+    if not paths:
+        errors.append(f"packageRules[{index}] has no matched paths to review")
+    for path in paths:
+        if path not in ledger:
+            errors.append(
+                f"packageRules[{index}] path {path!r} is missing from {ledger_path}"
+            )
+
+if errors:
+    for error in errors:
+        print(f"✗ {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(
+    f"✓ Renovate exclusion ledger current: {len(disabled)} disabled rule(s); "
+    f"review date is after {today.isoformat()}"
+)
+PY

--- a/tools/tests/run.sh
+++ b/tools/tests/run.sh
@@ -840,6 +840,16 @@ cp "$hsbak" "$ROOT/kubernetes/apps/ottawa/velero/schedules/home-backup.yaml"
 rm -f "$hsbak"
 exits  "restored schedule passes again" 0 "$T/check-velero-pvc-coverage.sh"
 
+# ---------------------------------------------------------------- Renovate exclusion ledger
+# Disabled rules are allowed only when their paths and a review-by date are
+# visible in the ledger. Advance the fixture date past the current review date
+# to prove the expiry is a real failing condition rather than documentation.
+section "Renovate exclusion ledger"
+exits "current exclusions are visible and unexpired" 0 \
+  "$T/check-renovate-exclusions.sh"
+exits "expired exclusion review date fails" 1 \
+  env RENOVATE_EXCLUSIONS_TODAY=2026-10-11 "$T/check-renovate-exclusions.sh"
+
 # ---------------------------------------------------------------- HelmRelease schema
 # Offline fixture tests use the repository-pinned kubeconform wrapper and the
 # complete Flux HelmRelease v2 schema. No rendered cluster or live API is used.


### PR DESCRIPTION
## Summary\n\n- Return kubernetes/apps/**/cliproxy*/** to the normal application automerge path. Renovate PR #2713 is clean, all checks pass, and the repository ruleset requires only validate; its own body identifies the actual blocker as “Automerge: Disabled by config.”\n- Make Zot's explicit nested image.tag visible to the existing Docker custom manager. The chart is already current, but the override is v2.1.20 while the chart appVersion/latest image is v2.1.21; this restores future detection without hand-bumping it.\n- Add an expiring, tested ledger for disabled Renovate rules. The generated/vendor bundle rule now has Review-by: 2026-10-10; the offline test fails when that date is advanced past the deadline.\n\n## Ownership decisions\n\n- Agent Sandbox remains a legitimate temporary hold because the deployed raw manifest is a generated bundle. Renovate can own it again once there is a reproducible upstream regeneration command plus render/schema coverage; the ledger records that exit condition and deadline.\n- Mimir and Envoy remain review-gated by their coupled-update groups; they are current, and this PR does not weaken those safety policies.\n- Zot retention PR #2953 is unrelated to the image-detection fix and remains Raj-held.\n- No dependency was hand-bumped in this PR.\n\n## Kubelet finding (diagnosis only)\n\n#2447/#2448/#2449 are separate intentional per-cluster Renovate groups (renovate/kubernetes-{cluster}), not one branch recreated three times. Their diffs target each cluster's Talos and Tuppr files. The common diagram failure reports generated inventory still at Kubernetes v1.36.3 while the PR renders v1.37.0; the offline self-test failure is the same stale-generated-inventory cascade. gh pr checks --required shows only validate is required. This PR does not touch or merge the kubelet bump.\n\n## Verification\n\n- tools/check-renovate-exclusions.sh\n- tools/check-diagram.sh\n- tools/tests/run.sh (CI and locked local run)\n