### PR TITLE
fix(ottawa): keep public Envoy flows on cluster path

### DIFF
--- a/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
@@ -76,5 +76,5 @@ spec:
         # the node IP (SNAT), not the real client — observability only; authZ is
         # Remote-Email / SSH key (see docs/incidents/677-*). Private and ts
         # gateways stay Local.
-        externalTrafficPolicy: Local
+        externalTrafficPolicy: Cluster
         loadBalancerIP: ${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.10.15


### PR DESCRIPTION
## Summary
- restore `externalTrafficPolicy: Cluster` for the Ottawa public Envoy Service
- prevent public-VIP ECMP mid-flow rehashes from landing on a node without the established Envoy tuple

## Evidence
A real Mac-originated authenticated SSH session reproduced the failure while the public Service was `Local`:

- established traffic used the `kaji` Envoy path;
- a reset was emitted by the `rei` path;
- UDM forwarded that reset to the client;
- Envoy recorded `downstream_detected_close_type=RemoteReset` and `upstream_detected_close_type=Normal`.

The Ottawa render gate passes with `tools/check.sh talos-ottawa`.

## Rollout verification
After merge and Flux reconciliation, repeat the authenticated public SSH soak and confirm the live Service reports `externalTrafficPolicy: Cluster`. Compare UDM packet traces and Envoy close telemetry against the reproduced `Local` failure.