### PR TITLE
revert(ottawa): restore local policy after public SSH A/B

### DIFF
--- a/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
+++ b/kubernetes/apps/base/home/home/local-gateway/envoyproxy-public.yaml
@@ -76,5 +76,5 @@ spec:
         # the node IP (SNAT), not the real client — observability only; authZ is
         # Remote-Email / SSH key (see docs/incidents/677-*). Private and ts
         # gateways stay Local.
-        externalTrafficPolicy: Cluster
+        externalTrafficPolicy: Local
         loadBalancerIP: ${CLUSTER_LOAD_BALANCER_CIDR%.*.*/*}.10.15


### PR DESCRIPTION
## Summary
- revert the public Envoy Service from `Cluster` back to `Local` after the packet-level A/B test
- document the reproduced Local and Cluster reset signatures and the remaining durable-fix boundary

## Evidence
The merged `Cluster` change was tested with a real authenticated Mac/Tailcat SSH session. It still failed after 151.724s:

- Envoy recorded `downstream_detected_close_type=RemoteReset` and `upstream_detected_close_type=Normal`;
- the UDM emitted the reset from the public-VIP LAN path;
- `Cluster` changed the node-SNAT source observed by Envoy but did not prevent the public-VIP next-hop reset.

The earlier `Local` capture showed the same failure with a different next-hop MAC. Neither Service policy is a durable fix; the public VIP needs stable next-hop/flow pinning or a single ingress owner.

## Validation
- `tools/check.sh talos-ottawa` passes.
- Documentation records both A/B results and the remaining router/ingress ownership boundary.